### PR TITLE
home-environment: fix evaluation error on undefined `lang.base`

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -9,7 +9,8 @@ let
   languageSubModule = types.submodule {
     options = {
       base = mkOption {
-        type = types.str;
+        default = null;
+        type = types.nullOr types.str;
         description = ''
           The language to use unless overridden by a more specific option.
         '';


### PR DESCRIPTION
Triggered by `home.sessionVariableSetter = "pam";`.