### PR TITLE
browserpass: add module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -14,6 +14,7 @@ let
     ./misc/pam.nix
     ./programs/bash.nix
     ./programs/beets.nix
+    ./programs/browserpass.nix
     ./programs/eclipse.nix
     ./programs/emacs.nix
     ./programs/firefox.nix

--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -1,23 +1,22 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-with import ../lib/dag.nix;
 
 let
-  browsers = {
-    chrome = 1;
-    chromium = 2;
-    firefox = 3;
-    vivaldi = 4;
-  };
+  browsers = [
+    "chrome"
+    "chromium"
+    "firefox"
+    "vivaldi"
+  ];
 in {
   options = {
     programs.browserpass = {
       enable = mkEnableOption "the browserpass extension host application";
 
       browsers = mkOption {
-        type = types.listOf (types.enum (builtins.attrNames browsers));
-        default = builtins.attrNames browsers;
+        type = types.listOf (types.enum browsers);
+        default = browsers;
         example = [ "firefox" ];
         description = "Which browsers to install browserpass for";
       };
@@ -25,62 +24,57 @@ in {
   };
 
   config = mkIf config.programs.browserpass.enable {
-    assertions = [
-      {
-        assertion = pkgs.stdenv.is64bit;
-        message = "Only 64-bit is supported";
-      }
-      {
-        assertion = (builtins.getEnv "USER") != "root";
-        message = "root install not supported";
-      }
-    ];
-
-    home.activation.browserpass = let
-      browserpass = pkgs.stdenv.mkDerivation (let
-        package = with pkgs.stdenv; if isLinux then
-            {
-              system = "linux64";
-              sha256 = "1swq91rzvah9jindclgsszsc17kk6mak434469szmdvg9cfp1ll1";
-            }
-          else if isDarwin then
-            {
-              system = "darwinx64";
-              sha256 = "0n1w8skzi15djacw7d6sh31qjq1wsrgynfcy973dirjz1d8a5xkn";
-            }
-          else if isOpenBSD then
-            {
-              system = "openbsd64";
-              sha256 = "0s47hbd1xbjxnpjknc3k7slsvvdh5427n71w73sliah81f4xda3b";
-            }
-          else abort "${currentSystem} not supported";
-      in rec {
-        name = "browserpass-${version}-bin_for-home-manager";
-        version = "1.0.5";
-
-        src = pkgs.fetchzip {
-          inherit (package) sha256;
-          url = "https://github.com/dannyvankooten/browserpass/releases/download/${version}/browserpass-${package.system}.zip";
-          stripRoot = false;
-        };
-
-        postUnpack = ''
-          # Files are not writable since they were copied from the nix store.
-          # That causes the install to fail next time because we can't overwrite them.
-          echo "chmod u+w \"\$TARGET_DIR/\$APP_NAME.json\"" >> browserpass-${package.system}.zip/install.sh
-          echo "[ \"\$BROWSER\" != ${toString browsers.firefox} ] && chmod u+w \"\$TARGET_DIR\"/../policies/managed/\"\$APP_NAME.json\" || :" >> browserpass-${package.system}.zip/install.sh
-          touch --date=@$SOURCE_DATE_EPOCH browserpass-${package.system}.zip/install.sh
-        '';
-
-        installPhase = ''
-          mkdir $out
-          mv * $out/
-        '';
-      });
-    in dagEntryAfter ["writeBoundary"] (builtins.concatStringsSep "" (map (browser: ''
-      $DRY_RUN_CMD ${browserpass}/install.sh <<EOF
-      ${toString browsers.${browser}}
-      EOF
-    '') config.programs.browserpass.browsers));
+    home.file = builtins.concatLists (with pkgs.stdenv; map (x:
+      if x == "chrome" then
+        let dir = if isDarwin
+          then "Library/Application Support/Google/Chrome/NativeMessagingHosts"
+          else ".config/google-chrome/NativeMessagingHosts";
+        in [
+          {
+            target = "${dir}/com.dannyvankooten.browserpass.json";
+            source = "${pkgs.browserpass}/etc/chrome-host.json";
+          }
+          {
+            target = "${dir}/../policies/managed/com.dannyvankooten.browserpass.json";
+            source = "${pkgs.browserpass}/etc/chrome-policy.json";
+          }
+        ]
+      else if x == "chromium" then
+        let dir = if isDarwin
+          then "Library/Application Support/Chromium/NativeMessagingHosts"
+          else ".config/chromium/NativeMessagingHosts";
+        in [
+          {
+            target = "${dir}/com.dannyvankooten.browserpass.json";
+            source = "${pkgs.browserpass}/etc/chrome-host.json";
+          }
+          {
+            target = "${dir}/../policies/managed/com.dannyvankooten.browserpass.json";
+            source = "${pkgs.browserpass}/etc/chrome-policy.json";
+          }
+        ]
+      else if x == "firefox" then
+        [ {
+          target = (if isDarwin
+            then "Library/Application Support/Mozilla/NativeMessagingHosts"
+            else ".mozilla/native-messaging-hosts")
+            + "/com.dannyvankooten.browserpass.json";
+          source = "${pkgs.browserpass}/lib/mozilla/native-messaging-hosts/com.dannyvankooten.browserpass.json";
+        } ]
+      else if x == "vivaldi" then
+        let dir = if isDarwin
+          then "Library/Application Support/Vivaldi/NativeMessagingHosts"
+          else ".config/vivaldi/NativeMessagingHosts";
+        in [
+          {
+            target = "${dir}/com.dannyvankooten.browserpass.json";
+            source = "${pkgs.browserpass}/etc/chrome-host.json";
+          }
+          {
+            target = "${dir}/../policies/managed/com.dannyvankooten.browserpass.json";
+            source = "${pkgs.browserpass}/etc/chrome-policy.json";
+          }
+        ]
+      else throw "unknown browser ${x}") config.programs.browserpass.browsers);
   };
 }

--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -41,22 +41,22 @@ in {
         package = with pkgs.stdenv; if isLinux then
             {
               system = "linux64";
-              sha256 = "1h1figz97jgzfykrq2kr8ywxzbbrfk9haqhalc65w6n7cks0wgx8";
+              sha256 = "1swq91rzvah9jindclgsszsc17kk6mak434469szmdvg9cfp1ll1";
             }
           else if isDarwin then
             {
               system = "darwinx64";
-              sha256 = "199zr0nvrm9pz0f39dzfz67m85b0k3c4l6hf98377w89vdcp28r5";
+              sha256 = "0n1w8skzi15djacw7d6sh31qjq1wsrgynfcy973dirjz1d8a5xkn";
             }
           else if isOpenBSD then
             {
               system = "openbsd64";
-              sha256 = "1yi861wgx1mwzkxc9qyhx3s8g0cyvsdac9f1la2knhfgr3g9rr7h";
+              sha256 = "0s47hbd1xbjxnpjknc3k7slsvvdh5427n71w73sliah81f4xda3b";
             }
           else abort "${currentSystem} not supported";
       in rec {
         name = "browserpass-${version}-bin_for-home-manager";
-        version = "1.0.4";
+        version = "1.0.5";
 
         src = pkgs.fetchzip {
           inherit (package) sha256;

--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -16,7 +16,7 @@ in {
       enable = mkEnableOption "the browserpass extension host application";
 
       browsers = mkOption {
-        type = types.listOf types.str;
+        type = types.listOf (types.enum (builtins.attrNames browsers));
         default = builtins.attrNames browsers;
         example = [ "firefox" ];
         description = "Which browsers to install browserpass for";
@@ -29,10 +29,6 @@ in {
       {
         assertion = pkgs.stdenv.is64bit;
         message = "Only 64-bit is supported";
-      }
-      {
-        assertion = builtins.all (x: builtins.any (y: x == y) (builtins.attrNames browsers)) config.programs.browserpass.browsers;
-        message = "Unsupported browser, must be one of: ${toString (builtins.attrNames browsers)}";
       }
       {
         assertion = (builtins.getEnv "USER") != "root";
@@ -81,7 +77,7 @@ in {
           mv * $out/
         '';
       });
-    in dagEntryBefore ["writeBoundary"] (builtins.concatStringsSep "" (map (browser: ''
+    in dagEntryAfter ["writeBoundary"] (builtins.concatStringsSep "" (map (browser: ''
       $DRY_RUN_CMD ${browserpass}/install.sh <<EOF
       ${toString browsers.${browser}}
       EOF

--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -1,0 +1,90 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with import ../lib/dag.nix;
+
+let
+  browsers = {
+    chrome = 1;
+    chromium = 2;
+    firefox = 3;
+    vivaldi = 4;
+  };
+in {
+  options = {
+    programs.browserpass = {
+      enable = mkEnableOption "the browserpass extension host application";
+
+      browsers = mkOption {
+        type = types.listOf types.str;
+        default = builtins.attrNames browsers;
+        example = [ "firefox" ];
+        description = "Which browsers to install browserpass for";
+      };
+    };
+  };
+
+  config = mkIf config.programs.browserpass.enable {
+    assertions = [
+      {
+        assertion = pkgs.stdenv.is64bit;
+        message = "Only 64-bit is supported";
+      }
+      {
+        assertion = builtins.all (x: builtins.any (y: x == y) (builtins.attrNames browsers)) config.programs.browserpass.browsers;
+        message = "Unsupported browser, must be one of: ${toString (builtins.attrNames browsers)}";
+      }
+      {
+        assertion = (builtins.getEnv "USER") != "root";
+        message = "root install not supported";
+      }
+    ];
+
+    home.activation.browserpass = let
+      browserpass = pkgs.stdenv.mkDerivation (let
+        package = with pkgs.stdenv; if isLinux then
+            {
+              system = "linux64";
+              sha256 = "1h1figz97jgzfykrq2kr8ywxzbbrfk9haqhalc65w6n7cks0wgx8";
+            }
+          else if isDarwin then
+            {
+              system = "darwinx64";
+              sha256 = "199zr0nvrm9pz0f39dzfz67m85b0k3c4l6hf98377w89vdcp28r5";
+            }
+          else if isOpenBSD then
+            {
+              system = "openbsd64";
+              sha256 = "1yi861wgx1mwzkxc9qyhx3s8g0cyvsdac9f1la2knhfgr3g9rr7h";
+            }
+          else abort "${currentSystem} not supported";
+      in rec {
+        name = "browserpass-${version}-bin_for-home-manager";
+        version = "1.0.4";
+
+        src = pkgs.fetchzip {
+          inherit (package) sha256;
+          url = "https://github.com/dannyvankooten/browserpass/releases/download/${version}/browserpass-${package.system}.zip";
+          stripRoot = false;
+        };
+
+        postUnpack = ''
+          # Files are not writable since they were copied from the nix store.
+          # That causes the install to fail next time because we can't overwrite them.
+          echo "chmod u+w \"\$TARGET_DIR/\$APP_NAME.json\"" >> browserpass-${package.system}.zip/install.sh
+          echo "[ \"\$BROWSER\" != ${toString browsers.firefox} ] && chmod u+w \"\$TARGET_DIR\"/../policies/managed/\"\$APP_NAME.json\" || :" >> browserpass-${package.system}.zip/install.sh
+          touch --date=@$SOURCE_DATE_EPOCH browserpass-${package.system}.zip/install.sh
+        '';
+
+        installPhase = ''
+          mkdir $out
+          mv * $out/
+        '';
+      });
+    in dagEntryBefore ["writeBoundary"] (builtins.concatStringsSep "" (map (browser: ''
+      $DRY_RUN_CMD ${browserpass}/install.sh <<EOF
+      ${toString browsers.${browser}}
+      EOF
+    '') config.programs.browserpass.browsers));
+  };
+}


### PR DESCRIPTION
A module that installs the host application required by the [browserpass](https://github.com/dannyvankooten/browserpass) extension.

I just hacked this together this evening. A better alternative may be to ditch the install script and use `home.file` instead, but this works as well. I would also prefer to build from source.