### PR TITLE
fix home.activation.checkLinkTargets

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -260,7 +260,7 @@ in
             relativePath="''${sourcePath#$newGenFiles/}"
             targetPath="$HOME/$relativePath"
             if [[ -e "$targetPath" \
-                && ! "$(readlink -e "$targetPath")" =~ "${pattern}" ]] ; then
+                && ! "$(readlink "$targetPath")" =~ "${pattern}" ]] ; then
               errorEcho "Existing file '$targetPath' is in the way"
               collision=1
             fi


### PR DESCRIPTION
### Problem

We resolve symlinks from inside `/nix/store/HASH-home-manager-files` into the nix store as `/nix/store/HASH-DRVNAME` which does not match the pattern.

This happened to me because I pull in some repos in via `home.file`. The `home-manager-files` derivation links to the repo's derivation in the nix store. For example:

```nix
let nanorcs = fetchFromGitHub {
  owner = "scopatz";
  repo = "nanorc";
  …
}; in [
  {
    target = ".nano";
    source = nanorcs;
  }
  {
    target = ".nanorc";
    source = "${nanorcs}/nanorc";
  }
]
```

### Solution

Call `readlink` without `-e` to obtain only the first redirection from `~` to `/nix/store/HASH-home-manager-files`.

### Why a PR?

I am unsure why you used `-e` but saw you using it consistently. Is there an edge case I failed to notice?