### PR TITLE
envvars: add module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,7 @@ with lib;
 let
 
   modules = [
+    ./shell-session-vars.nix
     ./home-environment.nix
     ./manual.nix
     ./misc/gtk.nix

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -164,13 +164,13 @@ in
     };
 
     home.sessionVariableSetter = mkOption {
-      default = "bash";
-      type = types.enum [ "pam" "bash" ];
+      default = "shell";
+      type = types.enum [ "pam" "shell" "bash" ];
       example = "pam";
       description = ''
         Identifies the module that should set the session variables.
         </para><para>
-        If "bash" is set then <varname>config.bash.enable</varname>
+        If "shell" is set then <varname>config.bash.enable</varname>
         must also be enabled.
         </para><para>
         If "pam" is set then PAM must be used to set the system

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -110,9 +110,6 @@ in
       histControlStr = concatStringsSep ":" cfg.historyControl;
       histIgnoreStr = concatStringsSep ":" cfg.historyIgnore;
 
-      envVarsStr = concatStringsSep "\n" (
-        mapAttrsToList export config.home.sessionVariables
-      );
     in mkIf cfg.enable {
       home.file.".bash_profile".text = ''
         # -*- mode: sh -*-
@@ -127,8 +124,9 @@ in
       home.file.".profile".text = ''
         # -*- mode: sh -*-
 
-        ${optionalString (config.home.sessionVariableSetter == "bash")
-          envVarsStr}
+        ${optionalString (config.home.sessionVariableSetter == "shell"
+	  || config.home.sessionVariableSetter == "bash")
+          "~/.local/share/home-manager/env.sh"}
 
         ${cfg.profileExtra}
       '';

--- a/modules/programs/info.nix
+++ b/modules/programs/info.nix
@@ -60,7 +60,7 @@ in
     }];
 
     home.sessionVariables.INFOPATH =
-      "${cfg.homeInfoDirLocation}\${INFOPATH:+:}\${INFOPATH}";
+      "${cfg.homeInfoDirLocation}\$INFOPATH:+:\$INFOPATH";
 
     home.activation.createHomeInfoDir = dagEntryAfter ["installPackages"] ''
       $DRY_RUN_CMD mkdir -p "${cfg.homeInfoDirLocation}"

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -41,7 +41,7 @@ in
 
       home.sessionVariables =
         optionalAttrs cfg.enableSshSupport {
-          SSH_AUTH_SOCK = "\${XDG_RUNTIME_DIR}/gnupg/S.gpg-agent.ssh";
+          SSH_AUTH_SOCK = "\$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh";
         };
 
       programs.bash.initExtra = ''

--- a/modules/shell-session-vars.nix
+++ b/modules/shell-session-vars.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = (
+    let
+      export = n: v: "export ${n}=\"${toString v}\"";
+      setenv = n: v: "setenv ${n} \"${toString v}\"";
+      shEnvVarsStr = concatStringsSep "\n" (
+        mapAttrsToList export config.home.sessionVariables
+      );
+      cshEnvVarsStr = concatStringsSep "\n" (
+        mapAttrsToList setenv config.home.sessionVariables
+      );
+    in mkIf (config.home.sessionVariableSetter == "shell"
+      || config.home.sessionVariableSetter == "bash") {
+      home.file.".local/share/home-manager/env.sh".text = ''
+        ${shEnvVarsStr}
+      '';
+      home.file.".local/share/home-manager/env.csh".text = ''
+        ${cshEnvVarsStr}
+      '';
+    }
+  );
+}


### PR DESCRIPTION
This module generalises the session variables configuration to
make adding new shells easier