### PR TITLE
Fix script error handling

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -91,11 +91,13 @@ function doSwitch() {
     local wrkdir
     wrkdir="$(mktemp -d)"
 
-    if doBuild "$wrkdir/generation" ; then
-        "$wrkdir/generation/activate"
-    fi
+    local exitCode=0
+    doBuild "$wrkdir/generation" && "$wrkdir/generation/activate" || exitCode=1
 
+    # Because the previous command never fails, the script keeps running and
+    # $wrkdir is always removed.
     rm -r "$wrkdir"
+    return $exitCode
 }
 
 function doListGens() {

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -91,8 +91,9 @@ function doSwitch() {
     local wrkdir
     wrkdir="$(mktemp -d)"
 
+    local generation
     local exitCode=0
-    doBuild "$wrkdir/generation" && "$wrkdir/generation/activate" || exitCode=1
+    generation=$(doBuild "$wrkdir/result") && $generation/activate || exitCode=1
 
     # Because the previous command never fails, the script keeps running and
     # $wrkdir is always removed.


### PR DESCRIPTION
Before commit `home-manager: exit with an error on build failure`, this snippet exited with no error:

    cat << EOF > buildError
    { pkgs, ... }:
    {
      home.packages = [ (pkgs.runCommand "fail" {} "exit 1") ];
    }
    EOF
    home-manager -f buildError switch
 
Demonstrate how the nix-store path of the activation script appears in the error message after commit  `show the original nix-store path in activation script error messages`:

    cat << EOF > activationError
    let
    dag = import ~/.nixpkgs/home-manager/modules/lib/dag.nix;
    in
    {
      home.activation.installPackages = dag.dagEntryAfter ["writeBoundary"] "non_existing_command";
    }
    EOF
    home-manager -f activationError switch


