### PR TITLE
Fix error when deleting empty directories on activation

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -317,15 +317,11 @@ in
               $DRY_RUN_CMD rm $VERBOSE_ARG "$targetPath"
               targetDir="$(dirname "$targetPath")"
 
-              # Recursively remove the containing directory. We only
-              # do this if the containing folder is not $HOME since
-              # running rmdir on $HOME will result in a harmless but
-              # unpleasant error message.
-              if [[ "$targetDir" != "$HOME" ]] ; then
-                $DRY_RUN_CMD rmdir $VERBOSE_ARG \
-                    -p --ignore-fail-on-non-empty \
-                    "$targetDir"
-              fi
+              # Recursively remove empty parent directories.
+              while [[ "$targetDir" != "$HOME" && ! "$(ls -A "$targetDir")" ]]; do
+                $DRY_RUN_CMD rmdir $VERBOSE_ARG "$targetDir"
+                targetDir="$(dirname "$targetDir")"
+              done
             fi
           done
         '';


### PR DESCRIPTION
Here's how to reproduce the error:

1. Activate config with a file in a directory that is otherwise empty

        cat << EOF > cfgWithFile
        {
          home.file."foo/bar".text = "";
        }
        EOF
        home-manager -f cfgWithFile switch

2. Activate config without this file

        cat << EOF > cfgWithoutFile
        {}
        EOF
        home-manager -f cfgWithoutFile switch
