### PR TITLE
Fix error when deleting empty directories

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -315,16 +315,17 @@ in
             else
               echo "Checking $targetPath  gone (deleting)"
               $DRY_RUN_CMD rm $VERBOSE_ARG "$targetPath"
-              targetDir="$(dirname "$targetPath")"
 
-              # Recursively remove the containing directory. We only
-              # do this if the containing folder is not $HOME since
-              # running rmdir on $HOME will result in a harmless but
-              # unpleasant error message.
-              if [[ "$targetDir" != "$HOME" ]] ; then
+              # Recursively delete empty parent directories.
+              targetDir="$(dirname "$relativePath")"
+              if [[ "$targetDir" != "." ]] ; then
+                pushd "$HOME" > /dev/null
+                # Call rmdir with a relative path excluding $HOME. Otherwise, it
+                # might try to delete $HOME and exit with a permission error.
                 $DRY_RUN_CMD rmdir $VERBOSE_ARG \
                     -p --ignore-fail-on-non-empty \
                     "$targetDir"
+                popd > /dev/null
               fi
             fi
           done


### PR DESCRIPTION
Here's how to reproduce the error:

1. Activate config with a file in a directory that is otherwise empty

```bash
cat << EOF > cfgWithFile
{
  home.file."a/file".text = "";
}
EOF
home-manager -f cfgWithFile switch
```


2. Activate config without this file
```bash
cat << EOF > cfgWithoutFile
{}
EOF
home-manager -f cfgWithoutFile switch
```



The approach in this commit has the downside that the verbose rmdir output contains relative paths:
```
rmdir: removing directory, 'a'
```

Previously, it was
```
rmdir: removing directory, '/home/myhome/a'
```

As an alternative, consider https://github.com/nonsequitur/home-manager/commit/4d11d85512b732e35dbf77dec738150e89e84e16, which manually walks the parent dirs and prints absolute paths.