### PR TITLE
Use relative path symlink, so latest generation survives garbage collection

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -355,7 +355,7 @@ in
           if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
             echo "Creating profile generation $newGenNum"
             $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenProfilePath"
-            $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenProfilePath" "$genProfilePath"
+            $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG $(basename "$newGenProfilePath") "$genProfilePath"
             $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"
           else
             echo "No change so reusing latest profile generation $oldGenNum"


### PR DESCRIPTION
Currently, the `nix-collect-garbage -d` command removes all the symlink files, such as `/nix/var/nix/profiles/per-user/foo/home-manager-9-link`, including the latest one. That causes the `home-manager generations` command fail to find any generations. And the next build will start from generation one.

Apparently, using a relative path as the target of `/nix/var/nix/profiles/per-user/foo/home-manager` effectively prevents the latest generation link from being removed unexpectedly.

I'm not sure if it is a bug of the `nix-collect-garbage` script. Other (system, container, channels) profiles seem to use relative paths. We might want to be consistent. :)
