### PR TITLE
udiskie: provide correct path for xdg-open

### DIFF
--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -18,7 +18,7 @@ with lib;
         };
 
         Service = {
-          ExecStart = "${pkgs.pythonPackages.udiskie}/bin/udiskie -2 -A -n -s";
+          ExecStart = "${pkgs.pythonPackages.udiskie}/bin/udiskie -2 -A -n -s -f ${pkgs.xdg_utils}/bin/xdg-open";
         };
 
         Install = {


### PR DESCRIPTION
By default, udiskie uses `xdg-open` as a program to open mounted folders ([src](http://manpages.ubuntu.com/manpages/wily/man8/udiskie.8.html)), but it can't find it according to this log message:
```
Can't find file browser: u'xdg-open'. You may want to change the value for the '-f' option
```