### PR TITLE
zsh module improvements

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -112,6 +112,8 @@ in
           fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions)
         done
 
+        HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
+
         ${if cfg.enableCompletion then "autoload -U compinit && compinit" else ""}
         ${optionalString (cfg.enableAutosuggestions)
           "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -107,6 +107,11 @@ in
         ${if cfg.history.ignoreDups then "setopt" else "unsetopt"} HIST_IGNORE_DUPS
         ${if cfg.history.share then "setopt" else "unsetopt"} SHARE_HISTORY
 
+        # Tell zsh how to find installed completions
+        for p in ''${(z)NIX_PROFILES}; do
+          fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions)
+        done
+
         ${if cfg.enableCompletion then "autoload -U compinit && compinit" else ""}
         ${optionalString (cfg.enableAutosuggestions)
           "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"


### PR DESCRIPTION
It would be even better if we could make something like this with the history options:
```
programs.zsh = {
  history = {
    size = 10000;
    file = "$HOME/.zsh_history"
    share = true;
    ignoreDups = true;
  };
};
```
But I'm not sure how to acheive this in Nix. Used options are described [here](http://zsh.sourceforge.net/Doc/Release/Options.html).

I also added some code from [zsh nixos module](https://github.com/NixOS/nixpkgs/blob/release-17.03/nixos/modules/programs/zsh/zsh.nix#L110) for cases when users will install zsh only in user environment.