### PR TITLE
systemd: don't fail on activation when services changed

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -147,7 +147,7 @@ in
             --old-line-format='-%L' \
             --unchanged-line-format=' %L' \
             "$oldServiceFiles" "$newServiceFiles" \
-            > $servicesDiffFile
+            > $servicesDiffFile || true
 
           local -a maybeRestart=( $(grep '^ ' $servicesDiffFile | cut -c2-) )
           local -a toStop=( $(grep '^-' $servicesDiffFile | cut -c2-) )


### PR DESCRIPTION
diff exits with status 1 when detecting differences. Because of
'set -e', this caused the activation to fail.