### PR TITLE
Fix syntax error caused by copy-paste

### DIFF
--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -6,7 +6,7 @@ let
       let
         conf = import confPath;
       in
-        if confAttr == "" then conf else conf.''${confAttr};
+        if confAttr == "" then conf else conf.${confAttr};
     pkgs = pkgs;
   };
 in


### PR DESCRIPTION
I managed to switch to the previous generation of home-manager and this change seems to fix Issue https://github.com/rycee/home-manager/issues/48.