### PR TITLE
zsh: remove search for installed completions

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -107,11 +107,6 @@ in
         ${if cfg.history.ignoreDups then "setopt" else "unsetopt"} HIST_IGNORE_DUPS
         ${if cfg.history.share then "setopt" else "unsetopt"} SHARE_HISTORY
 
-        # Tell zsh how to find installed completions
-        for p in ''${(z)NIX_PROFILES}; do
-          fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions)
-        done
-
         HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
 
         ${if cfg.enableCompletion then "autoload -U compinit && compinit" else ""}


### PR DESCRIPTION
1. Takes a lot of time: seriously, this takes 2 seconds at first launch, and like .25 second for the following launches;
2. Is redundant with using `oh-my-zsh`, completions is set in there, works well, and does not lag as much (why?). For using the `oh-my-zsh` config, one must enable zsh first.