### PR TITLE
Home file improvements

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -15,9 +15,7 @@ in
 pkgs.stdenv.mkDerivation {
   name = "home-manager";
 
-  phases = [ "installPhase" ];
-
-  installPhase = ''
+  buildCommand = ''
     install -v -D -m755 ${./home-manager} $out/bin/home-manager
 
     substituteInPlace $out/bin/home-manager \

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -410,9 +410,7 @@ in
         home-files = pkgs.stdenv.mkDerivation {
           name = "home-manager-files";
 
-          phases = [ "installPhase" ];
-
-          installPhase =
+          buildCommand =
             "mkdir -p $out\n" +
             concatStringsSep "\n" (
               mapAttrsToList (n: v:
@@ -431,9 +429,7 @@ in
         pkgs.stdenv.mkDerivation {
           name = "home-manager-generation";
 
-          phases = [ "installPhase" ];
-
-          installPhase = ''
+          buildCommand = ''
             install -D ${activationScript} $out/activate
 
             substituteInPlace $out/activate \

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -389,7 +389,7 @@ in
             abort ("Dependency cycle in activation script: "
               + builtins.toJSON sortedCommands);
 
-        sf = pkgs.writeText "activation-script" ''
+        activationScript = pkgs.writeScript "activation-script" ''
           #!${pkgs.stdenv.shell}
 
           set -eu
@@ -434,7 +434,7 @@ in
           phases = [ "installPhase" ];
 
           installPhase = ''
-            install -D -m755 ${sf} $out/activate
+            install -D ${activationScript} $out/activate
 
             substituteInPlace $out/activate \
               --subst-var-by GENERATION_DIR $out

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -124,18 +124,21 @@ in
               '';
             };
 
-            mode = mkOption {
-              type = types.str;
-              default = "444";
-              description = "The permissions to apply to the file.";
+            executable = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Set file as executable.";
             };
           };
 
           config = {
             target = mkDefault name;
-            source = mkIf (config.text != null) (
-              mkDefault (pkgs.writeText "home-file" config.text)
-            );
+            source = mkIf (config.text != null)
+                       (mkDefault (pkgs.writeTextFile {
+                          name = "home-file";
+                          text = config.text;
+                          executable = config.executable;
+                        }));
           };
         })
       );
@@ -419,7 +422,7 @@ in
                     mkdir -pv "$(dirname "$out/${v.target}")"
                     ln -sv "${v.source}" "$out/${v.target}"
                   else
-                    install -D -m${v.mode} "${v.source}" "$out/${v.target}"
+                    install -D -m${if v.executable then "+x" else "-x"} "${v.source}" "$out/${v.target}"
                   fi
                 ''
               ) cfg.file

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -134,8 +134,7 @@ in
           config = {
             target = mkDefault name;
             source = mkIf (config.text != null) (
-              let name' = "user-etc-" + baseNameOf name;
-              in mkDefault (pkgs.writeText name' config.text)
+              mkDefault (pkgs.writeText "home-file" config.text)
             );
           };
         })

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -90,6 +90,8 @@ let
     };
   };
 
+  homeFilePattern = "-home-manager-files/";
+
 in
 
 {
@@ -252,7 +254,6 @@ in
     # overwrite an existing file.
     home.activation.checkLinkTargets = dagEntryBefore ["writeBoundary"] (
       let
-        pattern = "-home-manager-files/";
         check = pkgs.writeText "check" ''
           . ${./lib-bash/color-echo.sh}
 
@@ -262,7 +263,7 @@ in
             relativePath="''${sourcePath#$newGenFiles/}"
             targetPath="$HOME/$relativePath"
             if [[ -e "$targetPath" \
-                && ! "$(readlink "$targetPath")" =~ "${pattern}" ]] ; then
+                && ! "$(readlink "$targetPath")" =~ "${homeFilePattern}" ]] ; then
               errorEcho "Existing file '$targetPath' is in the way"
               collision=1
             fi
@@ -288,8 +289,6 @@ in
 
     home.activation.linkGeneration = dagEntryAfter ["writeBoundary"] (
       let
-        pattern = "-home-manager-files/";
-
         link = pkgs.writeText "link" ''
           newGenFiles="$1"
           shift
@@ -312,7 +311,7 @@ in
             targetPath="$HOME/$relativePath"
             if [[ -e "$newGenFiles/$relativePath" ]] ; then
               $VERBOSE_ECHO "Checking $targetPath: exists"
-            elif [[ ! "$(readlink "$targetPath")" =~ "${pattern}" ]] ; then
+            elif [[ ! "$(readlink "$targetPath")" =~ "${homeFilePattern}" ]] ; then
               warnEcho "Path '$targetPath' not link into Home Manager generation. Skipping delete."
             else
               $VERBOSE_ECHO "Checking $targetPath: gone (deleting)"

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -72,7 +72,7 @@ in
     };
 
     home.file.".xsession" = {
-      mode = "555";
+      executable = true;
       text = ''
         if [[ -e "$HOME/.profile" ]]; then
           . "$HOME/.profile"


### PR DESCRIPTION
## Replace option `mode` with option `executable` ([Commit](https://github.com/nonsequitur/home-manager/commit/0ebef01d5a4756e020cae9d42137b1397dcec18e))
We could maintain backwards compatibility by translating the chmod directive of
`mode` to the boolean value `executable`. But this either needs a very complex direct
implementation or an ugly hack (write file to nix-store with `mode` and read back
the executable bit). So I'd suggest a breaking change.

# Link home files
I had an issue with large home files that caused bloated `home-manager-files`.
[Commit `link home files instead of copying`](https://github.com/nonsequitur/home-manager/commit/6f512f52587e02e1340ce8cfde58ce1ff1788f79) fixes this.

The commit is straightforward but it inherits some other problems of the original code:
- Files with a non-matching execute bit are still needessly copied for each new generation.
  Solution: For each file with an external source, make a wrapper derivation that copies on
  demand or otherwise just creates a link.
- After garbage collection, all home file derivations get deleted from the store and must be re-built when
  creating a new generation. This can also lead to multiple copies of identical home
  files among different generations.
  Solution: Use symlinks instead of hardlinks in `home-manager-files`, so that Nix can
  recognize the linked files as store dependencies.
  This has the downside that each home file needs a chain of two symlinks to
  point from `$HOME` to its final store location.

I've implemented both solutions [here](https://github.com/nonsequitur/home-manager/commit/d6d5895893627c4972d15a44f993bcddb27f4c5c).
Note that for home files `text` now takes precedence over the `source` option.

The symlink chain issue can be fixed, too:
Give all home file derivations the same unique name that makes them identifiable as
home files and link to them directly from `$HOME`.
That's the approach that I would recommend and that I'm using in my fork. [Here's the implementation](https://github.com/nonsequitur/home-manager/commit/5cf8ab6b52c806b3817fa9896bf67dfa0be584eb).
Downside: To make this backwards compatible, the old `-home-manager-files/` pattern
must also be considered when detecting home files: [Implementation](https://www.pastiebin.com/59afbd3ab268f), [full commit](https://github.com/nonsequitur/home-manager/commit/face223648a58a576b96a4d513775339a7dafbdf).

Here's a config for experimenting:
```
cat << EOF > homeFiles
{ pkgs, ... }:
let
  nonExecutableFile = pkgs.writeText "a" "a";
  executableFile = pkgs.writeScript "a" "a";
in
  {
    home.file."basic_file" = { text = "a"; };

    home.file."test/my/nested/file" = { text = "a"; };
    home.file."test/spēcïal chârs" = { text = "a"; };

    home.file."test/noexec" = { text = "a"; };
    home.file."test/exec" = { text = "a"; executable = true; };

    home.file."test/noexecSrcExec" = { source = executableFile; };
    home.file."test/noexecSrcNoExec" = { source = nonExecutableFile; };

    home.file."test/execSrcExec" = { source = executableFile; executable = true; };
    home.file."test/execSrcNoExec" = { source = nonExecutableFile; executable = true; };

    # home.file."test/dir" = { source = ~/my_dir; };
  }
EOF
home-manager -f homeFiles switch
```