### PR TITLE
blueman-applet: add module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -34,6 +34,7 @@ let
     ./programs/texlive.nix
     ./programs/vim.nix
     ./programs/zsh.nix
+    ./services/blueman-applet.nix
     ./services/dunst.nix
     ./services/gnome-keyring.nix
     ./services/gpg-agent.nix

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -108,6 +108,12 @@ in
   config = {
     news.entries = [
       {
+        time = "2017-09-12T14:22:18+00:00";
+        message = ''
+          New service is available: 'services.blueman-applet'.
+        '';
+      }
+      {
         time = "2017-09-12T13:11:48+00:00";
         condition = (
           config.programs.zsh.enable &&

--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options = {
+    services.blueman-applet = {
+      enable = mkEnableOption "Blueman applet";
+    };
+  };
+
+  config = mkIf config.services.blueman-applet.enable {
+    systemd.user.services.blueman-applet = {
+        Unit = {
+          Description = "Blueman applet";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          ExecStart = "${pkgs.blueman}/bin/blueman-applet";
+        };
+    };
+  };
+}


### PR DESCRIPTION
It would be nice if we would have a standard news entry message template for adding new services, programs, etc. Ideally it should probably be in CONTRIBUTING.md file.