### PR TITLE
vim: add package option

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -46,6 +46,12 @@ in
         '';
         description = "Custom .vimrc lines";
       };
+
+      package = mkOption {
+        type = types.package;
+        description = "Resulting customized vim package";
+        readOnly = true;
+      };
     };
   };
 
@@ -71,7 +77,8 @@ in
       };
 
     in mkIf cfg.enable {
-      home.packages = [ vim ];
+      programs.vim.package = vim;
+      home.packages = [ cfg.package ];
     }
   );
 }


### PR DESCRIPTION
This adds a readonly package option which will be set to the resulting
configured vim package, so it can be refered to by other configuration.
An example and my usecase is `home.sessionVariables.EDITOR =
config.programs.vim.package`.

`cfg.package` is used instead of `vim` in `home.packages` because otherwise the option wouldn't be checked, not sure why.