### PR TITLE
screen-locker: add module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -44,6 +44,7 @@ let
     ./services/owncloud-client.nix
     ./services/random-background.nix
     ./services/redshift.nix
+    ./services/screen-locker.nix
     ./services/syncthing.nix
     ./services/taffybar.nix
     ./services/tahoe-lafs.nix

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -185,6 +185,13 @@ in
           A new service is available: 'services.compton'.
         '';
       }
+
+      {
+        time = "2017-09-20T14:47:14+00:00";
+        message = ''
+          A new service is available: 'services.screen-locker'.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.screen-locker;
+
+in {
+
+  options.services.screen-locker = {
+    enable = mkEnableOption "screen locker for X session";
+
+    lockCmd = mkOption {
+      type = types.str;
+      description = "Locker command to run.";
+      example = "\${pkgs.i3lock}/bin/i3lock -n -c 000000";
+    };
+
+    inactiveInterval = mkOption {
+      type = types.int;
+      default = 10;
+      description = ''
+        Inactive time interval in minutes after which session will be locked.
+        The minimum is 1 minute, and the maximum is 1 hour.
+        See <link xlink:href="https://linux.die.net/man/1/xautolock"/>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.xautolock-session = {
+      Unit = {
+        Description = "xautolock, session locker service";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        ExecStart = ''
+          ${pkgs.xautolock}/bin/xautolock \
+          -detectsleep \
+          -time ${toString cfg.inactiveInterval} \
+          -locker '${pkgs.systemd}/bin/loginctl lock-session $XDG_SESSION_ID'
+        '';
+      };
+    };
+
+    # xss-lock will run specified screen locker when the session is locked via loginctl
+    # can't be started as a systemd service,
+    # see https://bitbucket.org/raymonad/xss-lock/issues/13/allow-operation-as-systemd-user-unit
+    xsession.initExtra = "${pkgs.xss-lock}/bin/xss-lock -- ${cfg.lockCmd} &";
+  };
+
+}

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -87,6 +87,7 @@ in
         systemctl --user import-environment XAUTHORITY
         systemctl --user import-environment XDG_DATA_DIRS
         systemctl --user import-environment XDG_RUNTIME_DIR
+        systemctl --user import-environment XDG_SESSION_ID
 
         systemctl --user start hm-graphical-session.target
 


### PR DESCRIPTION
The combination of `xautolocker` and `xss-lock` allows to use `$ loginctl lock-session` command to lock the session and the screen. `xautolocker` launches `loginctl lock-session` when the system is idle and `xss-lock` is listening to this event and executes the locker specified by the user. It also fixes the screen locking on suspend.

Unfortunatelly, `xss-lock` can't be launched from systemd service and I din't manage to find the replacement for it, therefore I had to put it into `.xsession` file.