### PR TITLE
vim: add option `programs.vim.settings`

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -255,6 +255,25 @@ in
           'xsession.windowManager.i3'.
         '';
       }
+
+      {
+        time = "2017-09-30T09:44:18+00:00";
+        condition = with config.programs.vim;
+          enable && (tabSize != null || lineNumbers != null);
+        message = ''
+          The options 'programs.vim.tabSize' and 'programs.vim.lineNumbers' have
+          been deprecated and will be removed in the near future.
+
+          The new and preferred way to configure tab size and line numbers is to
+          use the more general 'programs.vim.settings' option. Specifically,
+          instead of
+
+          - 'programs.vim.lineNumbers' use 'programs.vim.settings.number', and
+
+          - 'programs.vim.tabSize' use 'programs.vim.settings.tabstop' and
+            'programs.vim.settings.shiftwidth'.
+        '';
+      }
     ];
   };
 }


### PR DESCRIPTION
This option gathers basic Vim settings into a single place. The idea is to allow many options without making the Home Manager documentation too verbose. A screenshot of the man page shows that the documentation is quite compact so it should be possible to squeeze in quite a few settings:

![programs-vim-settings-man-page](https://user-images.githubusercontent.com/798147/30670768-ec3dcfde-9e63-11e7-845c-7df3ee5a6396.png)

Note, it's been a along time since I used Vim regularly so I cannot vouch for the validity of `setExpr`.