### PR TITLE
readme: add man page info

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ $ home-manager build
 which will create a `result` link to a directory containing an
 activation script and the generated home directory files.
 
+To see available configuration options with descriptions
+and usage examples run
+
+```
+$ man home-configuration.nix
+```
+
 Keeping your ~ safe from harm
 -----------------------------
 


### PR DESCRIPTION
I just realized that we don't have any information about the generated manual page, which is probably the primary source of documentation about available parameters for now.

@rycee, fill free to rephrase the sentence if you want.