### PR TITLE
git: change extraConfig from str to attrs

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -192,6 +192,34 @@ in
           A new service is available: 'services.screen-locker'.
         '';
       }
+
+      {
+        time = "2017-09-22T12:09:01+00:00";
+        condition = isString config.programs.git.extraConfig;
+        message = ''
+          The 'programs.git.extraConfig' parameter is now
+          accepting attributes instead of strings which allows more
+          flexible configuration.
+
+          The string parameter type will be deprecated in the future,
+          please change your configuration file accordingly.
+
+          For example, if your configuration includes
+
+              programs.git.extraConfig = '''
+                [core]
+                editor = vim
+              ''';
+
+          then you can now change it to
+
+              programs.git.extraConfig = {
+                core = {
+                  editor = "vim";
+                };
+              };
+        '';
+      }
     ];
   };
 }


### PR DESCRIPTION
This makes it possible to configure git like this:
```
programs.git {
  enable = true;
  extraConfig = {
    pull = {
      rebase = true;
    };
  };
};
```

Instead of specifying the string like this:
```
programs.git {
  enable = true;
  extraConfig = ''
    [pull]
    rebase=true
  '';
};
```

Unfortunately, it doesn't allow to define sections in multiple modules, e.g. if it will be another module which will have `programs.git.extraConfig.pull = { ff = true; }`, then the final configuration will only contain one of the options:
```
[pull]
ff=1
```
At the same time, string value doesn't allow to extend individual sections either.

For now couldn't find the reason to use string value instead of attributes, correct me if I'm wrong.