### PR TITLE
xsession: deprecate `xsession.windowManager`

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -257,6 +257,13 @@ in
       }
 
       {
+        time = "2017-09-29T12:28:31+00:00";
+        message = ''
+          A new module is available: 'xsession.windowManager.xmonad'.
+        '';
+      }
+
+      {
         time = "2017-09-30T09:44:18+00:00";
         condition = with config.programs.vim;
           enable && (tabSize != null || lineNumbers != null);

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -1,0 +1,86 @@
+{ pkgs }: { config, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.xmonad;
+
+  xmonad = pkgs.xmonad-with-packages.override {
+    ghcWithPackages = cfg.haskellPackages.ghcWithPackages;
+    packages = self:
+      cfg.extraPackages self
+      ++ optionals cfg.enableContribAndExtras [
+        self.xmonad-contrib self.xmonad-extras
+      ];
+  };
+
+in
+
+{
+  options = {
+    xmonad = {
+      enable = mkEnableOption "xmonad";
+
+      haskellPackages = mkOption {
+        default = pkgs.haskellPackages;
+        defaultText = "pkgs.haskellPackages";
+        example = literalExample "pkgs.haskell.packages.ghc784";
+        description = ''
+          The <varname>haskellPackages</varname> used to build xmonad
+          and other packages. This can be used to change the GHC
+          version used to build xmonad and the packages listed in
+          <varname>extraPackages</varname>.
+        '';
+      };
+
+      extraPackages = mkOption {
+        default = self: [];
+        defaultText = "self: []";
+        example = literalExample ''
+          haskellPackages: [
+            haskellPackages.xmonad-contrib
+            haskellPackages.monad-logger
+          ]
+        '';
+        description = ''
+          Extra packages available to GHC when rebuilding xmonad. The
+          value must be a function which receives the attribute set
+          defined in <varname>haskellPackages</varname> as the sole
+          argument.
+        '';
+      };
+
+      enableContribAndExtras = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Enable xmonad-{contrib,extras} in xmonad.";
+      };
+
+      config = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = literalExample ''
+          pkgs.writeText "xmonad.hs" '''
+            import XMonad
+            main = xmonad defaultConfig
+                { terminal    = "urxvt"
+                , modMask     = mod4Mask
+                , borderWidth = 3
+                }
+          '''
+        '';
+        description = ''
+          The configuration file to be used for xmonad. This must be
+          an absolute path or <literal>null</literal> in which case
+          <filename>~/.xmonad/xmonad.hs</filename> will not be managed
+          by Home Manager.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    command = "${xmonad}/bin/xmonad";
+  };
+}


### PR DESCRIPTION
The intention is for the `xsession.windowManager` to be available for full modules in the future. The option `xsession.windowManagerExec` should now be used specify the window manager command.