### PR TITLE
rofi: add module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -35,6 +35,7 @@ let
     ./programs/texlive.nix
     ./programs/vim.nix
     ./programs/zsh.nix
+    ./programs/rofi.nix
     ./services/blueman-applet.nix
     ./services/compton.nix
     ./services/dunst.nix

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -232,6 +232,12 @@ in
           tool in that NIX_AUTO_INSTALL is not supported.
         '';
       }
+      {
+        time = "2017-09-28T12:39:36+00:00";
+        message = ''
+          A new program module is available: 'programs.rofi';
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -1,0 +1,260 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with builtins;
+
+let
+
+  cfg = config.programs.rofi;
+
+  colorOption = description: mkOption {
+    type = types.string;
+    description = description;
+  };
+
+  rowColorSubmodule = types.submodule {
+    options = {
+      background = colorOption "Background color";
+      foreground = colorOption "Foreground color";
+      backgroundAlt = colorOption "Alternative background color";
+      highlight = mkOption {
+        type = types.submodule {
+          options = {
+            background = colorOption "Highlight background color";
+            foreground = colorOption "Highlight foreground color";
+          };
+        };
+        description = "Color settings for highlighted row.";
+      };
+    };
+  };
+
+  windowColorSubmodule = types.submodule {
+    options = {
+      background = colorOption "Window background color";
+      border = colorOption "Window border color";
+      separator = colorOption "Separator color";
+    };
+  };
+
+  colorsSubmodule = types.submodule {
+    options = {
+      window = mkOption {
+        default = null;
+        type = windowColorSubmodule;
+        description = "Window color settings.";
+      };
+      rows = mkOption {
+        default = null;
+        type = types.submodule {
+          options = {
+            normal = mkOption {
+              default = null;
+              type = types.nullOr rowColorSubmodule;
+              description = "Normal row color settings.";
+            };
+            active = mkOption {
+              default = null;
+              type = types.nullOr rowColorSubmodule;
+              description = "Active row color settings.";
+            };
+            urgent = mkOption {
+              default = null;
+              type = types.nullOr rowColorSubmodule;
+              description = "Urgent row color settings.";
+            };
+          };
+        };
+        description = "Rows color settings.";
+      };
+    };
+  };
+
+  valueToString = value:
+    if isBool value
+      then (if value then "true" else "else")
+      else toString value;
+
+  windowColorsToString = window: concatStringsSep ", " (with window; [
+    background
+    border
+    separator
+  ]);
+
+  rowsColorsToString = rows: ''
+    ${optionalString
+        (rows.normal != null)
+        (setOption "color-normal" (rowColorsToString rows.normal))}
+    ${optionalString
+        (rows.active != null)
+        (setOption "color-active" (rowColorsToString rows.active))}
+    ${optionalString
+        (rows.urgent != null)
+        (setOption "color-urgent" (rowColorsToString rows.urgent))}
+  '';
+
+  rowColorsToString = row: concatStringsSep ", " (with row; [
+    background
+    foreground
+    backgroundAlt
+    highlight.background
+    highlight.foreground
+  ]);
+
+  setOption = name: value:
+    optionalString (value != null) "rofi.${name}: ${valueToString value}";
+
+  setColorScheme = colors: optionalString (colors != null) ''
+    ${optionalString
+        (colors.window != null)
+        setOption "color-window" (windowColorsToString colors.window)}
+    ${optionalString
+        (colors.rows != null)
+        (rowsColorsToString colors.rows)}
+  '';
+
+in
+
+{
+  options.programs.rofi = {
+    enable = mkEnableOption "Rofi: A window switcher, application launcher and dmenu replacement";
+
+    width = mkOption {
+      default = null;
+      type = types.nullOr types.int;
+      description = "Window width";
+      example = 100;
+    };
+
+    lines = mkOption {
+      default = null;
+      type = types.nullOr types.int;
+      description = "Number of lines";
+      example = 10;
+    };
+
+    borderWidth = mkOption {
+      default = null;
+      type = types.nullOr types.int;
+      description = "Border width";
+      example = 1;
+    };
+
+    rowHeight = mkOption {
+      default = null;
+      type = types.nullOr types.int;
+      description = "Row height (in chars)";
+      example = 1;
+    };
+
+    padding = mkOption {
+      default = null;
+      type = types.nullOr types.int;
+      description = "Padding";
+      example = 400;
+    };
+
+    font = mkOption {
+      default = null;
+      type = types.nullOr types.string;
+      example = "Droid Sans Mono 14";
+      description = "Font to use";
+    };
+
+    scrollbar = mkOption {
+      default = null;
+      type = types.nullOr types.bool;
+      description = "Whether to show a scrollbar.";
+    };
+
+    terminal = mkOption {
+      default = null;
+      type = types.nullOr types.string;
+      description = ''
+        Path to the terminal which will be used to run console applications
+      '';
+      example = "\${pkgs.gnome3.gnome_terminal}/bin/gnome-terminal";
+    };
+
+    separator = mkOption {
+      default = null;
+      type = types.nullOr (types.enum [ "none" "dash" "solid" ]);
+      description = "Separator style";
+      example = "solid";
+    };
+
+    cycle = mkOption {
+      default = null;
+      type = types.nullOr types.bool;
+      description = "Whether to cycle through the results list";
+    };
+
+    colors = mkOption {
+      default = null;
+      type = types.nullOr colorsSubmodule;
+      description = ''
+        Color scheme settings.
+        Colors can be specified in CSS color formats.
+      '';
+      example = literalExample ''
+        colors = {
+          window = {
+            background = "argb:583a4c54";
+            border = "argb:582a373e";
+            separator = "#c3c6c8";
+          };
+
+          rows = {
+            normal = {
+              background = "argb:58455a64";
+              foreground = "#fafbfc";
+              backgroundAlt = "argb:58455a64";
+              highlight = {
+                background = "#00bcd4";
+                foreground = "#fafbfc";
+              };
+            };
+          };
+        };
+      '';
+    };
+
+    configPath = mkOption {
+      default = ".config/rofi/config";
+      type = types.string;
+      description = "Path where to put generated configuration file.";
+    };
+
+    extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      description = "Additional configuration to add.";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.rofi ];
+
+    home.file."${cfg.configPath}".text = ''
+      ${setOption "width" cfg.width}
+      ${setOption "lines" cfg.lines}
+      ${setOption "font" cfg.font}
+      ${setOption "bw" cfg.borderWidth}
+      ${setOption "eh" cfg.rowHeight}
+      ${setOption "padding" cfg.padding}
+      ${setOption "separator-style" cfg.separator}
+      ${setOption "hide-scrollbar" (
+        if (cfg.scrollbar != null)
+        then (! cfg.scrollbar)
+        else cfg.scrollbar
+      )}
+      ${setOption "terminal" cfg.terminal}
+      ${setOption "cycle" cfg.cycle}
+
+      ${setColorScheme cfg.colors}
+
+      ${cfg.extraConfig}
+    '';
+  };
+}


### PR DESCRIPTION
There are more options available in rofi configuration, but they are easy to add in the future as well.

My configuration for testing:

```
{ config, pkgs, lib, ... }:


let
  background = "#3a4c54";
  backgroundAlt = "#455a64";
  foreground = "#eceff1";
  highlightBG = "#00bcd4";
  highlightFG = "#fafbfc";
  primary = "#ff9800";
  secondary = "#03a9f4";
  urgent = "#ad1457";
  alpha = 58;
  transparent = color: ''argb:${toString alpha}${lib.removePrefix "#" color}'';

  rowsCommon = {
    background = transparent backgroundAlt;
    backgroundAlt = transparent backgroundAlt;
    highlight = {
      background = secondary;
      foreground = foreground;
    };
  };

in

{
  programs.rofi = {
    enable = true;
    width = 100;
    lines = 10;
    font = "Droid Sans Mono 14";
    borderWidth = 0;
    padding = 400;
    rowHeight = 1;
    separator = "solid";
    scrollbar = false;
    terminal = "${pkgs.gnome3.gnome_terminal}/bin/gnome-terminal";
    colors = {
      window = {
        background = transparent background;
        border = transparent background;
        separator = foreground;
      };
      rows = {
        normal = (rowsCommon // { foreground = foreground; });
        active = (rowsCommon // { foreground = secondary; });
        urgent = (rowsCommon // { foreground = urgent; });
      };
    };
  };
}
```