### PR TITLE
polybar: add module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -44,6 +44,7 @@ let
     ./services/keepassx.nix
     ./services/network-manager-applet.nix
     ./services/owncloud-client.nix
+    ./services/polybar.nix
     ./services/random-background.nix
     ./services/redshift.nix
     ./services/screen-locker.nix

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -295,6 +295,13 @@ in
           A new module is available: 'xsession.windowManager.xmonad'.
         '';
       }
+
+      {
+        time = "2017-10-06T08:21:43+00:00";
+        message = ''
+          A new service is available: 'services.polybar'.
+        '';
+      }
     ];
   };
 }


### PR DESCRIPTION
This module can be used only to configure polybar, but it doesn't start the bars.
The problem with launch is that it might require setting some environment variables depending on the user's configuration.
For example, this is the script I use to run my bar on all screens:

```
#!/usr/bin/env bash

killall -q polybar

while pgrep -u $UID -x polybar >/dev/null; do sleep 1; done

PRIMARY_MONITOR=`xrandr | grep "primary" | cut -d " " -f1`
MONITOR=$PRIMARY_MONITOR TRAY_POSITION=right polybar bar &

EXTRA_MONITORS=`xrandr | grep " connected" | grep -v $PRIMARY_MONITOR | cut -d " " -f1`
for MONITOR in $EXTRA_MONITORS; do
    MONITOR=$MONITOR polybar bar &
done

echo "Bars launched..."
```