### PR TITLE
Experimental NixOS module

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,4 +9,6 @@ rec {
   install = import ./home-manager/install.nix {
     inherit home-manager pkgs;
   };
+
+  nixos = import ./nixos;
 }

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -291,6 +291,7 @@ in
     # script's "check" and the "write" phases.
     home.activation.writeBoundary = dag.entryAnywhere "";
 
+    # Install packages to the user environment.
     home.activation.installPackages = dag.entryAfter ["writeBoundary"] ''
       $DRY_RUN_CMD nix-env -i ${cfg.path}
     '';

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -568,6 +568,52 @@ in
           GTK configurations.
         '';
       }
+
+      {
+        time = "2018-02-06T20:23:34+00:00";
+        message = ''
+          It is now possible to use Home Manager as a NixOS module.
+          This allows you to prepare user environments from the system
+          configuration file, which often is more convenient than
+          using the 'home-manager' tool. It also opens up additional
+          possibilities, for example, to automatically configure user
+          environments in NixOS declarative containers or on systems
+          deployed through NixOps.
+
+          This feature should be considered experimental for now and
+          some critial limitations apply. For example, it is currently
+          not possible to use 'nixos-rebuild build-vm' when using the
+          Home Manager NixOS module. That said, it should be
+          reasonably robust and stable for simpler use cases.
+
+          To make Home Manager available in your NixOS system
+          configuration you can add
+
+              imports = [
+                "''${builtins.fetchTarball https://github.com/rycee/home-manager/archive/master.tar.gz}/nixos"
+              ];
+
+          to your 'configuration.nix' file. This will introduce a new
+          NixOS option called 'home-manager.users' whose type is an
+          attribute set mapping user names to Home Manager
+          configurations.
+
+          For example, a NixOS configuration may include the lines
+
+              users.users.eve.isNormalUser = true;
+              home-manager.users.eve = {
+                home.packages = [ pkgs.atool pkgs.httpie ];
+                programs.bash.enable = true;
+              };
+
+          and after a 'nixos-rebuild switch' the user eve's
+          environment should include a basic Bash configuration and
+          the packages atool and httpie.
+
+          More detailed documentation on the intricacies of this new
+          feature is slowly forthcoming.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -3,6 +3,9 @@
 
   # Whether to enable module type checking.
 , check ? true
+
+  # Whether these modules are inside a NixOS submodule.
+, nixosSubmodule ? false
 }:
 
 with lib;
@@ -75,10 +78,17 @@ let
   ];
 
   pkgsModule = {
+    options.nixosSubmodule = mkOption {
+      type = types.bool;
+      internal = true;
+      readOnly = true;
+    };
+
     config._module.args.baseModules = modules;
     config._module.args.pkgs = lib.mkDefault pkgs;
     config._module.check = check;
     config.lib = import ./lib { inherit lib; };
+    config.nixosSubmodule = nixosSubmodule;
     config.nixpkgs.system = mkDefault pkgs.system;
   };
 

--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -32,7 +32,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf (cfg.enable && !config.nixosSubmodule) {
     home.packages = [
       (import ../../home-manager {
         inherit pkgs;

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, utils, ... }:
+
+with lib;
+
+let
+
+  cfg = config.home-manager;
+
+  hmModule = types.submodule ({name, ...}: {
+    imports = import ../modules/modules.nix {
+      inherit lib pkgs;
+      nixosSubmodule = true;
+    };
+
+    config = {
+      home.username = config.users.users.${name}.name;
+      home.homeDirectory = config.users.users.${name}.home;
+    };
+  });
+
+in
+
+{
+  options = {
+    home-manager.users = mkOption {
+      type = types.attrsOf hmModule;
+      default = {};
+      description = ''
+        Per-user Home Manager configuration.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.users != {}) {
+    systemd.services = mapAttrs' (username: usercfg:
+      nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {
+        description = "Home Manager environment for ${username}";
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          User = username;
+          Type = "oneshot";
+          RemainAfterExit = "yes";
+          SyslogIdentifier = "hm-activate-${username}";
+
+          # The activation script is run by a login shell to make sure
+          # that the user is given a sane Nix environment.
+          ExecStart = pkgs.writeScript "activate-${username}" ''
+            #! ${pkgs.stdenv.shell} -el
+            echo Activating home-manager configuration for ${username}
+            exec ${usercfg.home.activationPackage}/activate
+          '';
+        };
+      }
+    ) cfg.users;
+  };
+}


### PR DESCRIPTION
With this it is possible to put, e.g.,
```nix
{
  # …

  imports = [
    (import (builtins.fetchTarball https://github.com/rycee/home-manager/archive/nixos-module.tar.gz) {}).nixos
  ];

  users.users.jimdumree.isNormalUser = true;

  home-manager.users.jimdumree = {
    home.file."TEST".text = "foo";
    home.packages = [ pkgs.nload ];
    services.random-background = { enable = true; imageDirectory = "bgs"; };
  };

  # …
}
```
in the system `configuration.nix` and the user environment will be set up when `nixos-rebuild switch` runs. No need to install Home Manager first.

Hacky for now and some HM modules won't work.