### PR TITLE
Change home-manager Nix path semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,50 +46,62 @@ Currently the easiest way to install Home Manager is as follows:
     since Home Manager uses these directories to manage your profile
     generations. On NixOS these should already be available.
 
-2.  Clone the Home Manager repository into the `~/.config/nixpkgs`
-    directory:
+2.  Assign a temporary variable holding the URL to the appropriate
+    archive. Typically this is
 
     ```console
-    $ git clone -b master https://github.com/rycee/home-manager ~/.config/nixpkgs/home-manager
+    $ HM_PATH=https://github.com/rycee/home-manager/archive/master.tar.gz
     ```
 
     or
 
     ```console
-    $ git clone -b release-17.09 https://github.com/rycee/home-manager ~/.config/nixpkgs/home-manager
+    $ HM_PATH=https://github.com/rycee/home-manager/archive/release-17.09.tar.gz
     ```
 
-    depending on whether you are tracking Nixpkgs unstable or version
-    17.09.
+    depending on whether you follow Nixpkgs unstable or version 17.09.
 
-3.  Add Home Manager to your user's Nixpkgs, for example by symlinking the
-    overlay to `~/.config/nixpkgs/overlays`:
+2.  Create an initial Home Manager configuration file:
 
     ```console
-    $ ln -s ~/.config/nixpkgs/home-manager/overlay.nix ~/.config/nixpkgs/overlays/home-manager.nix
+    $ cat > ~/.config/nixpkgs/home.nix <<EOF
+    {
+      programs.home-manager.enable = true;
+      programs.home-manager.path = $HM_PATH;
+    }
+    EOF
     ```
 
-4.  Install the `home-manager` package:
+3.  Create the first Home Manager generation:
 
     ```console
-    $ nix-env -f '<nixpkgs>' -iA home-manager
-    installing ‘home-manager’
+    $ nix-shell $HM_PATH -A install --run 'home-manager switch'
     ```
+
+    Home Manager should now be active and available in your user
+    environment.
+
+Note, because the `HM_PATH` variable above points to the live Home
+Manager repository you will automatically get updates whenever you
+build a new generation. If you dislike automatic updates then perform
+a Git clone of the desired branch and set `programs.home-manager.path`
+to the absolute path of your clone.
 
 Usage
 -----
 
-The `home-manager` package installs a tool that is conveniently called
-`home-manager`. This tool can apply configurations to your home
+Home Manager is typically managed through the `home-manager` tool.
+This tool can, for example, apply configurations to your home
 directory, list user packages installed by the tool, and list the
 configuration generations.
 
-As an example, let us set up a very simple configuration that installs
-the htop and fortune packages, installs Emacs with a few extra
-packages enabled, installs Firefox with Adobe Flash enabled, and
-enables the user gpg-agent service.
+As an example, let us expand the initial configuration file from the
+installation above to install the htop and fortune packages, install
+Emacs with a few extra packages enabled, install Firefox with Adobe
+Flash enabled, and enable the user gpg-agent service.
 
-First create a file `~/.config/nixpkgs/home.nix` containing
+To satisfy the above setup we should elaborate the
+`~/.config/nixpkgs/home.nix` file as follows:
 
 ```nix
 { pkgs, ... }:
@@ -118,6 +130,11 @@ First create a file `~/.config/nixpkgs/home.nix` containing
     defaultCacheTtl = 1800;
     enableSshSupport = true;
   };
+
+  programs.home-manager = {
+    enable = true;
+    path = "…";
+  };
 }
 ```
 
@@ -136,8 +153,8 @@ $ home-manager build
 which will create a `result` link to a directory containing an
 activation script and the generated home directory files.
 
-To see available configuration options with descriptions
-and usage examples run
+To see available configuration options with descriptions and usage
+examples run
 
 ```console
 $ man home-configuration.nix

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,14 @@
-# Simply defer to the home-manager script derivation.
-import ./home-manager
+{ pkgs ? import <nixpkgs> {} }:
+
+rec {
+  home-manager = import ./home-manager {
+    inherit pkgs;
+    path = ./.;
+  };
+
+  install =
+    pkgs.runCommand
+      "home-manager-install"
+      { propagatedBuildInputs = [ home-manager ]; }
+      "";
+}

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,14 +1,14 @@
 { pkgs
 
-  # Extra path to the Home Manager modules. If set then this path will
-  # be tried before `$HOME/.config/nixpkgs/home-manager/modules` and
-  # `$HOME/.nixpkgs/home-manager/modules`.
-, modulesPath ? null
+  # Extra path to Home Manager. If set then this path will be tried
+  # before `$HOME/.config/nixpkgs/home-manager` and
+  # `$HOME/.nixpkgs/home-manager`.
+, path ? null
 }:
 
 let
 
-  modulesPathStr = if modulesPath == null then "" else modulesPath;
+  pathStr = if path == null then "" else path;
 
 in
 
@@ -24,8 +24,7 @@ pkgs.stdenv.mkDerivation {
       --subst-var-by bash "${pkgs.bash}" \
       --subst-var-by coreutils "${pkgs.coreutils}" \
       --subst-var-by less "${pkgs.less}" \
-      --subst-var-by MODULES_PATH '${modulesPathStr}' \
-      --subst-var-by HOME_MANAGER_EXPR_PATH "${./home-manager.nix}"
+      --subst-var-by HOME_MANAGER_PATH '${pathStr}'
   '';
 
   meta = with pkgs.stdenv.lib; {

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -40,13 +40,13 @@ function setConfigFile() {
     exit 1
 }
 
-function setHomeManagerModulesPath() {
-    local modulesPath
-    for modulesPath in "@MODULES_PATH@" \
-                       "$HOME/.config/nixpkgs/home-manager/modules" \
-                       "$HOME/.nixpkgs/home-manager/modules" ; do
-        if [[ -e "$modulesPath" ]] ; then
-            export NIX_PATH="$NIX_PATH${NIX_PATH:+:}home-manager=$modulesPath"
+function setHomeManagerNixPath() {
+    local path
+    for path in "@HOME_MANAGER_PATH@" \
+                "$HOME/.config/nixpkgs/home-manager" \
+                "$HOME/.nixpkgs/home-manager" ; do
+        if [[ -e "$path" || "$path" =~ ^https?:// ]] ; then
+            export NIX_PATH="$NIX_PATH${NIX_PATH:+:}home-manager=$path"
             return
         fi
     done
@@ -54,7 +54,7 @@ function setHomeManagerModulesPath() {
 
 function doBuildAttr() {
     setConfigFile
-    setHomeManagerModulesPath
+    setHomeManagerNixPath
 
     local extraArgs="$*"
 
@@ -67,7 +67,7 @@ function doBuildAttr() {
     fi
 
     nix-build \
-        "@HOME_MANAGER_EXPR_PATH@" \
+        "<home-manager/home-manager/home-manager.nix>" \
         $extraArgs \
         --argstr confPath "$HOME_MANAGER_CONFIG" \
         --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"

--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -9,7 +9,7 @@ with pkgs.lib;
 
 let
 
-  env = import <home-manager> {
+  env = import <home-manager/modules> {
     configuration =
       let
         conf = import confPath;

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -370,6 +370,46 @@ in
           chosen version.
         '';
       }
+
+      {
+        time = "2017-10-23T22:54:33+00:00";
+        condition = config.programs.home-manager.modulesPath != null;
+        message = ''
+          The 'programs.home-manager.modulesPath' option is now
+          deprecated and will be removed on November 24, 2017. Please
+          use the option 'programs.home-manager.path' instead.
+        '';
+      }
+
+      {
+        time = "2017-10-23T23:10:29+00:00";
+        condition = !config.programs.home-manager.enable;
+        message = ''
+          Unfortunately, due to some internal restructuring it is no
+          longer possible to install the home-manager command when
+          having
+
+              home-manager = import ./home-manager { inherit pkgs; };
+
+          in the '~/.config/nixpkgs/config.nix' package override
+          section. Attempting to use the above override will now
+          result in the error "cannot coerce a set to a string".
+
+          To resolve this please delete the override from the
+          'config.nix' file and either link the Home Manager overlay
+
+              $ ln -s ~/.config/nixpkgs/home-manager/overlay.nix \
+                      ~/.config/nixpkgs/overlays/home-manager.nix
+
+          or add
+
+              programs.home-manager.enable = true;
+
+          to your Home Manager configuration. The latter is
+          recommended as the home-manager tool then is updated
+          automatically whenever you do a switch.
+        '';
+      }
     ];
   };
 }


### PR DESCRIPTION
Instead of having the `<home-manager>` path point to the modules directory we let it point to the project root, i.e., the parent of the modules directory. With a few tweaks this allows the home-manager tool work directly with the GitHub archive. As a result the installation can be simplified and the home-manager module can automatically keep the installation up to date.