### PR TITLE
modules/programs/home-manager.nix: fix syntax error

### DIFF
--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -67,7 +67,7 @@ in
     # Without this a file collision error will be printed.
     home.activation.uninstallHomeManager =
       dagEntryBetween [ "installPackages" ] [ "writeBoundary" ] ''
-        if nix-env -q | grep -q '^home-manager$' ; then
+        if nix-env -q | grep -q "^home-manager$" ; then
           $DRY_RUN_CMD nix-env -e home-manager
 
           echo "You can now remove the 'home-manager' packageOverride"


### PR DESCRIPTION
Before this change, I get:

error: syntax error, unexpected $undefined, expecting IND_STR or DOLLAR_CURLY or
IND_STRING_CLOSE, at
/Users/rkm/git/deployments/realms/temmie.local/home-manager/modules/programs/home-manager.nix:70:47

And am unable to use the new NixOS module.