### PR TITLE
Support recursive linking of source directories

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -186,6 +186,8 @@ in
     home-files = pkgs.stdenv.mkDerivation {
       name = "home-manager-files";
 
+      nativeBuildInputs = [ pkgs.xlibs.lndir ];
+
       # Symlink directories and files that have the right execute bit.
       # Copy files that need their execute bit changed or use the
       # deprecated 'mode' option.
@@ -197,6 +199,7 @@ in
           local relTarget="$2"
           local executable="$3"
           local mode="$4"     # For backwards compatibility.
+          local recursive="$5"
 
           # Figure out the real absolute path to the target.
           local target
@@ -210,7 +213,12 @@ in
 
           mkdir -p "$(dirname "$target")"
           if [[ -d $source ]]; then
-            ln -s "$source" "$target"
+            if [[ $recursive ]]; then
+              mkdir -p "$target"
+              lndir -silent "$source" "$target"
+            else
+              ln -s "$source" "$target"
+            fi
           elif [[ $mode ]]; then
             install -m "$mode" "$source" "$target"
           else
@@ -234,7 +242,8 @@ in
                      "${if v.executable == null
                         then "symlink"
                         else builtins.toString v.executable}" \
-                     "${builtins.toString v.mode}"
+                     "${builtins.toString v.mode}" \
+                     "${builtins.toString v.recursive}"
         '') cfg
       );
     };

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -89,6 +89,23 @@ in
             for files created through the <varname>text</varname> option.
           '';
         };
+
+        recursive = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If the file source is a directory, then this option
+            determines whether the directory should be recursively
+            linked to the target location. This option has no effect
+            if the source is a file.
+            </para><para>
+            If <literal>false</literal> (the default) then the target
+            will be a symbolic link to the source directory. If
+            <literal>true</literal> then the target will be a
+            directory structure matching the source's but whose leafs
+            are symbolic links to the files of the source directory.
+          '';
+        };
       };
 
       config = {


### PR DESCRIPTION
It is currently possible to use a directory as source in `home.file` and the directory will be linked to the home directory. Sometimes, however, it is convenient to not link the directory itself but rather recursively link the files within the directory. This could possibly be accomplished by adding a Boolean option `recursive` that when `true` makes the `home-manager-files` derivation use `lndir` to link the directory.