### PR TITLE
neovim: init module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -35,6 +35,7 @@ let
     ./programs/info.nix
     ./programs/lesspipe.nix
     ./programs/man.nix
+    ./programs/neovim.nix
     ./programs/rofi.nix
     ./programs/ssh.nix
     ./programs/termite.nix

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -442,6 +442,12 @@ in
           December 6, 2017.
         '';
       }
+      {
+        time = "2017-11-12T00:18:59+00:00";
+        message = ''
+          A new program module is available: 'program.neovim'.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.neovim;
+in
+{
+  options = {
+    programs.neovim = {
+      enable = mkEnableOption "Neovim";
+
+      withPython = mkOption {
+        type = types.nullOr types.bool;
+        default = true;
+        description = ''
+          Enable python 2 provider. Set to true to use python 2 plugins.
+        '';
+      };
+
+      extraPythonPackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExample ''
+          [ pandas jedi ]
+        '';
+        description = ''
+          List here python 2 packages required for your plugins to work.
+        '';
+      };
+
+      withRuby = mkOption {
+        type = types.nullOr types.bool;
+        default = true;
+        description = ''
+          Enable ruby provider.
+        '';
+      };
+
+      withPython3 = mkOption {
+        type = types.nullOr types.bool;
+        default = true;
+        description = ''
+          Enable python 3 provider. Set to true to use python 3 plugins.
+        '';
+      };
+
+      extraPython3Packages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        example = ''
+          [ python-language-server ]
+        '';
+        description = ''
+          List here python 3 packages required for your plugins to work.
+        '';
+      };
+    };
+  };
+
+  config =
+    let
+      neovim = pkgs.neovim.override {
+        inherit (cfg) extraPython3Packages withPython3 extraPythonPackages withPython withRuby;
+      };
+    in mkIf cfg.enable rec {
+      home.packages = [ neovim ];
+    };
+}
+


### PR DESCRIPTION
This is a basic module that allows to configure different neovim providers than
the system ones.

I did start trying to generate a custom init.vim (rather an init.bis.vim that I wanted to source from my init.vim) but I was not sure how to try to reuse the vim stuff.

I might do that later but as I am busy, I wanted to merge this first as it makes my neovim programming workflow easier.