### PR TITLE
programs.git: use xdg

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -89,7 +89,7 @@ in
           email = cfg.userEmail;
         };
 
-        home.file.".gitconfig".text =
+        xdg.configFile."git/config".text =
           generators.toINI {} cfg.iniContent;
       }
 
@@ -110,7 +110,7 @@ in
       })
 
       (mkIf (lib.isString cfg.extraConfig) {
-        home.file.".gitconfig".text = cfg.extraConfig;
+        xdg.configFile."git/config".text = cfg.extraConfig;
       })
     ]
   );


### PR DESCRIPTION
This uses the `xdg` module to store git config (in `.config/git/config`), instead of `.gitignore`.