### PR TITLE
Return a derivation fn in main nix expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Currently the easiest way to install Home Manager is as follows:
 4.  Create the first Home Manager generation:
 
     ```console
-    $ nix-shell $HM_PATH -A install --run 'home-manager switch'
+    $ $(nix-build $HM_PATH --no-out-link)/bin/home-manager switch
     ```
 
     Home Manager should now be active and available in your user

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,6 @@
 { pkgs ? import <nixpkgs> {} }:
 
-rec {
-  home-manager = import ./home-manager {
-    inherit pkgs;
-    path = ./.;
-  };
-
-  install =
-    pkgs.runCommand
-      "home-manager-install"
-      { propagatedBuildInputs = [ home-manager ]; }
-      "";
+import ./home-manager {
+  inherit pkgs;
+  path = toString ./.;
 }


### PR DESCRIPTION
This simplifies installing by (re-)enabling the standard practice of using the main package expression as a function that returns the package derivation.

Convert the src dir path to a string to avoid needlessly copying the whole dir to the nix store.