### PR TITLE
i3: correct example for config.floating.criteria

### DIFF
--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -163,7 +163,7 @@ let
               type = types.listOf criteriaModule;
               default = [];
               description = "List of criteria for windows that should be opened in a floating mode.";
-              example = [ "title='Steam - Update News'" "class='Pavucontrol'" ];
+              example = [ {"title" = "Steam - Update News";} {"class" = "Pavucontrol";} ];
             };
           };
         };


### PR DESCRIPTION
accepts a `listOf` `criteriaModule` (which is `types.attrs`, not `types.string`)