### PR TITLE
home-manager: use `shellHook` to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Currently the easiest way to install Home Manager is as follows:
     EOF
     ```
 
-4.  Create the first Home Manager generation:
+4.  Install Home Manager and create the first Home Manager generation:
 
     ```console
-    $ nix-shell $HM_PATH -A install --run 'home-manager switch'
+    $ nix-shell $HM_PATH -A install
     ```
 
     Home Manager should now be active and available in your user

--- a/default.nix
+++ b/default.nix
@@ -6,9 +6,7 @@ rec {
     path = toString ./.;
   };
 
-  install =
-    pkgs.runCommand
-      "home-manager-install"
-      { propagatedBuildInputs = [ home-manager ]; }
-      "";
+  install = import ./home-manager/install.nix {
+    inherit home-manager pkgs;
+  };
 }

--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -1,0 +1,37 @@
+{ home-manager, pkgs }:
+
+pkgs.runCommand
+  "home-manager-install"
+  {
+    propagatedBuildInputs = [ home-manager ];
+    shellHook = ''
+      echo
+      echo "Creating initial Home Manager generation..."
+      echo
+
+      if home-manager switch; then
+        cat <<EOF
+
+      All done! The home-manager tool should now be installed and you
+      can edit
+
+          ''${XDG_CONFIG_HOME:-~/.config}/nixpkgs/home.nix
+
+      to configure Home Manager. Run 'man home-configuration.nix' to
+      see all available options.
+      EOF
+        exit 0
+      else
+        cat <<EOF
+
+      Uh oh, the installation failed! Please create an issue at
+
+          https://github.com/rycee/home-manager/issues
+
+      if the error seems to be the fault of Home Manager.
+      EOF
+        exit 1
+      fi
+    '';
+  }
+  ""


### PR DESCRIPTION
This changes the installation command from

    nix-shell $HM_PATH -A install --run 'home-manager switch'

to

    nix-shell $HM_PATH -A install

The added shell hook will print some useful information and run `home-manager switch`.