### PR TITLE
kbfs: add binaries to user profile

### DIFF
--- a/modules/services/kbfs.nix
+++ b/modules/services/kbfs.nix
@@ -61,6 +61,7 @@ in
       };
     };
 
+    home.packages = [ pkgs.kbfs ];
     services.keybase.enable = true;
   };
 }


### PR DESCRIPTION
Add the binaries produced by 'pkgs.kbfs' to the profile, so that
the git-remote-keybase helper can work automatically with
'keybase://' remotes.