### PR TITLE
lib: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -67,6 +67,7 @@ let
     ./xsession.nix
     <nixpkgs/nixos/modules/misc/assertions.nix>
     <nixpkgs/nixos/modules/misc/meta.nix>
+    <nixpkgs/nixos/modules/misc/lib.nix>
   ];
 
   pkgsModule = {


### PR DESCRIPTION
This adds the rather simple [`lib` module from nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/misc/lib.nix). Maybe this could be used to get rid of the ugly dag importing (probably not though because recursion). I don't think this module needs a news entry, it doesn't *add* anything really.