### PR TITLE
zsh: fix ZDOTDIR setting when PAM is used

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -27,7 +27,7 @@ let
     mapAttrsToList (k: v: "alias ${k}='${v}'") cfg.shellAliases
   );
 
-  zdotdir = "$HOME/" + cfg.dotDir;
+  zdotdir = config.home.homeDirectory + "/" + cfg.dotDir;
 
   historyModule = types.submodule {
     options = {
@@ -322,7 +322,7 @@ in
     })
 
     (mkIf (cfg.dotDir != null) {
-      programs.zsh.sessionVariables.ZDOTDIR = if config.home.sessionVariableSetter == "pam" then "@{HOME}/" + cfg.dotDir else zdotdir;
+      programs.zsh.sessionVariables.ZDOTDIR = zdotdir;
 
       # When dotDir is set, only use ~/.zshenv to source ZDOTDIR/.zshenv,
       # This is so that if ZDOTDIR happens to be

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -322,7 +322,7 @@ in
     })
 
     (mkIf (cfg.dotDir != null) {
-      programs.zsh.sessionVariables.ZDOTDIR = zdotdir;
+      programs.zsh.sessionVariables.ZDOTDIR = if config.home.sessionVariableSetter == "pam" then "@{HOME}/" + cfg.dotDir else zdotdir;
 
       # When dotDir is set, only use ~/.zshenv to source ZDOTDIR/.zshenv,
       # This is so that if ZDOTDIR happens to be


### PR DESCRIPTION
`$HOME` is not available at the time `~/.pam_environment` is loaded by pam.
See also:
https://wiki.archlinux.org/index.php/Environment_variables#Using_pam_env
 http://www.linux-pam.org/Linux-PAM-html/sag-pam_env.html