### PR TITLE
systemd: remove filename hack

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -254,13 +254,7 @@ in
             # i.e., if the executable bit of the source is the same we
             # expect for the target. Otherwise, we copy the file and
             # set the executable bit to the expected value.
-            #
-            # Note, as a special case we always copy systemd units
-            # because it derives the unit name from the ultimate link
-            # target, which may be a store path with the hash
-            # included.
-            if [[ ($executable == inherit || $isExecutable == $executable) \
-                && $relTarget != *"/systemd/user/"* ]]; then
+            if [[ $executable == inherit || $isExecutable == $executable ]]; then
               ln -s "$source" "$target"
             else
               cp "$source" "$target"

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -24,16 +24,19 @@ let
 
   buildService = style: name: serviceCfg:
     let
-      source = pkgs.writeText "${name}.${style}" (toSystemdIni serviceCfg);
+      filename = "${name}.${style}";
+
+      # Needed because systemd derives unit names from the ultimate link target
+      source = "${pkgs.writeTextDir filename (toSystemdIni serviceCfg)}/${filename}";
 
       wantedBy = target:
         {
-          name = "systemd/user/${target}.wants/${name}.${style}";
+          name = "systemd/user/${target}.wants/${filename}";
           value = { inherit source; };
         };
     in
       singleton {
-        name = "systemd/user/${name}.${style}";
+        name = "systemd/user/${filename}";
         value = { inherit source; };
       }
       ++


### PR DESCRIPTION
This moves/removes the hack needed for systemd using the unit files ultimate link target filename as service names by just using `writeTextDir` instead of `writeText`.

I tested adding and removing units, works without problems.

This fixes something #156 would also fix