### PR TITLE
WIP: Restart dunst on configuration changes

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -150,6 +150,7 @@ in
             Type = "dbus";
             BusName = "org.freedesktop.Notifications";
             ExecStart = "${pkgs.dunst}/bin/dunst";
+            ExecStop = "${pkgs.procps}/bin/pkill -u $USER dunst";
           };
         };
       }

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -157,6 +157,7 @@ in
 
       (mkIf (cfg.settings != {}) {
         xdg.configFile."dunst/dunstrc".text = toDunstIni cfg.settings;
+        systemd.user.services.dunst.Unit.X-Restart-Triggers = [ config.xdg.configFile."dunst/dunstrc".source ];
       })
     ]
   );


### PR DESCRIPTION
This changes the dunst service to restart on config change.

Currently, systemd doesn't really notice socket-activated dunst processes and would spawn a second one on restart, so we `pkill` the old one for now.