### PR TITLE
parcellite: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -503,6 +503,15 @@ in
               'services.kbfs' and 'services.keybase'
         '';
       }
+
+      {
+        time = "2017-12-07T22:23:11+00:00";
+        message = ''
+          New module is available:
+
+              'services.parcellite'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -51,6 +51,7 @@ let
     ./services/keybase.nix
     ./services/network-manager-applet.nix
     ./services/owncloud-client.nix
+    ./services/parcellite.nix
     ./services/polybar.nix
     ./services/random-background.nix
     ./services/redshift.nix

--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.parcellite;
+  package = pkgs.parcellite;
+
+in
+
+{
+  meta.maintainers = [ maintainers.gleber ];
+
+  options = {
+    services.parcellite = {
+      enable = mkEnableOption "Parcellite";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ package ];
+
+    systemd.user.services.parcellite = {
+      Unit = {
+        Description = "Lightweight GTK+ clipboard manager";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        # PATH have been added in nixpkgs.parcellite, keeping it here for
+        # backward compatibility. XDG_DATA_DIRS is necessary to make it pick up
+        # icons correctly.
+        Environment = ''
+          PATH=${package}/bin:${pkgs.which}/bin:${pkgs.xdotool}/bin XDG_DATA_DIRS=${pkgs.hicolor_icon_theme}/share
+        '';
+        ExecStart = "${package}/bin/parcellite";
+        Restart = "on-abort";
+      };
+    };
+  };
+}


### PR DESCRIPTION
This adds a Parcellite service. It has no configuration options, since the app
has its own mutable preferences dialog, which unconditionally replaces
~/.config/parcellite/parcelliterc when preferences are saved.