### PR TITLE
xmonad: make package lower priority

### DIFF
--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -83,7 +83,7 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     {
-      home.packages = [ xmonad ];
+      home.packages = [ (lowPrio xmonad) ];
       xsession.windowManager.command = "${xmonad}/bin/xmonad";
     }
 


### PR DESCRIPTION
This avoids a conflict for when the user has an xmonad package installed through
`haskellPackages.ghcWithPackages`, which is necessary for wanting to
load the xmonad config with ghc.