### PR TITLE
Use .profile for interactive settings

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -148,15 +148,6 @@ in
 
         ${envVarsStr}
 
-        ${cfg.profileExtra}
-      '';
-
-      home.file.".bashrc".text = ''
-        # -*- mode: sh -*-
-
-        # Skip if not running interactively.
-        [ -z "$PS1" ] && return
-
         ${export "HISTSIZE" cfg.historySize}
         ${export "HISTFILESIZE" cfg.historyFileSize}
         ${exportIfNonEmpty "HISTCONTROL" histControlStr}
@@ -166,10 +157,16 @@ in
 
         ${aliasesStr}
 
-        ${cfg.initExtra}
+        ${cfg.profileExtra}
 
         ${optionalString cfg.enableAutojump
           ". ${pkgs.autojump}/share/autojump/autojump.bash"}
+      '';
+
+      home.file.".bashrc".text = ''
+        # -*- mode: sh -*-
+
+        ${cfg.initExtra}
       '';
 
       home.packages =


### PR DESCRIPTION
Instead of starting `.bashrc` with `[ -z "$PS1" ] && return` in order to skip interactive-only settings, why not just put interactive settings in `.profile`, which is only run for a login shell?  Stubbing out the rest of `.bashrc` makes it impossible to define variables (like `PATH`) in order for them to be visible to SSH.
  