### PR TITLE
zsh: fix HISTSIZE configuration

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -238,11 +238,6 @@ in
         ++ optional cfg.enableCompletion nix-zsh-completions
         ++ optional cfg.oh-my-zsh.enable oh-my-zsh;
 
-      programs.zsh.sessionVariables = {
-        HISTSIZE = cfg.history.size;
-        HISTFILE = "$HOME/" + cfg.history.path;
-      };
-
       home.file."${relToDotDir ".zshenv"}".text = ''
         typeset -U fpath
         ${optionalString (config.home.sessionVariableSetter != "pam") ''
@@ -288,6 +283,11 @@ in
         ${concatStrings (map (plugin: ''
           source "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}"
         '') cfg.plugins)}
+
+        # HISTSIZE, HISTFILE have to be set in .zshrc and after oh-my-zsh sourcing
+        # see https://github.com/rycee/home-manager/issues/177
+        HISTSIZE="${toString cfg.history.size}"
+        HISTFILE="$HOME/${cfg.history.path}"
 
         ${cfg.initExtra}
 


### PR DESCRIPTION
HISTSIZE has to be set before sourcing oh-my-zsh
since otherwise it will be overridden. Fixes #177.