### PR TITLE
polybar: fix the case when config value is a path

### DIFF
--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -13,7 +13,7 @@ let
     let
       value' =
         if isBool value then (if value then "true" else "false")
-        else if isString value then "\"${value}\""
+        else if (isString value && key != "include-file") then ''"${value}"''
         else toString value;
     in
       "${key}=${value'}";


### PR DESCRIPTION
Polybar treats 'include-file' property differently.
In particular, its value can't be enclosed in
double quotes. Fixes #185.