### PR TITLE
home-manager: check whether a command is passed

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -337,6 +337,11 @@ done
 # Get rid of the options.
 shift "$((OPTIND-1))"
 
+if [ $# -eq 0 ]; then
+    doHelp >&2
+    exit 1
+fi
+
 cmd="$1"
 shift 1
 


### PR DESCRIPTION
"set -u" treats unset variables as an error, and $1 is unbound when no
command is passed.