### PR TITLE
syncthing: start tray service after bars

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -51,7 +51,7 @@ with lib;
         qsyncthingtray = {
           Unit = {
             Description = "QSyncthingTray";
-            After = [ "graphical-session-pre.target" ];
+            After = [ "graphical-session-pre.target" "polybar.service" "taffybar.service" ];
             PartOf = [ "graphical-session.target" ];
           };
 


### PR DESCRIPTION
Qsyncthing tray service requires running tray
providers such as polybar and taffybar.

@rycee, I tested your fix, and seems like it works for me (with polybar), thanks for investigating.