### PR TITLE
rofi: make theme option

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -543,6 +543,21 @@ in
           The old module will be removed on February 25, 2018.
         '';
       }
+      {
+        time = "2018-02-07T18:00:00+00:00";
+        condition = with config.programs.rofi; enable && colors != null;
+        message = ''
+          The options 'programs.rofi.colours' have been been deprecated and
+          will be removed in the near future.
+
+          The new and preferred way to configure the theme is using rasi themes
+          through the 'programs.rofi.theme' option which can take either a name
+          of a pre-installed theme or a path to a theme to install.
+
+          A rasi theme can be generated from an Xresources config using
+          `rofi -dump-theme`.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -201,6 +201,7 @@ in
       description = ''
         Color scheme settings.
         Colors can be specified in CSS color formats.
+        DEPRECATED: Use <varname>programs.rofi.theme</varname>.
       '';
       example = literalExample ''
         colors = {
@@ -253,7 +254,6 @@ in
     in
     mkMerge [
       {
-        warnings = optional (cfg.theme != null && cfg.colors != null) "rofi: colors shouldn't be set when using themes";
         home.packages = [ pkgs.rofi ];
 
         home.file."${cfg.configPath}".text = ''
@@ -273,7 +273,6 @@ in
           ${setOption "cycle" cfg.cycle}
           ${setOption "fullscreen" cfg.fullscreen}
 
-          ${setColorScheme cfg.colors}
           ${setOption "theme" themeName}
 
           ${cfg.extraConfig}

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -225,6 +225,13 @@ in
       '';
     };
 
+    theme = mkOption {
+      default = null;
+      type = types.nullOr types.string;
+      description = "Name of theme to use";
+      example = "Arc";
+    };
+
     configPath = mkOption {
       default = ".config/rofi/config";
       type = types.string;
@@ -240,6 +247,7 @@ in
   };
 
   config = mkIf cfg.enable {
+    warnings = optional (cfg.theme != null && cfg.colors != null) "rofi: colors shouldn't be set when using themes";
     home.packages = [ pkgs.rofi ];
 
     home.file."${cfg.configPath}".text = ''
@@ -260,6 +268,7 @@ in
       ${setOption "fullscreen" cfg.fullscreen}
 
       ${setColorScheme cfg.colors}
+      ${setOption "theme" cfg.theme}
 
       ${cfg.extraConfig}
     '';


### PR DESCRIPTION
> (Partially) Because of the upcoming wayland support, xresources will be dropped in the future. We are currently in a transitional period (that is why they are internally converted into rasi (default) theme, you can actually see this theme by using -dump-theme).

https://github.com/DaveDavenport/rofi/issues/756#issuecomment-357697381

Rofi is phasing out support for Xresources theming and so I've added an option for the name of a theme to use. [Some themes](https://github.com/DaveDavenport/rofi/tree/next/themes) come preinstalled and extra themes can be installed to `$XDG_DATA_HOME` e.g.

```home.file.".local/share/rofi/themes/base16-monokai.rasi".source = base16-rofi/themes/base16-monokai.rasi```