### PR TITLE
home-environment: warn when a package can be installed with programs.*.enable

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -239,6 +239,15 @@ in
         Extra commands to run in the Home Manager generation builder.
       '';
     };
+
+    home.show_program_enable_warnings = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to show when packages can be installed with
+        <literal>programs.*.enable = true</literal>.
+      '';
+    };
   };
 
   config = {
@@ -252,6 +261,12 @@ in
         message = "Home directory could not be determined";
       }
     ];
+    warnings = optionals cfg.show_program_enable_warnings
+      (map (x: concatStrings ["home-environment: " x " can be installed using programs." x ".enable = true"])
+      (filter (x: !attrByPath [x "enable"] false config.programs)
+      (filter (x: hasAttrByPath [x] config.programs)
+      (map (x: (builtins.parseDrvName x).name)
+      (map (x: x.name) config.home.packages)))));
 
     home.username = mkDefault (builtins.getEnv "USER");
     home.homeDirectory = mkDefault (builtins.getEnv "HOME");


### PR DESCRIPTION
I thought it could be useful to show a warning when a package can be installed using `programs.*.enable` instead of having it included in `home.packages` as it shows that the package can be configured through home.nix.
Is this useful and is there a better name to use when talking about the `programs.*.enable` interface?
The nix code needs tiding up but I hadn't looked into nix's code style or functions much before.