### PR TITLE
mercurial: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -543,6 +543,13 @@ in
           The old module will be removed on February 25, 2018.
         '';
       }
+
+      {
+        time = "2018-02-02T11:15:00+00:00";
+        message = ''
+          A new program configuration is available: 'programs.mercurial'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -34,6 +34,7 @@ let
     ./programs/info.nix
     ./programs/lesspipe.nix
     ./programs/man.nix
+    ./programs/mercurial.nix
     ./programs/neovim.nix
     ./programs/rofi.nix
     ./programs/ssh.nix

--- a/modules/programs/mercurial.nix
+++ b/modules/programs/mercurial.nix
@@ -1,0 +1,102 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.mercurial;
+
+in
+
+{
+
+  options = {
+    programs.mercurial = {
+      enable = mkEnableOption "Mercurial";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.mercurial;
+        defaultText = "pkgs.mercurial";
+        description = "Mercurial package to install.";
+      };
+
+      userName = mkOption {
+        type = types.str;
+        description = "Default user name to use.";
+      };
+
+      userEmail = mkOption {
+        type = types.str;
+        description = "Default user email to use.";
+      };
+
+      aliases = mkOption {
+        type = types.attrs;
+        default = {};
+        description = "Mercurial aliases to define.";
+      };
+
+      extraConfig = mkOption {
+        type = types.either types.attrs types.lines;
+        default = {};
+        description = "Additional configuration to add.";
+      };
+
+      iniContent = mkOption {
+        type = types.attrsOf types.attrs;
+        internal = true;
+      };
+
+      ignores = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "*~" "*.swp" ];
+        description = "List of globs for files to be globally ignored.";
+      };
+
+      ignoresRegexp = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "^.*~$" "^.*\\.swp$" ];
+        description =
+            "List of regular expressions for files to be globally ignored.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (
+    mkMerge [
+      {
+        home.packages = [ cfg.package ];
+
+        programs.mercurial.iniContent.ui = {
+          username = cfg.userName + " <" + cfg.userEmail + ">";
+        };
+
+        xdg.configFile."hg/hgrc".text = generators.toINI {} cfg.iniContent;
+      }
+
+      (mkIf (cfg.ignores != [] || cfg.ignoresRegexp != []) {
+        programs.mercurial.iniContent.ui.ignore =
+            "${config.xdg.configHome}/hg/hgignore_global";
+
+        xdg.configFile."hg/hgignore_global".text = 
+            "syntax: glob\n"   + concatStringsSep "\n" cfg.ignores + "\n" +
+            "syntax: regexp\n" + concatStringsSep "\n" cfg.ignoresRegexp + "\n";
+      })
+
+      (mkIf (cfg.aliases != {}) {
+        programs.mercurial.iniContent.alias = cfg.aliases;
+      })
+
+      (mkIf (lib.isAttrs cfg.extraConfig) {
+        programs.mercurial.iniContent = cfg.extraConfig;
+      })
+
+      (mkIf (lib.isString cfg.extraConfig) {
+        xdg.configFile."hg/hgrc".text = cfg.extraConfig;
+      })
+    ]
+  );
+}


### PR DESCRIPTION
This provides a very simple module for configuring the mercurial DVCS. I don't know whether it will be of interest, but I find it useful to be able to configure multiple similar programs in a similar manner.  

This is basically a copy of the programs.git module but modified to configure mercurial correctly.

I tried to keep the options mostly the the same, to enable users to share of configuration for simple use cases - something like:
 ```
   {...}:
    let vcsconfig = {
            enable = true;
            userName = "John Smith";
            userEmail = "js@example.com";
            ignores = [ "*.swp" "*~" ];
        };
    in {
        programs.git = vcsconfig // {...extra git config ...};
        programs.mercurial = vcsconfig // {...extra hg confg...};
    }
```

Aditionally:
- I did not include GPG signing (mercurial has a somewhat different story for this)
- There is `regexpIgnores` option to provide ignores under `syntax: regexp`. This complements `ignores`, which works with globs, much as git does.