### PR TITLE
stalonetray: add modulue

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -548,6 +548,12 @@ in
         time = "2018-02-02T11:15:00+00:00";
         message = ''
           A new program configuration is available: 'programs.mercurial'
+      }
+
+      {
+        time = "2018-02-03T10:00:00+00:00";
+        message = ''
+          A new module is available: 'services.stalonetray'
         '';
       }
     ];

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -57,6 +57,7 @@ let
     ./services/random-background.nix
     ./services/redshift.nix
     ./services/screen-locker.nix
+    ./services/stalonetray.nix
     ./services/syncthing.nix
     ./services/taffybar.nix
     ./services/tahoe-lafs.nix

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -1,0 +1,97 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.stalonetray;
+
+  package = pkgs.stalonetray;
+
+in
+
+{
+  options = {
+    services.stalonetray = {
+      enable = mkEnableOption "Stalonetray system tray";
+
+      package = mkOption {
+        default = pkgs.stalonetray;
+        defaultText = "pkgs.stalonetray";
+        type = types.package;
+        example = literalExample "pkgs.stalonetray";
+        description = "The package to use for the Stalonetray binary.";
+      };
+
+      config = mkOption {
+          type = with types;
+            attrsOf (nullOr (either str (either bool int)));
+          description = ''
+            Stalonetray configuration as a set of attributes.
+          '';
+          default = {};
+          example = {
+            geometry = "3x1-600+0";
+            decorations = null;
+            icon_size = 30;
+            sticky = true;
+            background = ''"#cccccc"'';
+          };
+      };
+    
+      extraConfig = mkOption {
+        type = types.lines;
+        description = "Additional configuration lines for stalonetrayrc.";
+        default = "";
+        example = ''
+            geometry 3x1-600+0
+            decorations none
+            icon_size 30
+            sticky true
+            background "#cccccc"
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = [ pkgs.stalonetray ];
+
+      systemd.user.services.stalonetray = {
+        Unit = {
+          Description = "Stalonetray system tray";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          ExecStart = "${package}/bin/stalonetray";
+          Restart = "on-failure";
+        };
+      };
+    }
+    
+    (mkIf (cfg.config != {}) {
+      home.file.".stalonetrayrc".text = 
+        let 
+          valueToString = v:
+            if isBool v then (if v then "true" else "false")
+            else if (v==null) then "none"
+            else toString v;
+        in
+          concatStrings (
+            mapAttrsToList (k: v: "${k} ${valueToString v}\n") cfg.config
+          );
+    })
+
+    (mkIf (cfg.extraConfig != "") {
+      home.file.".stalonetrayrc".text = cfg.extraConfig;
+    })
+  ]);
+}
+

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.services.stalonetray;
 
-  package = pkgs.stalonetray;
-
 in
 
 {
@@ -35,7 +33,7 @@ in
             decorations = null;
             icon_size = 30;
             sticky = true;
-            background = ''"#cccccc"'';
+            background = "#cccccc";
           };
       };
     
@@ -56,7 +54,7 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     {
-      home.packages = [ pkgs.stalonetray ];
+      home.packages = [ cfg.package ];
 
       systemd.user.services.stalonetray = {
         Unit = {
@@ -70,7 +68,7 @@ in
         };
 
         Service = {
-          ExecStart = "${package}/bin/stalonetray";
+          ExecStart = "${cfg.package}/bin/stalonetray";
           Restart = "on-failure";
         };
       };
@@ -82,7 +80,7 @@ in
           valueToString = v:
             if isBool v then (if v then "true" else "false")
             else if (v==null) then "none"
-            else toString v;
+            else ''"${toString v}"'';
         in
           concatStrings (
             mapAttrsToList (k: v: "${k} ${valueToString v}\n") cfg.config

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -52,7 +52,10 @@ with lib;
         qsyncthingtray = {
           Unit = {
             Description = "QSyncthingTray";
-            After = [ "graphical-session-pre.target" "polybar.service" "taffybar.service" ];
+            After = [ "graphical-session-pre.target"
+                      "polybar.service"
+                      "taffybar.service"
+                      "stalonetray.service" ];
             PartOf = [ "graphical-session.target" ];
           };
 


### PR DESCRIPTION
Adds a service for the Stalonetray system tray. Configured through a `services.stalonetray.config` attribute set, which writes space separated key value pairs on successive lines to `~/.stalonetrayrc`.

Apologies for bombarding with another PR - I'm currently pulling modules for things I tend to use myself, so thought it worth sharing in case they might be useful to others. Fully understand if you'd rather keep to a more limited set of packages though.

I've also taken the liberty of adding `"stalonetray.service"` to the list
of system tray services in `services.syncthing`, as reading through commit history suggests
this is necessary for the qsyncthingtray. I haven't been able to test this though as I'm not using syncthing at the moment.