### PR TITLE
neovim: add 'configure' flag

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -58,6 +58,28 @@ in
           List here Python 3 packages required for your plugins to work.
         '';
       };
+
+      configure = mkOption {
+        type = types.nullOr types.attrs;
+        default = null;
+        example = literalExample ''
+          configure = {
+              customRC = $''''
+              " here your custom configuration goes!
+              $'''';
+              packages.myVimPackage = with pkgs.vimPlugins; {
+                # loaded on launch
+                start = [ fugitive ];
+                # manually loadable by calling `:packadd $plugin-name`
+                opt = [ ];
+              };
+            };
+        '';
+        description = ''
+          Generate your init file from your list of plugins and custom commands, 
+          and loads it from the store via <command>nvim -u /nix/store/hash-vimrc</command>
+        '';
+      };
     };
   };
 
@@ -67,7 +89,7 @@ in
         inherit (cfg)
           extraPython3Packages withPython3
           extraPythonPackages withPython
-          withRuby;
+          withRuby configure;
       })
     ];
   };


### PR DESCRIPTION
so that we have the same options as in nixpkgs.

The configure options is a pain to use so I hope to improve it in nixpkgs at later date (to set $MYVIMRC, fix paths for neovim etc) but meanwhile we have to stick with this.