### PR TITLE
[WIP] Mail programs support

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -16,7 +16,25 @@ let
           description = "The foreground color.";
         };
 
-         address = mkOption {
+        realname = mkOption {
+          type = types.str;
+          description = "Name displayed when sending mails.";
+        };
+
+        signature = mkOption {
+          type = types.str;
+          default = "default signature";
+          example = "luke@tatooine.com";
+          description = "Your signature";
+        };
+
+        address = mkOption {
+          type = types.str;
+          example = "luke@tatooine.com";
+          description = "Your mail address";
+        };
+
+        key = mkOption {
           type = types.str;
           example = "luke@tatooine.com";
           description = "Your mail address";
@@ -145,9 +163,9 @@ in
     };
 
     home.mailAccounts = mkOption {
-          type = types.listOf mailAccount;
-          # type = types.attrsOf mailAccount;
-          description = "List your email accounts.";
+      type = types.listOf mailAccount;
+      # type = types.attrsOf mailAccount;
+      description = "List your email accounts.";
     };
 
     home.homeDirectory = mkOption {

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -40,6 +40,12 @@ let
           description = "Your mail address";
         };
 
+        sendHost = mkOption {
+          type = types.str;
+          example = "luke@tatooine.com";
+          description = "Your mail address";
+        };
+
         # might be hard to abstract
         # passwordRetrieval = mkOption {
         #   default = null;

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -8,6 +8,35 @@ let
 
   dag = config.lib.dag;
 
+  mailAccount = types.submodule (
+    { ... }: {
+      options = {
+        userName = mkOption {
+          type = types.str;
+          description = "The foreground color.";
+        };
+
+         address = mkOption {
+          type = types.str;
+          example = "luke@tatooine.com";
+          description = "Your mail address";
+        };
+
+        # might be hard to abstract
+        # passwordRetrieval = mkOption {
+        #   default = null;
+        #   type = types.nullOr types.str;
+        #   description = "The bold color, null to use same as foreground.";
+        # };
+
+        store = mkOption {
+          type = types.path;
+          description = "Where to store mail for this account";
+        };
+      };
+    }
+  );
+
   languageSubModule = types.submodule {
     options = {
       base = mkOption {
@@ -113,6 +142,12 @@ in
       type = types.str;
       defaultText = "$USER";
       description = "The user's username.";
+    };
+
+    home.mailAccounts = mkOption {
+          type = types.listOf mailAccount;
+          # type = types.attrsOf mailAccount;
+          description = "List your email accounts.";
     };
 
     home.homeDirectory = mkOption {

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -11,6 +11,11 @@ let
   mailAccount = types.submodule (
     { ... }: {
       options = {
+
+        name = mkOption {
+          type = types.str;
+          description = "Just to identify the account";
+        };
         userName = mkOption {
           type = types.str;
           description = "The foreground color.";
@@ -47,7 +52,7 @@ let
         };
 
         # might be hard to abstract
-        # passwordRetrieval = mkOption {
+        # getPassCommand = mkOption {
         #   default = null;
         #   type = types.nullOr types.str;
         #   description = "The bold color, null to use same as foreground.";

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -8,69 +8,6 @@ let
 
   dag = config.lib.dag;
 
-  mailAccount = types.submodule (
-    { ... }: {
-      options = {
-
-        # should be unque across mailAccounts => use it as key ?
-        # but it is used
-        name = mkOption {
-          type = types.str;
-          description = "Just to identify the account";
-        };
-        userName = mkOption {
-          type = types.str;
-          description = "The foreground color.";
-        };
-
-        realname = mkOption {
-          type = types.str;
-          description = "Name displayed when sending mails.";
-        };
-
-        signature = mkOption {
-          type = types.str;
-          default = "default signature";
-          example = "luke@tatooine.com";
-          description = "Your signature";
-        };
-
-        address = mkOption {
-          type = types.str;
-          example = "luke@tatooine.com";
-          description = "Your mail address";
-        };
-
-        # pgp key
-        key = mkOption {
-          type = types.path;
-          example = null;
-          description = "Your PGP key/file";
-        };
-
-        sendHost = mkOption {
-          type = types.str;
-          example = "luke@tatooine.com";
-          description = "Your mail address";
-        };
-
-        # might be hard to abstract
-        # getPassCommand = mkOption {
-        #   default = null;
-        #   type = types.nullOr types.str;
-        #   description = "The bold color, null to use same as foreground.";
-        # };
-
-        store = mkOption {
-          type = types.path;
-          default = "${config.home.homeDirectory}/maildir/${name}";
-          description = "Where to store mail for this account";
-        };
-
-      };
-    }
-  );
-
   languageSubModule = types.submodule {
     options = {
       base = mkOption {
@@ -176,12 +113,6 @@ in
       type = types.str;
       defaultText = "$USER";
       description = "The user's username.";
-    };
-
-    home.mailAccounts = mkOption {
-      type = types.listOf mailAccount;
-      # type = types.attrsOf mailAccount;
-      description = "List your email accounts.";
     };
 
     home.homeDirectory = mkOption {

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -12,6 +12,8 @@ let
     { ... }: {
       options = {
 
+        # should be unque across mailAccounts => use it as key ?
+        # but it is used
         name = mkOption {
           type = types.str;
           description = "Just to identify the account";
@@ -39,10 +41,11 @@ let
           description = "Your mail address";
         };
 
+        # pgp key
         key = mkOption {
-          type = types.str;
-          example = "luke@tatooine.com";
-          description = "Your mail address";
+          type = types.path;
+          example = null;
+          description = "Your PGP key/file";
         };
 
         sendHost = mkOption {
@@ -60,8 +63,10 @@ let
 
         store = mkOption {
           type = types.path;
+          default = "${config.home.homeDirectory}/maildir/${name}";
           description = "Where to store mail for this account";
         };
+
       };
     }
   );

--- a/modules/lib/mail.nix
+++ b/modules/lib/mail.nix
@@ -5,5 +5,7 @@
 
 
   getNotmuchConfig = account:
-    "${config.xdg.configFile}/notmuch/notmuch_${account.name}";
+    # "${config.xdg.configFile}/notmuch/notmuch_${account.name}";
+
+    "$XDG_CONFIG_HOME/notmuch/notmuch_${account.name}";
 }

--- a/modules/lib/mail.nix
+++ b/modules/lib/mail.nix
@@ -1,0 +1,9 @@
+{ config, lib }:
+{
+  getStore = account:
+    if account.store != null then account.store else config.mail.maildir + "/${account.name}";
+
+
+  getNotmuchConfig = account:
+    "${config.xdg.configFile}/notmuch/notmuch_${account.name}";
+}

--- a/modules/lib/mail.nix
+++ b/modules/lib/mail.nix
@@ -3,6 +3,11 @@
   getStore = account:
     if account.store != null then account.store else config.mail.maildir + "/${account.name}";
 
+    isGmail = account:
+      if account.imapHost != null then
+      (builtins.match ".*\.gmail\..*" account.imapHost) != null
+      else false
+      ;
 
   getNotmuchConfig = account:
     # "${config.xdg.configFile}/notmuch/notmuch_${account.name}";

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -83,12 +83,21 @@ let
           description = "path to the hooks folder to use for a specific account";
         };
 
+        # default actions
+        defaultActions = mkOption {
+          # TODO add it only if notmuch available ?
+          type = types.listOf (types.enum [ "cryptoSign" "cipher" "appendSignature" "attachSignature" ]);
+          default = false;
+          description = "Wether to sign messages";
+        };
+
         # can have only one mta
         mra = mkOption {
           type =  types.enum [config.programs.offlineimap];
           default = config.programs.offlineimap;
           description = "Mail Retrieval Agent to use";
         };
+
         mta = mkOption {
           type =  types.enum [config.programs.msmtp];
           default = config.programs.msmtp;

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -257,7 +257,7 @@ in
           # fold genAccountAliases [] mailAccounts ;
         in
         {
-          alot_test="echo 'test successful'";
+          # alot_test="echo 'test successful'";
         }
         // (lib.optionalAttrs cfg.generateShellAliases 
               (

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -1,0 +1,213 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with import ./lib/mail.nix { inherit lib config; };
+
+let
+
+  cfg = config.mail;
+
+  dag = config.lib.dag;
+
+  fileType = (import ./lib/file-type.nix {
+    inherit (config.home) homeDirectory;
+    inherit lib pkgs;
+  }).fileType;
+
+    mailAccount = types.submodule {
+      options = rec {
+
+        # should be unque across mailAccounts => use it as key ?
+        # but it is used
+        name = mkOption {
+          type = types.str;
+          description = "Just to identify the account";
+        };
+
+        userName = mkOption {
+          type = types.str;
+          description = "The foreground color.";
+        };
+
+        realname = mkOption {
+          type = types.str;
+          description = "Name displayed when sending mails.";
+        };
+
+        signature = mkOption {
+          type = types.str;
+          default = "default signature";
+          example = "luke@tatooine.com";
+          description = "Your signature";
+        };
+
+        address = mkOption {
+          type = types.str;
+          example = "luke@tatooine.com";
+          description = "Your mail address";
+        };
+
+        # pgp key
+        # key = mkOption {
+        #   type = types.path;
+        #   example = null;
+        #   description = "Your PGP key/file";
+        # };
+
+        imapHost = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "imap.server.be";
+          description = "IMAP host to receive mails from";
+        };
+
+        sendHost = mkOption {
+          type = types.str;
+          example = "luke@tatooine.com";
+          description = "MSMTP host to use to send mails";
+        };
+
+        # might be hard to abstract
+        # getPassCommand = mkOption {
+        #   default = null;
+        #   type = types.nullOr types.str;
+        #   description = "The bold color, null to use same as foreground.";
+        # };
+
+        # depend if notmuch is enabled or not
+        postSyncHook = mkOption {
+          type = types.nullOr types.path;
+          # ${name}
+          default = null;
+          # default = "${cfg.maildir}/${name}";
+          description = "Where to store mail for this account";
+        };
+        
+        # MtaSubmoduleMsmtp = types.submodule {
+
+        #   offlineSendMethod = mkOption {
+        #     # https://wiki.archlinux.org/index.php/Msmtp#Using_msmtp_offline
+        #     # see for a list of methodds 
+        #     # https://github.com/pazz/alot/wiki/Tips,-Tricks-and-other-cool-Hacks
+        #     type = types.enum [ "none" "native" ];
+        #     default = "native";
+        #     description = "Extra configuration lines to add to .msmtprc.";
+        #   };
+
+        #   sendCommand = mkOption {
+        #     # https://wiki.archlinux.org/index.php/Msmtp#Using_msmtp_offline
+        #     # see for a list of methodds 
+        #     # https://github.com/pazz/alot/wiki/Tips,-Tricks-and-other-cool-Hacks
+        #     # type = types.str;
+        #     default = sendMsmtpCommand ;
+        #     description = "Extra configuration lines to add to .msmtprc.";
+        #   };
+
+        #   extraConfig = mkOption {
+        #     type = types.lines;
+        #     default = "";
+        #     description = "Extra configuration lines to add to .msmtprc.";
+        #   };
+        # };
+        # types.submodule {
+
+        # submodule
+        # types.attrs;
+        # mta = mkOption {
+        #   type = types.enum [ MtaSubmoduleMsmtp ];
+        #   # path
+        #   # type = types.str;
+        #   # ${name}
+        #   default = MtaSubmoduleMsmtp;
+        #   description = "Where to store mail for this account";
+        # };
+
+        # keep it for now ?
+        store = mkOption {
+          # path
+          type = types.nullOr types.path;
+          default = null;
+          # default = "${cfg.maildir}/${name.value}";
+          description = "Where to store mail for this account";
+        };
+
+      };
+    };
+
+in
+
+{
+
+  options.mail = rec {
+    maildir = mkOption {
+      type = types.path;
+      # fileType "<varname>mail.maildir</varname>" cfg.configHome + "maildir";
+      default = config.home.homeDirectory + "/maildir";
+      description = ''
+        Attribute set of files to link into the user's XDG
+        configuration home.
+      '';
+    };
+
+    # enable = mkEnableOption "management of XDG base directories";
+
+    accounts = mkOption {
+      type = types.listOf mailAccount;
+      # type = types.attrsOf mailAccount;
+      description = "List your email accounts.";
+    };
+
+
+    generateAliases = mkOption {
+      default = true;
+      type = types.bool;
+      # todo let it a function ?
+      description = ''
+        Generate one shell alias per (program/account). For instance, if alot is enabled and an account is defined with name gmail, then it will generate alot-gmail
+      '';
+
+      # generateDesktopFiles = mkOption {
+      #   default = true;
+      #   type = types.bool;
+      #   description = ''
+      #     Generate .desktop files if MUA has already a desktop.
+      #   '';
+      # };
+    };
+  };
+
+  config = mkMerge [
+    {
+    # mkIf cfg.enable {
+      home.sessionVariables = {
+        MAILDIR = cfg.maildir;
+      };
+
+      # TODO might neeed to generate several aliases depending on mua
+
+      programs.bash.shellAliases = 
+      let 
+        genAliasesList = mailAccounts:
+          map  (account: { name = "alot-${account.name}"; value = "${pkgs.alot} -n ${config.xdg.configHome}/notmuch/notmuch_${account.name}"; }) mailAccounts ;
+        listToAttrs = list: (foldr // {} list);
+          # builtins.listToAttrs
+        in
+        {
+          alot_test="echo 'test successful'";
+        }
+        // (lib.optionalAttrs cfg.generateAliases (
+          builtins.listToAttrs (genAliasesList cfg.accounts) 
+        )
+      );
+
+      # todo check mta/mua creation process
+      home.activation.createMailStores = dag.entryBefore [ "linkGeneration" ] (
+        concatStringsSep ";" (map (account: "mkdir ${getStore account}") cfg.accounts)
+      );
+      # need to create the maildirs !
+    }
+    # )
+  ];
+
+}
+

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -76,7 +76,8 @@ let
 
         # depend if notmuch is enabled or not
         postSyncHook = mkOption {
-          type = types.nullOr types.path;
+          # should be a function ?
+          # type = types.nullOr types.path;
           # ${name}
           default = null;
           # default = "${cfg.maildir}/${name}";
@@ -188,9 +189,7 @@ in
       programs.bash.shellAliases = 
       let 
         genAliasesList = mailAccounts:
-          map  (account: { name = "alot-${account.name}"; value = "${pkgs.alot} -n ${config.xdg.configHome}/notmuch/notmuch_${account.name}"; }) mailAccounts ;
-        listToAttrs = list: (foldr // {} list);
-          # builtins.listToAttrs
+          map  (account: { name = "alot-${account.name}"; value = "${pkgs.alot}/bin/alot -n ${config.xdg.configHome}/notmuch/notmuch_${account.name}"; }) mailAccounts ;
         in
         {
           alot_test="echo 'test successful'";
@@ -201,13 +200,21 @@ in
       );
 
       # todo check mta/mua creation process
-      home.activation.createMailStores = dag.entryBefore [ "linkGeneration" ] (
-        concatStringsSep ";" (map (account: "mkdir ${getStore account}") cfg.accounts)
+      home.activation.createMailStores = 
+      let 
+        # -p to remove errors but might be 
+        # add a hook home.activation dat.after["createMailStores"]
+        createMailStore = account:
+          "mkdir -p ${getStore account}";
+      in 
+      dag.entryBefore [ "linkGeneration" ] (
+        concatStringsSep ";" (map createMailStore cfg.accounts)
       );
       # need to create the maildirs !
     }
     # )
-  ];
+  ]
+  ;
 
 }
 

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -35,16 +35,17 @@ let
         };
 
         # make into a submodule ? attach signature ?
-        signature = mkOption {
-          type = types.str;
-          default = "default signature";
-          example = "luke@tatooine.com";
-          description = "Your signature";
+        signatureFilename = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "";
+          description = "Path to signature";
         };
 
-        attachSignature = mkOption {
-          type = types.bool;
-          default = false;
+        showSignature = mkOption {
+          # TODO enum attach/append
+          type = types.enum [ "append" "attach" "no" ];
+          default = "no";
           description = "wether to attach signature";
         };
 
@@ -71,6 +72,14 @@ let
           type = types.str;
           example = "luke@tatooine.com";
           description = "MSMTP host to use to send mails";
+        };
+
+        # see http://alot.readthedocs.io/en/latest/configuration/contacts_completion.html
+        contactCompletion = mkOption {
+          # TODO add it only if notmuch available ?
+          type = types.enum [ "notmuch address simple" "notmuch address" ];
+          default = "notmuch address";
+          description = "path to the hooks folder to use for a specific account";
         };
 
         # can have only one mta
@@ -150,7 +159,7 @@ let
 
         # keep it for now ?
         store = mkOption {
-          # path
+          # TODO default to maildir
           type = types.nullOr types.path;
           default = null;
           # default = "${cfg.maildir}/${name.value}";
@@ -158,8 +167,8 @@ let
         };
 
         configStore = mkOption {
-          type = types.nullOr types.path;
-          default = ./.;
+          type = types.nullOr types.str;
+          default = null;
           # default = "${cfg.maildir}/${name.value}";
           description = ''
             path to additionnal per-program configuration, for instance notmuch hooks. It should follow a specific structure
@@ -212,6 +221,7 @@ in
     };
   };
 
+  # TODO assert on an unset store ?
   config = mkMerge [
     {
     # mkIf cfg.enable {

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -47,6 +47,11 @@ let
           default = false;
         };
 
+        gpgKey = mkOption {
+          type = types.path;
+          default = false;
+        };
+
         address = mkOption {
           type = types.str;
           example = "luke@tatooine.com";
@@ -73,9 +78,12 @@ let
           description = "MSMTP host to use to send mails";
         };
 
+        # can have only one mta
         mta = mkOption {
-          type =  types.enum [ config.programs.msmtp ];
-          default = [ config.programs.msmtp ];
+          type =  types.enum [ "msmtp" ];
+          default = "msmtp";
+          # type =  types.enum [config.programs.msmtp];
+          # default = config.programs.msmtp;
           description = "Mail Transfer Agent to use";
         };
 
@@ -197,8 +205,10 @@ in
       # TODO might neeed to generate several aliases depending on mua
       programs.bash.shellAliases = 
       let 
+        # return a list of [ {name=; value;} ]
         genAccountAliases = account:
-          map (mua.generateAliases account) account.MUAs;
+          map (mua: mua.generateAliases account) account.MUAs;
+        # 
         genAliasesList = mailAccounts:
           map genAccountAliases mailAccounts ;
         in
@@ -206,7 +216,7 @@ in
           alot_test="echo 'test successful'";
         }
         // (lib.optionalAttrs cfg.generateAliases (
-          builtins.listToAttrs (genAliasesList cfg.accounts) 
+          builtins.listToAttrs trace (genAliasesList cfg.accounts) 
         )
       );
 

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -249,8 +249,8 @@ in
         # return a list of [ {name=; value;} ]
         genAccountAliases = account:
         (map (mua: mua.generateShellAliases account) account.MUAs)
-          ++ [ account.mra.generateShellAliases account ];
-        # 
+          # ++ [ account.mra.generateShellAliases account ]
+          ;
         genAliasesList = mailAccounts:
           map genAccountAliases mailAccounts ;
           # fold genAccountAliases [] mailAccounts ;

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -253,17 +253,18 @@ in
         MAILDIR = cfg.maildir;
       };
 
+
       # TODO might neeed to generate several aliases depending on mua
+      # TODO best to generate wrappers the since aliases need to be reloaded
+      # home.activation.wrapMUAs = 
       programs.bash.shellAliases = 
       let 
         # return a list of [ {name=; value;} ]
         genAccountAliases = account:
         (map (mua: mua.generateShellAliases account) account.MUAs)
-          # ++ [ account.mra.generateShellAliases account ]
           ;
         genAliasesList = mailAccounts:
           map genAccountAliases mailAccounts ;
-          # fold genAccountAliases [] mailAccounts ;
         in
         {
           # alot_test="echo 'test successful'";

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -49,8 +49,9 @@ let
           description = "wether to attach signature";
         };
 
+        # identity ? at least of alot
         gpgKey = mkOption {
-          type = types.nullOr types.path;
+          type = types.nullOr types.string;
           default = null;
           description = "your gpg key";
         };

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -93,7 +93,7 @@ let
 
         # can have only one mta
         mra = mkOption {
-          type =  types.enum [config.programs.offlineimap];
+          type =  types.enum [config.programs.mbsync config.programs.offlineimap];
           default = config.programs.offlineimap;
           description = "Mail Retrieval Agent to use";
         };

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -218,13 +218,13 @@ in
       description = "List your email accounts.";
     };
 
-    certificates = mkOption {
+    certificateStore = mkOption {
       type = types.path;
-      default = config.security.pki.certificateFiles
+      default =  "/etc/ssl/certs/ca-certificates.crt";
       description = ''
         Path towards the certificates files.
       '';
-    } 
+    };
 
     generateShellAliases = mkOption {
       default = true;

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -206,15 +206,29 @@ in
     accounts = mkOption {
       type = types.listOf mailAccount;
       # type = types.attrsOf mailAccount;
+      example = literalExample ''
+        {
+          name = "gmail";
+          userName = "Luke";
+          realname = "Luke skywalker";
+          address = "luke.skywalker@gmail.com";
+          sendHost = "smtp.gmail.com";
+          contactCompletion = "notmuch address";
+        }'';
       description = "List your email accounts.";
     };
 
+    certificates = mkOption {
+      type = types.path;
+      default = config.security.pki.certificateFiles
+      description = ''
+        Path towards the certificates files.
+      '';
+    } 
 
-
-    generateAliases = mkOption {
+    generateShellAliases = mkOption {
       default = true;
       type = types.bool;
-      # todo let it a function ?
       description = ''
         Generate one shell alias per (program/account). For instance, if alot is enabled and an account is defined with name gmail, then it will generate alot-gmail
       '';
@@ -234,7 +248,8 @@ in
       let 
         # return a list of [ {name=; value;} ]
         genAccountAliases = account:
-          map (mua: mua.generateAliases account) account.MUAs;
+        (map (mua: mua.generateShellAliases account) account.MUAs)
+          ++ [ account.mra.generateShellAliases account ];
         # 
         genAliasesList = mailAccounts:
           map genAccountAliases mailAccounts ;
@@ -243,8 +258,7 @@ in
         {
           alot_test="echo 'test successful'";
         }
-        // (lib.optionalAttrs cfg.generateAliases 
-        # lib.traceShowVal
+        // (lib.optionalAttrs cfg.generateShellAliases 
               (
                 builtins.listToAttrs (
                 builtins.concatLists (

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -45,11 +45,13 @@ let
         attachSignature = mkOption {
           type = types.bool;
           default = false;
+          description = "wether to attach signature";
         };
 
         gpgKey = mkOption {
           type = types.path;
           default = false;
+          description = "your gpg key";
         };
 
         address = mkOption {
@@ -80,15 +82,16 @@ let
 
         # can have only one mta
         mta = mkOption {
-          type =  types.enum [ "msmtp" ];
-          default = "msmtp";
-          # type =  types.enum [config.programs.msmtp];
-          # default = config.programs.msmtp;
+          # type =  types.enum [ "msmtp" ];
+          # default = "msmtp";
+          type =  types.enum [config.programs.msmtp];
+          default = config.programs.msmtp;
           description = "Mail Transfer Agent to use";
         };
 
         MUAs = mkOption {
-          type = types.listOf (types.enum [ config.programs.alot config.programs.astroid ]);
+          # TODO add astroid
+          type = types.listOf (types.enum [ config.programs.alot  ]);
           default = [ config.programs.alot ];
           description = "List of Mail User Agents to take into account";
         };
@@ -211,14 +214,22 @@ in
         # 
         genAliasesList = mailAccounts:
           map genAccountAliases mailAccounts ;
+          # fold genAccountAliases [] mailAccounts ;
         in
         {
           alot_test="echo 'test successful'";
         }
-        // (lib.optionalAttrs cfg.generateAliases (
-          builtins.listToAttrs trace (genAliasesList cfg.accounts) 
-        )
-      );
+        // (lib.optionalAttrs cfg.generateAliases 
+        # lib.traceShowVal
+              (
+                builtins.listToAttrs (
+                builtins.concatLists (
+                # [ [] ]
+                genAliasesList cfg.accounts
+                ) 
+                )
+              )
+              );
 
       # todo check mta/mua creation process
       home.activation.createMailStores = 

--- a/modules/mail.nix
+++ b/modules/mail.nix
@@ -49,8 +49,8 @@ let
         };
 
         gpgKey = mkOption {
-          type = types.path;
-          default = false;
+          type = types.nullOr types.path;
+          default = null;
           description = "your gpg key";
         };
 
@@ -59,13 +59,6 @@ let
           example = "luke@tatooine.com";
           description = "Your mail address";
         };
-
-        # pgp key
-        # key = mkOption {
-        #   type = types.path;
-        #   example = null;
-        #   description = "Your PGP key/file";
-        # };
 
         imapHost = mkOption {
           type = types.nullOr types.str;
@@ -81,9 +74,12 @@ let
         };
 
         # can have only one mta
+        mra = mkOption {
+          type =  types.enum [config.programs.offlineimap];
+          default = config.programs.offlineimap;
+          description = "Mail Retrieval Agent to use";
+        };
         mta = mkOption {
-          # type =  types.enum [ "msmtp" ];
-          # default = "msmtp";
           type =  types.enum [config.programs.msmtp];
           default = config.programs.msmtp;
           description = "Mail Transfer Agent to use";
@@ -161,6 +157,23 @@ let
           description = "Where to store mail for this account";
         };
 
+        configStore = mkOption {
+          type = types.nullOr types.path;
+          default = ./.;
+          # default = "${cfg.maildir}/${name.value}";
+          description = ''
+            path to additionnal per-program configuration, for instance notmuch hooks. It should follow a specific structure
+          '';
+        };
+
+        # store = mkOption {
+        #   # path
+        #   type = types.nullOr types.path;
+        #   default = null;
+        #   # default = "${cfg.maildir}/${name.value}";
+        #   description = "Where to store mail for this account";
+        # };
+
       };
     };
 
@@ -186,6 +199,7 @@ in
       # type = types.attrsOf mailAccount;
       description = "List your email accounts.";
     };
+
 
 
     generateAliases = mkOption {

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -45,6 +45,7 @@ let
     ./programs/msmtp.nix
     ./programs/neovim.nix
     ./programs/newsboat.nix
+    ./programs/offlineimap.nix
     ./programs/pidgin.nix
     ./programs/notmuch.nix
     ./programs/rofi.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -43,6 +43,7 @@ let
     ./programs/info.nix
     ./programs/lesspipe.nix
     ./programs/man.nix
+    ./programs/mbsync.nix
     ./programs/mercurial.nix
     ./programs/msmtp.nix
     ./programs/neovim.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -15,6 +15,7 @@ let
   modules = [
     ./files.nix
     ./home-environment.nix
+    ./mail.nix
     ./manual.nix
     ./misc/fontconfig.nix
     ./misc/gtk.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -24,6 +24,7 @@ let
     ./misc/qt.nix
     ./misc/xdg.nix
     ./programs/autorandr.nix
+    ./programs/alot.nix
     ./programs/bash.nix
     ./programs/beets.nix
     ./programs/browserpass.nix
@@ -41,9 +42,11 @@ let
     ./programs/lesspipe.nix
     ./programs/man.nix
     ./programs/mercurial.nix
+    ./programs/msmtp.nix
     ./programs/neovim.nix
     ./programs/newsboat.nix
     ./programs/pidgin.nix
+    ./programs/notmuch.nix
     ./programs/rofi.nix
     ./programs/ssh.nix
     ./programs/termite.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -26,6 +26,7 @@ let
     ./misc/xdg.nix
     ./programs/autorandr.nix
     ./programs/alot.nix
+    # ./programs/astroid.nix
     ./programs/bash.nix
     ./programs/beets.nix
     ./programs/browserpass.nix
@@ -43,7 +44,7 @@ let
     ./programs/lesspipe.nix
     ./programs/man.nix
     ./programs/mercurial.nix
-    # ./programs/msmtp.nix
+    ./programs/msmtp.nix
     ./programs/neovim.nix
     ./programs/newsboat.nix
     ./programs/offlineimap.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -43,7 +43,7 @@ let
     ./programs/lesspipe.nix
     ./programs/man.nix
     ./programs/mercurial.nix
-    ./programs/msmtp.nix
+    # ./programs/msmtp.nix
     ./programs/neovim.nix
     ./programs/newsboat.nix
     ./programs/offlineimap.nix

--- a/modules/programs/accounts.nix
+++ b/modules/programs/accounts.nix
@@ -1,28 +1,28 @@
 
-{ config, lib, pkgs, ... }:
+# { config, lib, pkgs, ... }:
 
-with lib;
-# with import ../lib/dag.nix { inherit lib; };
+# with lib;
+# # with import ../lib/dag.nix { inherit lib; };
 
-let
+# let
 
-  cfg = config.programs.mailaccounts;
+#   cfg = config.programs.mailaccounts;
 
-in
+# in
 
-{
+# {
 
-  options = {
-    programs.notmuch = {
-      enable = mkEnableOption "Notmuch";
+#   options = {
+#     programs.notmuch = {
+#       enable = mkEnableOption "Notmuch";
 
-    };
+#     };
 
-  };
+#   };
 
-  config = mkIf cfg.enable {
-    home.packages = [ notmuch ];
-  };
-}
+#   config = mkIf cfg.enable {
+#     home.packages = [ notmuch ];
+#   };
+# }
 
 

--- a/modules/programs/accounts.nix
+++ b/modules/programs/accounts.nix
@@ -1,0 +1,28 @@
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+# with import ../lib/dag.nix { inherit lib; };
+
+let
+
+  cfg = config.programs.mailaccounts;
+
+in
+
+{
+
+  options = {
+    programs.notmuch = {
+      enable = mkEnableOption "Notmuch";
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ notmuch ];
+  };
+}
+
+

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with import ../lib/dag.nix { inherit lib; };
+
+let
+
+  cfg = config.programs.alot;
+  sendCommand = account:
+    "msmtp --account=${account.userName} -t";
+
+  accountStr = {userName, address, realname, ...} @ account:
+    ''
+      [[${userName}]]
+      address=${address}
+      realname=${realname}
+
+      sendmail_command = ${sendCommand account}
+      '';
+
+  # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+  configFile = mailAccounts: pkgs.writeText "alot.conf" (  ''
+  [accounts]
+
+    ${concatStringsSep "\n" (map accountStr mailAccounts)}
+
+  '' 
+  # + cfg.extraConfig
+  );
+
+in
+
+{
+
+  options = {
+    programs.alot = {
+      enable = mkEnableOption "Alot";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Extra configuration lines to add to ~/.config/alot/config.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.alot ];
+
+    # create folder where to store mails
+      # home.activation.createAlotConfig = dagEntryBefore [ "linkGeneration" ] ''
+      #   #     "${config.xdg.configHome}/i3/config"; then
+      # '';
+
+      # ca s appelle notmuchrc plutot
+      xdg.configFile."alot/config".source = configFile config.home.mailAccounts;
+      # ''
+      # '';
+  };
+}
+

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -13,14 +13,43 @@ let
     value = "${pkgs.alot}/bin/alot -n ${config.xdg.configHome}/notmuch/notmuch_${account.name}"; 
   };
  
+  # TODO test simple
+  # command = 'notmuch address --format=json date:1Y..'
+  # TODO might need to add the database too
+  # or add --config ?
+  contactCompletionStr = account: 
+    ''
+      [[[abook]]]
+      type = shellcommand
+      command = '' + (
+    if account.contactCompletion == "notmuch address" then ''
+      '${pkgs.notmuch}/bin/notmuch address --format=json --output=recipients date:1Y.. AND from:my@address.org'
+  regexp = '\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?'
+  shellcommand_external_filtering = False
+    '' else if account.contactCompletion == "notmuch address simple" then
+    "'${pkgs.notmuch}/bin/notmuch address --format=json date:1Y..'"
+    else 
+      "");
 
-  accountStr = {name,userName, address, realname, ...} @ account:
+
+
+
+  # TODO add contact completion
+  # https://alot.readthedocs.io/en/latest/configuration/contacts_completion.html
+  # signature = ${if account?signatureFilename or ""}
+  accountStr = {name, userName, address, realname, ...} @ account:
     ''
       [[${name}]]
       address=${address}
       realname=${realname}
-
+      # gpg_key = D7D6C5AA
+      # gpg_key
       sendmail_command = ${account.mta.sendCommand account}
+      signature_as_attachment = ${if account.showSignature == "attach" then "True" else "False"}
+
+      # contact completion
+      ${contactCompletionStr account} 
+        
     '';
 
     # TODO use
@@ -31,11 +60,14 @@ let
 
 # alot hooks use default for now
 # hooksfile = ${xdg.configFile."alot/hm_hooks"}
+# mailinglists
   configFile = mailAccounts: pkgs.writeText "alot.conf" (''
 
     theme = ${cfg.theme}
     ${cfg.extraConfig}
-
+    
+    # TODO we should prepare our own hooks file
+    # hooksfile
     [accounts]
 
     ${concatStringsSep "\n" (map accountStr mailAccounts)}
@@ -67,16 +99,27 @@ in
         description = "default theme";
       };
 
+      # TODO make it a function of the account
+      contactCompletionCommand = mkOption {
+        # type = types.str;
+        default = contactCompletionStr;
+        description = "Can override what is decided in contactCompletion";
+      };
 
+      # what about editor/editor_spawn
+      # terminal_cmd
+      # themes_dir
       extraConfig = mkOption {
         type = types.lines;
         default = ''
           auto_remove_unread = True
           ask_subject = False
+          handle_mouse = True
           # launch sequence of commands separated by ;
           initial_command = search tag:inbox AND NOT tag:killed;
           input_timeout=0.3
           prefer_plaintext = True
+          thread_indent_replies = 4
         '';
         description = "Extra configuration lines to add to ~/.config/alot/config.";
       };

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -11,7 +11,7 @@ let
   {
     name = "alot-${account.name}";
     value = "${pkgs.alot}/bin/alot -n ${config.xdg.configHome}/notmuch/notmuch_${account.name}"; 
-  }
+  };
  
 
   accountStr = {name,userName, address, realname, ...} @ account:

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -9,9 +9,11 @@ let
   sendCommand = account:
     "msmtp --account=${account.name} -t";
 
-  accountStr = {userName, address, realname, ...} @ account:
+  # alot_hooks=
+
+  accountStr = {name,userName, address, realname, ...} @ account:
     ''
-      [[${userName}]]
+      [[${name}]]
       address=${address}
       realname=${realname}
 
@@ -19,13 +21,26 @@ let
       '';
 
   # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+  # should we set themes_dir as well ?
+# alot hooks use default for now
+# hooksfile = ${xdg.configFile."alot/hm_hooks"}
   configFile = mailAccounts: pkgs.writeText "alot.conf" (  ''
+
+theme = "solarized_dark"
+auto_remove_unread = True
+ask_subject = False
+#auto_replyto_mailinglist
+# launch sequence of commands separated by ;
+initial_command = search tag:inbox AND NOT tag:killed AND NOT tag:ietf ; 
+input_timeout=0.3
+# list of adresses
+mailinglists = lisp@ietf.org, taps@ietf.org 
+prefer_plaintext = True
   [accounts]
 
     ${concatStringsSep "\n" (map accountStr mailAccounts)}
 
   '' 
-  # + cfg.extraConfig
   );
 
 in
@@ -36,6 +51,11 @@ in
     programs.alot = {
       enable = mkEnableOption "Alot";
 
+      createAliases = mkOption {
+        type = types.bool;
+        default = false;
+        description = "create alias alot_\${account.name}";
+      };
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -54,8 +74,10 @@ in
 
       # ca s appelle notmuchrc plutot
       xdg.configFile."alot/config".source = configFile config.home.mailAccounts;
-      # ''
-      # '';
+
+      xdg.configFile."alot/hm_hooks".text = ''
+        # Home-manager custom hooks
+        '';
   };
 }
 

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -7,7 +7,7 @@ let
 
   cfg = config.programs.alot;
   sendCommand = account:
-    "msmtp --account=${account.userName} -t";
+    "msmtp --account=${account.name} -t";
 
   accountStr = {userName, address, realname, ...} @ account:
     ''

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -41,11 +41,11 @@ let
       "");
 
 
-  bindingsStr = fetchMailCommand:
-  ''
-    [bindings]
-    % = "shellescape ${account.mra.fetchMailCommand account} ; refresh"
-  '';
+  # bindingsStr = fetchMailCommand:
+  # ''
+  #   [bindings]
+  #   % = "shellescape ${account.mra.fetchMailCommand account} ; refresh"
+  # '';
 
   # TODO add contact completion
   # https://alot.readthedocs.io/en/latest/configuration/contacts_completion.html
@@ -66,7 +66,6 @@ let
       ${if account.showSignature == "attach" then "gpg_key = {account." else ""}
         
     ''
-    
     ;
 
 # alot hooks use default for now
@@ -82,6 +81,7 @@ in
     ${extraConfigStr cfg.extraConfig}
 
     [bindings] 
+    ${cfg.bindings}
 
     # TODO we should prepare our own hooks file
     # hooksfile
@@ -121,12 +121,17 @@ in
       };
 
       bindings = mkOption {
-        type = types.attrs;
-        default = {
-          # TODO it should
-    # % = "shellescape ${account.mra.fetchMailCommand account} ; refresh"
-           "%" = "refresh";
-        };
+        # type = types.submoduleOf
+        # type = types.attrs;
+        # default = {
+        #   # TODO it should
+    # # % = "shellescape ${account.mra.fetchMailCommand account} ; refresh"
+        #    "%" = "refresh";
+        # };
+        type = types.lines;
+        default = ''
+          % = refresh;
+        '';
         description = "Can override what is decided in contactCompletion";
       };
 

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -13,7 +13,8 @@ let
   {
     name = "alot-${name}";
     # -c $XDG_CONFIG_HOME/alot/alot-${name}
-    value = "${pkgs.alot}/bin/alot -n ${notmuchConfig account}"; 
+    #  -n ${notmuchConfig account}
+    value = "export NOTMUCH_CONFIG=${notmuchConfig account}; ${pkgs.alot}/bin/alot"; 
   };
  
   # TODO test simple
@@ -23,6 +24,7 @@ let
   contactCompletionStr = let
     
       # command="";
+      # --config ${notmuchConfig account}
     in
     account: 
     ''
@@ -30,7 +32,7 @@ let
       type = shellcommand
       command = '' + (
     if account.contactCompletion == "notmuch address" then ''
-      '${pkgs.bash}/bin/bash -c "${pkgs.notmuch}/bin/notmuch --config ${notmuchConfig account} address --format=json --output=recipients  date:1Y.."'
+      '${pkgs.bash}/bin/bash -c "${pkgs.notmuch}/bin/notmuch  address --format=json --output=recipients  date:1Y.."'
     regexp = '\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?'
     shellcommand_external_filtering = False
     '' else if account.contactCompletion == "notmuch --config ${notmuchConfig account} address simple" then

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -32,7 +32,12 @@ let
       "");
 
 
-
+  # todo should run the mra
+  bindingsStr = account:
+    ''[bindings]
+      # '/home/pazz/bin/pullmail.sh'
+    % = "shellescape ${account.mra.fetchMailCommand account} ; refresh"
+  '';
 
   # TODO add contact completion
   # https://alot.readthedocs.io/en/latest/configuration/contacts_completion.html
@@ -49,6 +54,7 @@ let
 
       # contact completion
       ${contactCompletionStr account} 
+      ${bindingsStr account} 
         
     '';
 
@@ -61,10 +67,15 @@ let
 # alot hooks use default for now
 # hooksfile = ${xdg.configFile."alot/hm_hooks"}
 # mailinglists
-  configFile = mailAccounts: pkgs.writeText "alot.conf" (''
+configFile = let
+  extraConfigStr = entries: concatStringsSep "\n" (
+    mapAttrsToList (key: val: "${key} = ${val}") entries
+  );
+in
+      mailAccounts: pkgs.writeText "alot.conf" (''
 
     theme = ${cfg.theme}
-    ${cfg.extraConfig}
+    ${extraConfigStr cfg.extraConfig}
     
     # TODO we should prepare our own hooks file
     # hooksfile
@@ -94,33 +105,28 @@ in
       };
 
       generateAliases = mkOption {
-        # type = types.enum [ "solarized_dark" ];
         default = generateNotmuchAlias;
         description = "default theme";
       };
 
-      # TODO make it a function of the account
       contactCompletionCommand = mkOption {
-        # type = types.str;
         default = contactCompletionStr;
         description = "Can override what is decided in contactCompletion";
       };
 
       # what about editor/editor_spawn
-      # terminal_cmd
-      # themes_dir
       extraConfig = mkOption {
-        type = types.lines;
-        default = ''
-          auto_remove_unread = True
-          ask_subject = False
-          handle_mouse = True
-          # launch sequence of commands separated by ;
-          initial_command = search tag:inbox AND NOT tag:killed;
-          input_timeout=0.3
-          prefer_plaintext = True
-          thread_indent_replies = 4
-        '';
+        type = types.attrs;
+        default = {
+          auto_remove_unread = "True";
+          ask_subject = "False";
+          handle_mouse = "True";
+          # launch sequence of commands separated by ;;
+          initial_command = "search tag:inbox AND NOT tag:killed";
+          input_timeout=0.3;
+          prefer_plaintext = "True";
+          thread_indent_replies = 4;
+        };
         description = "Extra configuration lines to add to ~/.config/alot/config.";
       };
     };

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -35,12 +35,12 @@ in
   options = {
     programs.alot = {
       enable = mkEnableOption "Alot";
-    };
 
-    extraConfig = mkOption {
-      type = types.lines;
-      default = "";
-      description = "Extra configuration lines to add to ~/.config/alot/config.";
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra configuration lines to add to ~/.config/alot/config.";
+      };
     };
   };
 

--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -14,6 +14,7 @@ let
     value = "${pkgs.astroid}/bin/alot -c ${config.xdg.configHome}/notmuch/notmuch_${account.name}"; 
   }
  
+
     
   accountStr = {name,userName, address, realname, ...} @ account:
     ''

--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -1,0 +1,236 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with import ../lib/dag.nix { inherit lib; };
+
+let
+
+  # astroid has no man but astroid --help shows some settings
+  cfg = config.programs.astroid;
+
+  generateNotmuchAlias = account:
+  {
+    name = "alot-${account.name}";
+    value = "${pkgs.astroid}/bin/alot -c ${config.xdg.configHome}/notmuch/notmuch_${account.name}"; 
+  }
+ 
+    
+  accountStr = {name,userName, address, realname, ...} @ account:
+    ''
+      [[${name}]]
+      address=${address}
+      realname=${realname}
+
+      sendmail_command = ${sendCommand account}
+      '';
+
+    bindingStr = ''
+      # TODO if offlineimap configured, run offlineimap
+      G = call hooks.getmail(ui)
+    '';
+
+  # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+  # should we set themes_dir as well ?
+# alot hooks use default for now
+# hooksfile = ${xdg.configFile."alot/hm_hooks"}
+# toJSON
+
+  accountsJson = accounts:
+    map ( toJSON account: 
+        account.name = {
+            name = account.username;
+            email = account.address;
+            # "gpgkey": "",
+            sendmail= account.mta.sendCommand;
+            # "default": "true",
+            # "save_sent": "false",
+            # "save_sent_to": "\/home\/root\/Mail\/sent\/cur\/",
+            # "additional_sent_tags": "",
+            # "save_drafts_to": "\/home\/root\/Mail\/drafts\/",
+            # "signature_file": "",
+            # "signature_default_on": "true",
+            # "signature_attach": "false",
+            # "always_gpg_sign": "false",
+            # "signature_separate": "false",
+            # "select_query": ""
+        }) accounts;
+
+  configFile = mailAccounts: pkgs.writeText "astroid.conf" (  ''
+
+  accounts = {
+
+    ${concatStringsSep "\n" (map accountJson mailAccounts)}
+
+    }
+  '' 
+  );
+
+in
+
+{
+
+  options = {
+    programs.alot = {
+      enable = mkEnableOption "Alot";
+
+      createAliases = mkOption {
+        type = types.bool;
+        default = false;
+        description = "create alias alot_\${account.name}";
+      };
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra configuration lines to add to ~/.config/alot/config.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # home.packages = [ pkgs.alot ];
+
+      # programs.zsh.shellAliases = lib.optional cfg.createAliases 
+      # # (map {} )
+      # (zipAttrsWith (account: )  home.mail.accounts)
+      # ;
+
+      # ca s appelle notmuchrc plutot
+      xdg.configFile."astroid/config".source = configFile config.mail.accounts;
+
+      # xdg.configFile."alot/hm_hooks".text = ''
+      #   # Home-manager custom hooks
+      #   '';
+  };
+}
+
+# {
+#     "astroid": {
+#         "config": {
+#             "version": "9"
+#         },
+#         "notmuch_config": "\/home\/teto\/.config\/notmuch\/notmuchrc",
+#         "debug": {
+#             "dryrun_sending": "false"
+#         },
+#         "hints": {
+#             "level": "0"
+#         }
+#     },
+#     "thread_index": {
+#         "page_jump_rows": "6",
+#         "sort_order": "newest",
+#         "thread_load_step": "250",
+#         "cell": {
+#             "font_description": "default",
+#             "line_spacing": "2",
+#             "date_length": "10",
+#             "message_count_length": "4",
+#             "authors_length": "20",
+#             "subject_color": "#807d74",
+#             "subject_color_selected": "#000000",
+#             "background_color_selected": "",
+#             "tags_length": "80",
+#             "tags_upper_color": "#e5e5e5",
+#             "tags_lower_color": "#333333",
+#             "tags_alpha": "0.5",
+#             "hidden_tags": "attachment,flagged,unread",
+#             "tags_color": "#31587a"
+#         }
+#     },
+#     "general": {
+#         "time": {
+#             "clock_format": "local",
+#             "same_year": "%b %-e",
+#             "diff_year": "%x"
+#         }
+#     },
+#     "editor": {
+#         "cmd": "gvim -f -c 'set ft=mail' '+set fileencoding=utf-8' '+set enc=utf-8' '+set ff=unix' %1",
+#         "external_editor": "true",
+#         "charset": "utf-8",
+#         "save_draft_on_force_quit": "true",
+#         "attachment_words": "attach",
+#         "attachment_directory": "~"
+#     },
+#     "mail": {
+#         "reply": {
+#             "quote_line": "Excerpts from %1's message of %2:",
+#             "mailinglist_reply_to_sender": "true"
+#         },
+#         "forward": {
+#             "quote_line": "Forwarding %1's message of %2:",
+#             "disposition": "inline"
+#         },
+#         "sent_tags": "sent",
+#         "message_id_fqdn": "",
+#         "message_id_user": "",
+#         "user_agent": "default",
+#         "send_delay": "2"
+#     },
+#     "poll": {
+#         "interval": "60"
+#     },
+#     "attachment": {
+#         "external_open_cmd": "xdg-open"
+#     },
+#     "thread_view": {
+#         "open_html_part_external": "true",
+#         "open_external_link": "xdg-open",
+#         "default_save_directory": "~",
+#         "indent_messages": "true",
+#         "code_prettify": {
+#             "enable": "true",
+#             "for_tags": "",
+#             "code_tag": "```",
+#             "enable_for_patches": "true",
+#             "uri_prefix": "https:\/\/google-code-prettify.googlecode.com\/svn\/loader\/"
+#         },
+#         "gravatar": {
+#             "enable": "true"
+#         },
+#         "mark_unread_delay": "0.5",
+#         "expand_flagged": "true",
+#         "mathjax": {
+#             "enable": "true",
+#             "uri_prefix": "https:\/\/cdn.mathjax.org\/mathjax\/latest\/",
+#             "for_tags": ""
+#         }
+#     },
+#     "crypto": {
+#         "gpg": {
+#             "path": "gpg2",
+#             "always_trust": "true"
+#         }
+#     },
+#     "saved_searches": {
+#         "show_on_startup": "false",
+#         "save_history": "true",
+#         "history_lines_to_show": "15",
+#         "history_lines": "1000"
+#     },
+#     "accounts": {
+#         "charlie": {
+#             "name": "Charlie Root",
+#             "email": "root@localhost",
+#             "gpgkey": "",
+#             "sendmail": "msmtp -t",
+#             "default": "true",
+#             "save_sent": "false",
+#             "save_sent_to": "\/home\/root\/Mail\/sent\/cur\/",
+#             "additional_sent_tags": "",
+#             "save_drafts_to": "\/home\/root\/Mail\/drafts\/",
+#             "signature_file": "",
+#             "signature_default_on": "true",
+#             "signature_attach": "false",
+#             "always_gpg_sign": "false",
+#             "signature_separate": "false",
+#             "select_query": ""
+#         }
+#     },
+#     "startup": {
+#         "queries": {
+#             "inbox": "tag:inbox"
+#         }
+#     }
+# }
+

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -1,0 +1,152 @@
+# TODO load template
+{ config, lib, pkgs, ... }:
+
+with lib;
+with import ../lib/dag.nix { inherit lib; };
+with import ../lib/mail.nix { inherit lib config; };
+
+let
+
+  cfg = config.programs.mbsync;
+
+  # TODO move to lib account.mta.postSyncHookCommand
+  # postSyncHookCommand = account: 
+  #   pkgs.writeScript "postSyncHook.sh" (
+
+  #   lib.optionalString config.programs.notmuch.enable (config.programs.notmuch.postSyncHook account)
+  #  + lib.optionalString (account.postSyncHook != null) account.postSyncHook
+  # );
+  # if (account.postSyncHook != null) then account.postSyncHook else if (config.programs.notmuch.enable) then config.programs.notmuch.postSyncHook else ""
+  # );
+  generateOfflineimapAlias = account:
+    "alias offlineimap-${account.name}='${cfg.fetchMailCommand account}'";
+    
+
+  # TODO maybe generate one config per account and load it with -c ?
+  # TODO add postsynchook only if notmuch enabled ?
+  # TODO allow for user customisation
+  # make the path towards config a function ?
+
+# postsynchook= ${postSyncHookCommand account}
+# remoteusereval = ${cfg.getLogin account}
+	# SSLType IMAPS
+	# CertificateFile /etc/ssl/certs/ca-certificates.crt
+    # ${if account.imapHost != null then "IMAP" else "Gmail"}
+      # ${if (isGmail account) then "Maildir" else "GmailMaildir"}
+  accountStr = {name, userName, address, realname, ...} @ account:
+    ''
+      IMAPAccount ${name}-remote
+      # holgerschurig@gmail.com
+      User  ${cfg.getPass account}
+      PassCmd ${cfg.getPass account}
+
+      IMAPStore ${name}-local
+      Account ${name}
+
+      Path ${getStore account}
+      # we don't need to specify inbox / trash right ?!
+      # Inbox ${getStore account}INBOX
+
+      Channel ${name}
+      Master :${name}-remote:
+      Slave :${name}-local:
+      Patterns *
+      Create Both
+      SyncState *
+      Sync All
+
+      '';
+
+  # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+  configFile = mailAccounts: pkgs.writeText "mbsyncrc" (  ''
+
+    # default settings for all channels
+    Fsync no
+
+    CopyArrivalDate yes
+    Create Slave
+    Sync All
+    Expunge Both
+
+    ${concatStringsSep "\n" (map accountStr mailAccounts)}
+
+  '' 
+  + cfg.extraConfig
+  );
+
+in
+
+{
+
+  options = {
+    programs.mbsync = {
+      enable = mkEnableOption "Mbsync";
+
+      # getLogin = mkOption {
+      #   # type = types.function;
+      #   default = account: "get_pass('${account.name}', 'login')";
+      #   description = "function accepting a mail account as parameter";
+      # };
+
+      # getPass = mkOption {
+      #   # type = types.function;
+      #   default = account: "get_pass('${account.name}', 'password')";
+      #   description = "function accepting a mail account as parameter";
+      # };
+
+      generateShellAliases = mkOption {
+        default = generateOfflineimapAlias;
+        description = "default theme";
+      };
+
+      # needs to be an option to be accessible by mra.fetchMailCommand
+      fetchMailCommand = mkOption {
+        default = account: 
+          "${pythonEnv}/bin/offlineimap -a${account.name}"
+        ;
+        description = "default theme";
+      };
+
+      # run on finish
+      # TODO should be per account
+      postSyncHookCommand = mkOption {
+        # type = types.str;
+        default = account: "";
+        description = "function accepting a mail account as parameter";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra configuration lines to add to ~/.config/alot/config.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    # home.packages =  [
+    #   pythonEnv
+    # ];
+
+    # create script to retrieve keyring
+    # "${config.xdg.configHome}/offlineimap/get_settings.py"
+    # home.activation.createAlotScript = dagEntryBefore [ "linkGeneration" ] ''
+
+    # '';
+
+    # todo rely on libsecret instead ? else we need to override offlineimap
+    # xdg.configFile."offlineimap/get_settings.py".text = ''
+    #   import keyring
+
+    #   def get_pass (service, name):
+    #       v = keyring.get_password(service, name)
+    #       # print("TEEESSTTT", v)
+    #       # print("type", type(v))
+    #       return v
+    # '';
+
+    # ca s appelle notmuchrc plutot
+    home.file.".mbsyncrc".source = configFile config.mail.accounts;
+  };
+}

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -7,12 +7,12 @@ let
 
   cfg = config.programs.msmtp;
 
-  # sendMsmtpCommand = account:
-  #     if cfg.offlineSendMethod == "native" then
-  #       "${pkgs.msmtp}/bin/msmtp-queue --account=${account.name} -t"
-  #     # "none"
-  #     else
-  #       "${pkgs.msmtp}/bin/msmtp --account=${account.name} -t";
+  sendMsmtpCommand = account:
+      if cfg.offlineSendMethod == "native" then
+        "${pkgs.msmtp}/bin/msmtp-queue --account=${account.name} -t"
+      # "none"
+      else
+        "${pkgs.msmtp}/bin/msmtp --account=${account.name} -t";
 
   accountStr = {userName, address, realname, ...} @ account:
     ''
@@ -42,40 +42,39 @@ in
 
 {
 
-  options = {
-    programs.msmtp = {
-      enable = mkEnableOption "Msmtp";
+  options.programs.msmtp = {
+    enable = mkEnableOption "Msmtp";
 
-      offlineSendMethod = mkOption {
-        # https://wiki.archlinux.org/index.php/Msmtp#Using_msmtp_offline
-        # see for a list of methodds 
-        # https://github.com/pazz/alot/wiki/Tips,-Tricks-and-other-cool-Hacks
-        type = types.enum [ "none" "native" ];
-        default = "native";
-        description = "Extra configuration lines to add to .msmtprc.";
-      };
+    offlineSendMethod = mkOption {
+      # https://wiki.archlinux.org/index.php/Msmtp#Using_msmtp_offline
+      # see for a list of methodds 
+      # https://github.com/pazz/alot/wiki/Tips,-Tricks-and-other-cool-Hacks
+      type = types.enum [ "none" "native" ];
+      default = "native";
+      description = "Extra configuration lines to add to .msmtprc.";
+    };
 
-      sendCommand = mkOption {
-        # https://wiki.archlinux.org/index.php/Msmtp#Using_msmtp_offline
-        # see for a list of methodds 
-        # https://github.com/pazz/alot/wiki/Tips,-Tricks-and-other-cool-Hacks
-        # type = types.str;
-        # default = sendMsmtpCommand ;
-        description = "Extra configuration lines to add to .msmtprc.";
-      };
+    sendCommand = mkOption {
+      # https://wiki.archlinux.org/index.php/Msmtp#Using_msmtp_offline
+      # see for a list of methodds 
+      # https://github.com/pazz/alot/wiki/Tips,-Tricks-and-other-cool-Hacks
+      # type = types.str;
+      default = sendMsmtpCommand ;
+      description = "Extra configuration lines to add to .msmtprc.";
+    };
 
 
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = "Extra configuration lines to add to .msmtprc.";
-      };
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Extra configuration lines to add to .msmtprc.";
     };
   };
+
   config = mkMerge [
-    mkIf cfg.enable { home.packages = [ pkgs.msmtp ]; }
+    (mkIf cfg.enable { home.packages = [ pkgs.msmtp ]; })
     {
-      home.file.".msmtprc".source = configFile config.mail.accounts;
+      home.file.".msmtprc".source =  configFile config.mail.accounts;
     }
   ];
 }

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -14,11 +14,12 @@ let
       else
         "${pkgs.msmtp}/bin/msmtp --account=${account.name} -t";
 
+  # TODO support passwordeval if needed
   accountStr = {userName, address, realname, ...} @ account:
     ''
 defaults
 tls on
-#tls_trust_file /etc/ssl/certs/ca-certificates.crt
+tls_trust_file ${config.mail.certificate}
 logfile ~/.msmtp.log
 
 account ${account.name}

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -5,7 +5,7 @@ with import ../lib/dag.nix { inherit lib; };
 
 let
 
-  cfg = config.programs.alot;
+  cfg = config.programs.msmtp;
   sendCommand = account:
     "msmtp --account=${account.userName} -t";
 
@@ -43,12 +43,12 @@ in
   options = {
     programs.msmtp = {
       enable = mkEnableOption "Msmtp";
-    };
 
-    extraConfig = mkOption {
-      type = types.lines;
-      default = "";
-      description = "Extra configuration lines to add to .msmtprc.";
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra configuration lines to add to .msmtprc.";
+      };
     };
   };
 

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -1,0 +1,68 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with import ../lib/dag.nix { inherit lib; };
+
+let
+
+  cfg = config.programs.alot;
+  sendCommand = account:
+    "msmtp --account=${account.userName} -t";
+
+  accountStr = {userName, address, realname, ...} @ account:
+    ''
+      [[${userName}]]
+      address=${address}
+      realname=${realname}
+
+      sendmail_command = ${sendCommand account}
+
+account gmail
+host smtp.gmail.com
+from username@gmail.com
+auth on
+user username@gmail.com
+tls_certcheck off
+port 587
+      '';
+
+  # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+  configFile = mailAccounts: pkgs.writeText "msmtp.conf" (  ''
+  [accounts]
+
+    ${concatStringsSep "\n" (map accountStr mailAccounts)}
+
+  '' 
+  # + cfg.extraConfig
+  );
+
+in
+
+{
+
+  options = {
+    programs.msmtp = {
+      enable = mkEnableOption "Msmtp";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Extra configuration lines to add to .msmtprc.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.msmtp ];
+
+    # create folder where to store mails
+      # home.activation.createAlotConfig = dagEntryBefore [ "linkGeneration" ] ''
+      #   #     "${config.xdg.configHome}/i3/config"; then
+      # '';
+
+      # ca s appelle notmuchrc plutot
+      xdg.configFile.".msmtprc".source = configFile config.home.mailAccounts;
+      # ''
+      # '';
+  };
+}

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -11,27 +11,27 @@ let
 
   accountStr = {userName, address, realname, ...} @ account:
     ''
-      [[${userName}]]
-      address=${address}
-      realname=${realname}
-
-      sendmail_command = ${sendCommand account}
+defaults
+tls on
+#tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile ~/.msmtp.log
 
 account gmail
-host smtp.gmail.com
-from username@gmail.com
+host ${account.sendHost}
+from ${address}
 auth on
-user username@gmail.com
+user ${account.login}
 tls_certcheck off
 port 587
+
       '';
 
   # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
-  configFile = mailAccounts: pkgs.writeText "msmtp.conf" (  ''
-  [accounts]
+  configFile = mailAccounts: pkgs.writeText "msmtp" (  ''
 
     ${concatStringsSep "\n" (map accountStr mailAccounts)}
 
+    account default : gmail
   '' 
   # + cfg.extraConfig
   );
@@ -61,7 +61,7 @@ in
       # '';
 
       # ca s appelle notmuchrc plutot
-      xdg.configFile.".msmtprc".source = configFile config.home.mailAccounts;
+      home.file.".msmtprc".source = configFile config.home.mailAccounts;
       # ''
       # '';
   };

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -7,12 +7,12 @@ let
 
   cfg = config.programs.msmtp;
 
-  sendMsmtpCommand = account:
-      if config.programs.msmtp.offlineSendMethod == "native" then
-        "${pkgs.msmtp}/bin/msmtp-queue --account=${account.name} -t"
-      # "none"
-      else
-        "${pkgs.msmtp}/bin/msmtp --account=${account.name} -t";
+  # sendMsmtpCommand = account:
+  #     if cfg.offlineSendMethod == "native" then
+  #       "${pkgs.msmtp}/bin/msmtp-queue --account=${account.name} -t"
+  #     # "none"
+  #     else
+  #       "${pkgs.msmtp}/bin/msmtp --account=${account.name} -t";
 
   accountStr = {userName, address, realname, ...} @ account:
     ''
@@ -43,7 +43,7 @@ in
 {
 
   options = {
-    programs.msmtp = rec {
+    programs.msmtp = {
       enable = mkEnableOption "Msmtp";
 
       offlineSendMethod = mkOption {
@@ -60,7 +60,7 @@ in
         # see for a list of methodds 
         # https://github.com/pazz/alot/wiki/Tips,-Tricks-and-other-cool-Hacks
         # type = types.str;
-        default = sendMsmtpCommand ;
+        # default = sendMsmtpCommand ;
         description = "Extra configuration lines to add to .msmtprc.";
       };
 
@@ -72,11 +72,10 @@ in
       };
     };
   };
-
   config = mkMerge [
     mkIf cfg.enable { home.packages = [ pkgs.msmtp ]; }
     {
       home.file.".msmtprc".source = configFile config.mail.accounts;
     }
-    ];
+  ];
 }

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -7,7 +7,7 @@ let
 
   cfg = config.programs.msmtp;
   sendCommand = account:
-    "msmtp --account=${account.userName} -t";
+    "msmtp --account=${account.name} -t";
 
   accountStr = {userName, address, realname, ...} @ account:
     ''
@@ -16,11 +16,11 @@ tls on
 #tls_trust_file /etc/ssl/certs/ca-certificates.crt
 logfile ~/.msmtp.log
 
-account gmail
+account ${account.name}
 host ${account.sendHost}
 from ${address}
 auth on
-user ${account.login}
+user ${account.userName}
 tls_certcheck off
 port 587
 
@@ -31,6 +31,7 @@ port 587
 
     ${concatStringsSep "\n" (map accountStr mailAccounts)}
 
+    # TODO fix pick one
     account default : gmail
   '' 
   # + cfg.extraConfig

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -28,18 +28,14 @@ auth on
 user ${account.userName}
 tls_certcheck off
 port 587
-
       '';
 
-  # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+    # TODO fix pick one
+    # account default : gmail
   configFile = mailAccounts: pkgs.writeText "msmtp" (  ''
 
     ${concatStringsSep "\n" (map accountStr mailAccounts)}
-
-    # TODO fix pick one
-    account default : gmail
   '' 
-  # + cfg.extraConfig
   );
 
 in
@@ -77,17 +73,10 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    home.packages = [ pkgs.msmtp ];
-
-    # create folder where to store mails
-      # home.activation.createAlotConfig = dagEntryBefore [ "linkGeneration" ] ''
-      #   #     "${config.xdg.configHome}/i3/config"; then
-      # '';
-
-      # ca s appelle notmuchrc plutot
+  config = mkMerge [
+    mkIf cfg.enable { home.packages = [ pkgs.msmtp ]; }
+    {
       home.file.".msmtprc".source = configFile config.mail.accounts;
-      # ''
-      # '';
-  };
+    }
+    ];
 }

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -15,11 +15,12 @@ let
         "${pkgs.msmtp}/bin/msmtp --account=${account.name} -t";
 
   # TODO support passwordeval if needed
+  # TODO restore 
   accountStr = {userName, address, realname, ...} @ account:
     ''
 defaults
 tls on
-tls_trust_file ${config.mail.certificate}
+tls_trust_file ${config.mail.certificateStore}
 logfile ~/.msmtp.log
 
 account ${account.name}

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -8,16 +8,13 @@ let
 
   cfg = config.programs.notmuch;
 
-  getNotmuchConfig = account: 
-    "$XDG_CONFIG_HOME/notmuch/notmuch_${account.name}";
-
   # best to  so that tags can use it
   postSyncCommand = account:
     ''
       # we export so that hooks use the correct DB
       # (not sure it would work with --config)
       export NOTMUCH_CONFIG=${getNotmuchConfig account}
-      notmuch new
+      ${pkgs.notmuch}/bin/notmuch new
     '';
 
   # TODO test simple
@@ -118,23 +115,9 @@ in
     home.packages = [ pkgs.notmuch ];
 
 
-    # create folder where to store mails
-        # ${map (account: (account.store.".notmuch/hooks".source = getHooks account)
-        # # {
-        # #   target = "";
-        # #   text = "";
-        # # }
-        #   )  top.config.mail.accounts}
-        # to print advice
-      # ${map (hccount: ('VERBOSE_ECHO "you can generate"')) top.config.home.mailAccounts}
-        
       home.activation.createMailStores = dagEntryBefore [ "linkGeneration" ] ''
         echo 'hello world, notmuch link activation'
       '' 
-      # we need to create the store folders 
-        # + (concatMapStrings (account: ''
-        # mkdir -vf ${account.store}
-        # '') home.mailAccounts)
       ;
 
       # TODO need to add the hooks

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -1,0 +1,87 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+# with import ../lib/dag.nix { inherit lib; };
+
+let
+
+  cfg = config.programs.notmuch;
+
+in
+
+{
+# TODO per account specifics
+# [new]
+# tags=unread;inbox;
+# ignore=
+
+  options = {
+    programs.notmuch = {
+      enable = mkEnableOption "Notmuch";
+
+    };
+  };
+
+
+
+
+  let 
+  configFile = pkgs.writeText "notmuch.conf" ((if cfg.config != null then with cfg.config; ''
+
+      [database]
+      path=${home}
+[user]
+name=matt
+primary_email=mattator@gmail.com
+# other_email=
+
+[new]
+tags=unread;inbox;
+ignore=
+
+[search]
+exclude_tags=deleted;spam;
+
+[maildir]
+synchronize_flags=true
+    font pango:${concatStringsSep ", " fonts}
+    floating_modifier ${floating.modifier}
+    new_window ${if window.titlebar then "normal" else "pixel"} ${toString window.border}
+    new_float ${if floating.titlebar then "normal" else "pixel"} ${toString floating.border}
+    force_focus_wrapping ${if focus.forceWrapping then "yes" else "no"}
+    focus_follows_mouse ${if focus.followMouse then "yes" else "no"}
+    focus_on_window_activation ${focus.newWindow}
+
+    client.focused ${colorSetStr colors.focused}
+  '' else "") + "\n" );
+    # ${keybindingsStr keybindings}
+    # ${concatStringsSep "\n" (mapAttrsToList modeStr modes)}
+    # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+    # ${concatStringsSep "\n" (map barStr bars)}
+    # ${optionalString (gaps != null) gapsStr}
+    # ${concatStringsSep "\n" (map floatingCriteriaStr floating.criteria)}
+    # ${concatStringsSep "\n" (map startupEntryStr startup)}
+
+in
+
+
+  config = mkIf cfg.enable {
+    home.packages = [ notmuch ];
+
+    # create folder where to store mails
+      home.activation.createMailStore = dagEntryBefore [ "linkGeneration" ] ''
+        echo 'hello world, notmuch link activation'
+        # if ! cmp --quiet \
+        #     "${configFile}" \
+        #     "${config.xdg.configHome}/i3/config"; then
+        #   i3Changed=1
+        # fi
+      '';
+
+      xdg.configFile."notmuch/config".source = configFile;
+      # ''
+      # '';
+  };
+}
+
+

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -99,10 +99,10 @@ in
         do
           originalHook=${account.configStore}/$hookName
           destHook=${getStore account}/.notmuch/hooks/$hookName
+          echo "If hook $originalHook exists, create [$destHook] wrapper"
           if [ -f "$originalHook" ] && [ ! -f "$destHook" ]; then
             makeWrapper "$originalHook" \
-              "$destHook" \
-            --set NOTMUCH_CONFIG ${getNotmuchConfig account}
+              "$destHook" --set NOTMUCH_CONFIG "${getNotmuchConfig account}"
           fi
 
         done

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -100,10 +100,10 @@ in
           originalHook=${account.configStore}/$hookName
           destHook=${getStore account}/.notmuch/hooks/$hookName
           echo "If hook $originalHook exists, create [$destHook] wrapper"
-          if [ -f "$originalHook" ] && [ ! -f "$destHook" ]; then
+          # if [ -f "$originalHook" ] && [ ! -f "$destHook" ]; then
             makeWrapper "$originalHook" \
               "$destHook" --set NOTMUCH_CONFIG "${getNotmuchConfig account}"
-          fi
+          # fi
 
         done
     '';

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -112,16 +112,16 @@ in
     in 
     dagEntryAfter [ "createMailStores" ] (
       concatStrings  (map wrapHook config.mail.accounts) 
-    )
-      # ''
-      # ''
-    ;
+    );
 
-    # TODO need to add the hooks
+
+    # TODO target the hookFolder
+    # xdg.homeFile = map (account: {
+    #   config.mail.accounts) 
+    # }) 
 
     # Hooks  are  scripts  (or arbitrary executables or symlinks to such) that notmuch invokes before and after certain actions. These scripts reside in the .notmuch/hooks
       # directory within the database directory and must have executable permissions 
-
     xdg.configFile = map (account: {
       target = "notmuch/notmuch_${account.name}";
       text = configFile account; 

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -88,22 +88,24 @@ in
 
     home.activation.createNotmuchHooks =
     let
+      # for now we don't wrap them and instead NOTMUCH_CONFIG
       wrapHook = account: ''
         mkdir -p ${getStore account}/.notmuch/hooks
         ''
         + lib.optionalString  (account.configStore != null) ''
     # buildInputs = [makeWrapper];
-          source ${pkgs.makeWrapper}/nix-support/setup-hook
+          # source ${pkgs.makeWrapper}/nix-support/setup-hook
 
         for hookName in post-new pre-new post-insert
         do
           originalHook=${account.configStore}/$hookName
+          # mauvaise destination ?
           destHook=${getStore account}/.notmuch/hooks/$hookName
           echo "If hook $originalHook exists, create [$destHook] wrapper"
-          # if [ -f "$originalHook" ] && [ ! -f "$destHook" ]; then
-            makeWrapper "$originalHook" \
-              "$destHook" --set NOTMUCH_CONFIG "${getNotmuchConfig account}"
-          # fi
+          if [ -f "$originalHook" ] && [ ! -f "$destHook" ]; then
+            ln -s "$originalHook" "$destHook"
+            # makeWrapper "$originalHook"  "$destHook" --set NOTMUCH_CONFIG "${getNotmuchConfig account}"
+          fi
 
         done
     '';

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -23,24 +23,55 @@ exclude_tags=deleted;spam;
 
 [maildir]
 synchronize_flags=true
-'';
+''
+# tODO need to pass the actual config
+  + lib.optionalString (cf.contactCompletion == "notmuch address") ''
+command = 'notmuch address --format=json --output=recipients date:1Y.. AND from:my@address.org'
+regexp = '\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?'
+shellcommand_external_filtering = False
+  ''
+  ;
+
 
   # TODO run notmuch new instead ?
   configFile = mailAccount:
   ''
       [database]
       # todo make it configurable
-      path=${config.home.homeDirectory}/maildir
+      path=${mailAccount.store}
 
       ${accountStr mailAccount}
-  '';
+  ''
+  + cfg.extraConfig
+  ;
 in
 {
 
   options = {
     programs.notmuch = {
       enable = mkEnableOption "Notmuch";
+
+      # rename getHooksFolder
+      getHooks = mkOption {
+        # type = types.function;
+        default = account: account.store.".notmuch/hooks";
+        description = "path to the hooks folder to use for a specific account";
+      };
+      # rename getHooksFolder
+      contactCompletion = mkOption {
+        type = types.enum [ "notmuch address" ];
+        # type = types.function;
+        default = "notmuch address";
+        description = "path to the hooks folder to use for a specific account";
+      };
+    # function that returns specific hooks
+      extraConfig = mkOption {
+        type = types.str;
+        default = "";
+        description = "string that will be appended to the config";
+      };
     };
+
   };
 
   config = mkIf cfg.enable {
@@ -48,14 +79,24 @@ in
 
 
     # create folder where to store mails
-      # home.activation.createMailStore = dagEntryBefore [ "linkGeneration" ] ''
-      #   echo 'hello world, notmuch link activation'
-      #   # if ! cmp --quiet \
-      #   #     "${configFile}" \
-      #   #     "${config.xdg.configHome}/i3/config"; then
-      #   #   i3Changed=1
-      #   # fi
-      # '';
+      home.activation.createMailStores = dagEntryBefore [ "linkGeneration" ] ''
+        echo 'hello world, notmuch link activation'
+        # if ! cmp --quiet \
+        #     "${configFile}" \
+        #     "${config.xdg.configHome}/i3/config"; then
+        #   i3Changed=1
+        # Link the hooks in their respective stores
+        # our own hook folders
+        ${map (account: (account.store.".notmuch/hooks".source = getHooks account)
+        # {
+        #   target = "";
+        #   text = "";
+        # }
+          )  top.config.home.mailAccounts}
+      '';
+
+      # Hooks  are  scripts  (or arbitrary executables or symlinks to such) that notmuch invokes before and after certain actions. These scripts reside in the .notmuch/hooks
+       # directory within the database directory and must have executable permissions 
       xdg.configFile = map (account: {
         target = "notmuch/notmuch_${account.name}";
         text = configFile account; 

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -34,37 +34,18 @@ synchronize_flags=true
 
       ${accountStr mailAccount}
   '';
-
-  mails = top.config.home.mailAccounts;
-  # mails = [];
-  genRc = {userName, address, realname, ...} @ account:
-  {
-    xdg.configFile."notmuch/${userName}".text = configFile account; 
-  };
-
-  notmuchRcFiles = mailAccounts:
-    lib.lists.foldr (a: b: a // genRc b ) {} mailAccounts;
-
-  toto = notmuchRcFiles  mails;
 in
 {
-# TODO per account specifics
-# [new]
-# tags=unread;inbox;
-# ignore=
 
   options = {
     programs.notmuch = {
       enable = mkEnableOption "Notmuch";
-
     };
   };
 
-  # use listToAttrs
-  config = mkIf cfg.enable ({
+  config = mkIf cfg.enable {
     home.packages = [ pkgs.notmuch ];
 
-    # mapAttrs
 
     # create folder where to store mails
       # home.activation.createMailStore = dagEntryBefore [ "linkGeneration" ] ''
@@ -75,9 +56,11 @@ in
       #   #   i3Changed=1
       #   # fi
       # '';
-
-      # ca s appelle notmuchrc plutot
-  } // toto);
+      xdg.configFile = map (account: {
+        target = "notmuch/notmuch_${account.name}";
+        text = configFile account; 
+      }) top.config.home.mailAccounts;
+  };
 }
 
 

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -6,14 +6,10 @@ with import ../lib/dag.nix { inherit lib; };
 let
 
   cfg = config.programs.notmuch;
-  configFile = pkgs.writeText "notmuch.conf" 
-  # ((if cfg.config != null then with cfg.config; 
-  ''
 
-      [database]
-      # todo use account name instead
-      # create the folder or ?
-      path=${config.home.homeDirectory}/maildir
+
+  accountStr = {userName, address, realname, ...} @ account:
+    ''
 [user]
 name=matt
 primary_email=mattator@gmail.com
@@ -28,6 +24,19 @@ exclude_tags=deleted;spam;
 
 [maildir]
 synchronize_flags=true
+'';
+
+  # TODO run notmuch new instead ?
+  configFile = mailAccounts:
+  # ((if cfg.config != null then with cfg.config; 
+  ''
+      [database]
+      # todo use account name instead
+      # create the folder or ?
+      # todo make it configurable
+      path=${config.home.homeDirectory}/maildir
+
+    ${concatStringsSep "\n" (map accountStr mailAccounts)}
 
   '';
   # else "") + "\n" );
@@ -61,19 +70,17 @@ in
     home.packages = [ pkgs.notmuch ];
 
     # create folder where to store mails
-      home.activation.createMailStore = dagEntryBefore [ "linkGeneration" ] ''
-        echo 'hello world, notmuch link activation'
-        # if ! cmp --quiet \
-        #     "${configFile}" \
-        #     "${config.xdg.configHome}/i3/config"; then
-        #   i3Changed=1
-        # fi
-      '';
+      # home.activation.createMailStore = dagEntryBefore [ "linkGeneration" ] ''
+      #   echo 'hello world, notmuch link activation'
+      #   # if ! cmp --quiet \
+      #   #     "${configFile}" \
+      #   #     "${config.xdg.configHome}/i3/config"; then
+      #   #   i3Changed=1
+      #   # fi
+      # '';
 
       # ca s appelle notmuchrc plutot
-      xdg.configFile."notmuch/notmuchrc".source = configFile;
-      # ''
-      # '';
+      xdg.configFile."notmuch/notmuchrc".text = configFile config.home.mailAccounts;
   };
 }
 

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -1,12 +1,43 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-# with import ../lib/dag.nix { inherit lib; };
+with import ../lib/dag.nix { inherit lib; };
 
 let
 
   cfg = config.programs.notmuch;
+  configFile = pkgs.writeText "notmuch.conf" 
+  # ((if cfg.config != null then with cfg.config; 
+  ''
 
+      [database]
+      # todo use account name instead
+      # create the folder or ?
+      path=${config.home.homeDirectory}/maildir
+[user]
+name=matt
+primary_email=mattator@gmail.com
+# other_email=
+
+[new]
+tags=unread;inbox;
+ignore=
+
+[search]
+exclude_tags=deleted;spam;
+
+[maildir]
+synchronize_flags=true
+
+  '';
+  # else "") + "\n" );
+    # ${keybindingsStr keybindings}
+    # ${concatStringsSep "\n" (mapAttrsToList modeStr modes)}
+    # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+    # ${concatStringsSep "\n" (map barStr bars)}
+    # ${optionalString (gaps != null) gapsStr}
+    # ${concatStringsSep "\n" (map floatingCriteriaStr floating.criteria)}
+    # ${concatStringsSep "\n" (map startupEntryStr startup)}
 in
 
 {
@@ -25,48 +56,9 @@ in
 
 
 
-  let 
-  configFile = pkgs.writeText "notmuch.conf" ((if cfg.config != null then with cfg.config; ''
-
-      [database]
-      path=${home}
-[user]
-name=matt
-primary_email=mattator@gmail.com
-# other_email=
-
-[new]
-tags=unread;inbox;
-ignore=
-
-[search]
-exclude_tags=deleted;spam;
-
-[maildir]
-synchronize_flags=true
-    font pango:${concatStringsSep ", " fonts}
-    floating_modifier ${floating.modifier}
-    new_window ${if window.titlebar then "normal" else "pixel"} ${toString window.border}
-    new_float ${if floating.titlebar then "normal" else "pixel"} ${toString floating.border}
-    force_focus_wrapping ${if focus.forceWrapping then "yes" else "no"}
-    focus_follows_mouse ${if focus.followMouse then "yes" else "no"}
-    focus_on_window_activation ${focus.newWindow}
-
-    client.focused ${colorSetStr colors.focused}
-  '' else "") + "\n" );
-    # ${keybindingsStr keybindings}
-    # ${concatStringsSep "\n" (mapAttrsToList modeStr modes)}
-    # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
-    # ${concatStringsSep "\n" (map barStr bars)}
-    # ${optionalString (gaps != null) gapsStr}
-    # ${concatStringsSep "\n" (map floatingCriteriaStr floating.criteria)}
-    # ${concatStringsSep "\n" (map startupEntryStr startup)}
-
-in
-
 
   config = mkIf cfg.enable {
-    home.packages = [ notmuch ];
+    home.packages = [ pkgs.notmuch ];
 
     # create folder where to store mails
       home.activation.createMailStore = dagEntryBefore [ "linkGeneration" ] ''
@@ -78,7 +70,8 @@ in
         # fi
       '';
 
-      xdg.configFile."notmuch/config".source = configFile;
+      # ca s appelle notmuchrc plutot
+      xdg.configFile."notmuch/notmuchrc".source = configFile;
       # ''
       # '';
   };

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -8,6 +8,11 @@ let
 
   cfg = config.programs.offlineimap;
 
+  # TODO account.mta.postSyncHookCommand
+  postSyncHookCommand = account: pkgs.writeText "postSyncHook.sh" (
+  if (account.postSyncHook != null) then account.postSyncHook else if (config.programs.notmuch.enable) then config.programs.notmuch.postSyncHook else ""
+  );
+
   # TODO add postsynchook only if notmuch enabled ?
   # TODO allow for user customisation
   # make the path towards config a function ?
@@ -26,8 +31,8 @@ maxage=10
 synclabels= yes
 # presynchook=imapfilter
 # TODO write a function
-${if (config.programs.notmuch.enable && cfg.postSyncHook == null) then "postsynchook= notmuch --config=$XDG_CONFIG_HOME/notmuch/notmuch_${name} new" else cfg.postSyncHook}
 # labelsheader = X-Keywords
+postsynchook=${postSyncHookCommand account}
 
 [Repository ${name}-local]
 type = GmailMaildir
@@ -101,9 +106,9 @@ in
 
       # run on finish
       # TODO should be per account
-      postSyncHook = mkOption {
-        type = types.str;
-        default = null;
+      postSyncHookCommand = mkOption {
+        # type = types.str;
+        default = account: "";
         description = "function accepting a mail account as parameter";
       };
 
@@ -149,7 +154,7 @@ in
     '';
 
     # ca s appelle notmuchrc plutot
-    xdg.configFile."offlineimap/config".source = configFile config.home.mailAccounts;
+    xdg.configFile."offlineimap/config".source = configFile config.mail.accounts;
   };
 }
 

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -166,6 +166,3 @@ in
     xdg.configFile."offlineimap/config".source = configFile config.mail.accounts;
   };
 }
-
-
-

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -13,6 +13,7 @@ let
   if (account.postSyncHook != null) then account.postSyncHook else if (config.programs.notmuch.enable) then config.programs.notmuch.postSyncHook else ""
   );
 
+  # TODO maybe generate one config per account and load it with -c ?
   # TODO add postsynchook only if notmuch enabled ?
   # TODO allow for user customisation
   # make the path towards config a function ?
@@ -35,12 +36,14 @@ synclabels= yes
 postsynchook=${postSyncHookCommand account}
 
 [Repository ${name}-local]
-type = GmailMaildir
+# HACK
+type = ${if account.imapHost != null then "IMAP" else "GmailMaildir"}
 localfolders = ${account.store}
 
 [Repository ${name}-remote]
-type = Gmail
+type = ${if account.imapHost != null then "IMAP" else "Gmail"}
 # TODO user getLogin / getPass defined in module
+${if account.imapHost != null then "remotehost = "+ account.imapHost else ""}
 remoteusereval = ${cfg.getLogin account}
 remotepasseval = ${cfg.getPass account}
 realdelete = yes
@@ -81,7 +84,7 @@ folderfilter = lambda foldername: foldername not in ['[Gmail]/All Mail','[Gmail]
     ${concatStringsSep "\n" (map accountStr mailAccounts)}
 
   '' 
-  # + cfg.extraConfig
+  + cfg.extraConfig
   );
 
 in

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -11,9 +11,9 @@ let
 
   # TODO move to lib account.mta.postSyncHookCommand
   postSyncHookCommand = account: 
-    pkgs.writeText "postSyncHook.sh" (
+    pkgs.writeScript "postSyncHook.sh" (
 
-  lib.optionalString config.programs.notmuch.enable config.programs.notmuch.postSyncHook
+    lib.optionalString config.programs.notmuch.enable (config.programs.notmuch.postSyncHook account)
    + lib.optionalString (account.postSyncHook != null) account.postSyncHook
   );
   # if (account.postSyncHook != null) then account.postSyncHook else if (config.programs.notmuch.enable) then config.programs.notmuch.postSyncHook else ""
@@ -43,7 +43,7 @@ postsynchook= ${postSyncHookCommand account}
 
 [Repository ${name}-local]
 # HACK
-type = ${if account.imapHost != null then "IMAP" else "GmailMaildir"}
+type = ${if account.imapHost != null then "Maildir" else "GmailMaildir"}
 localfolders = ${getStore account}
 
 [Repository ${name}-remote]

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -1,3 +1,157 @@
 # TODO load template
+{ config, lib, pkgs, ... }:
+
+with lib;
+with import ../lib/dag.nix { inherit lib; };
+
+let
+
+  cfg = config.programs.offlineimap;
+
+  # TODO add postsynchook only if notmuch enabled ?
+  # TODO allow for user customisation
+  # make the path towards config a function ?
+  accountStr = {name, userName, address, realname, ...} @ account:
+    ''
+
+[Account ${name}]# {{{
+localrepository = ${name}-local
+remoterepository = ${name}-remote
+# interval between updates (in minutes)
+autorefresh=0
+# in bytes
+maxsize=2000000
+# in daysA
+maxage=10
+synclabels= yes
+# presynchook=imapfilter
+# TODO write a function
+${if (config.programs.notmuch.enable && cfg.postSyncHook == null) then "postsynchook= notmuch --config=$XDG_CONFIG_HOME/notmuch/notmuch_${name} new" else cfg.postSyncHook}
+# labelsheader = X-Keywords
+
+[Repository ${name}-local]
+type = GmailMaildir
+localfolders = ${account.store}
+
+[Repository ${name}-remote]
+type = Gmail
+# TODO user getLogin / getPass defined in module
+remoteusereval = ${cfg.getLogin account}
+remotepasseval = ${cfg.getPass account}
+realdelete = yes
+maxconnections = 3
+ssl= yes
+# seens to work without it ?
+sslcacertfile= /etc/ssl/certs/ca-certificates.crt
+# newer offlineimap > 6.5.4 needs this
+# cert_fingerprint = 89091347184d41768bfc0da9fad94bfe882dd358
+# name translations would need to be done in both repositories, but reverse
+#nametrans = lambda foldername: foldername.replace('bar', 'BAR')
+# prevent sync with All mail folder since it duplicates mail
+folderfilter = lambda foldername: foldername not in ['[Gmail]/All Mail','[Gmail]/Spam','[Gmail]/Important']
+      '';
+
+  # ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
+  configFile = mailAccounts: pkgs.writeText "offlineimap.conf" (  ''
+  [general]
+  accounts = gmail
+  maxsyncaccounts= 4
+  socktimeout = 10
+  pythonfile = $XDG_CONFIG_HOME/offlineimap/get_settings.py
+
+  metadata = $XDG_DATA_HOME/offlineimap
+  # choose one from machineui, blinkenlights, quiet, ttyui, basic
+  ui = ttyui
+
+  [mbnames]
+  #generate mailboxes file for mutt
+  enabled = yes
+  filename = $XDG_CONFIG_HOME/mutt/mailboxes
+  header = "mailboxes *\nmailboxes !\n"
+  peritem = mailboxes =%(accountname)s/%(foldername)s
+  sep = "\n"
+  footer = "\n"
+
+
+    ${concatStringsSep "\n" (map accountStr mailAccounts)}
+
+  '' 
+  # + cfg.extraConfig
+  );
+
+in
+
+{
+
+  options = {
+    programs.offlineimap = {
+      enable = mkEnableOption "Offlineimap";
+
+      getLogin = mkOption {
+        # type = types.function;
+        default = account: "get_pass('${account.name}', 'login')";
+        description = "function accepting a mail account as parameter";
+      };
+
+      getPass = mkOption {
+        # type = types.function;
+        default = account: "get_pass('${account.name}', 'password')";
+        description = "function accepting a mail account as parameter";
+      };
+
+      # run on finish
+      # TODO should be per account
+      postSyncHook = mkOption {
+        type = types.str;
+        default = null;
+        description = "function accepting a mail account as parameter";
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Extra configuration lines to add to ~/.config/alot/config.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    home.packages = let
+      pythonEnv = pkgs.python3.withPackages(ps: with ps; [ secretstorage keyring pygobject3 pkgs.offlineimap]);
+      in [
+      # pkgs.offlineimap 
+      # pkgs.python3Packages.toPythonApplication (pkgs.offlineimap.overrideAttrs (oldAttrs: {
+        # USERNAME 	echo " nix-shell -p python3Packages.secretstorage -p python36Packages.keyring -p python36Packages.pygobject3"
+        # propagatedBuildInputs = with pkgs.python3Packages; oldAttrs.propagatedBuildInputs ++ ;
+      # }))
+      pythonEnv
+
+      # pkgs.libsecret 
+    ];
+
+    # create script to retrieve keyring
+    # 
+    # "${config.xdg.configHome}/offlineimap/get_settings.py"
+    home.activation.createAlotScript = dagEntryBefore [ "linkGeneration" ] ''
+
+    '';
+
+    # todo rely on libsecret instead ? else we need to override offlineimap
+    xdg.configFile."offlineimap/get_settings.py".text = ''
+      import keyring
+
+      def get_pass (service, name):
+          v = keyring.get_password(service, name)
+          # print("TEEESSTTT", v)
+          # print("type", type(v))
+          return v
+    '';
+
+    # ca s appelle notmuchrc plutot
+    xdg.configFile."offlineimap/config".source = configFile config.home.mailAccounts;
+  };
+}
+
 
 

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -1,0 +1,3 @@
+# TODO load template
+
+

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -38,7 +38,7 @@ autorefresh=0
 # in bytes
 maxsize=2000000
 # in daysA
-maxage=10
+maxage=30
 synclabels= yes
 postsynchook= ${postSyncHookCommand account}
 

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -17,7 +17,7 @@ let
     mapAttrsToList (k: v: "alias ${k}='${v}'") cfg.shellAliases
   );
 
-  zdotdir = "$HOME/" + cfg.dotDir;
+  zdotdir = cfg.dotDir;
 
   historyModule = types.submodule ({ config, ... }: {
     options = {
@@ -340,7 +340,7 @@ in
         # History options should be set in .zshrc and after oh-my-zsh sourcing.
         # See https://github.com/rycee/home-manager/issues/177.
         HISTSIZE="${toString cfg.history.size}"
-        HISTFILE="$HOME/${cfg.history.path}"
+        HISTFILE="${cfg.history.path}"
         SAVEHIST="${toString cfg.history.save}"
 
         setopt HIST_FCNTL_LOCK


### PR DESCRIPTION
I did not intend to publish this but I am stuck on a problem I hope I can get help on.

This PR is code intended to help with programs on the client side, i.e., centralize mail accounts description to then generate configurations for programs such as notmuch/alot/neomutt/astroid/msmtp etc.
```

  home.mailAccounts = [
    {
      name = "gmail_perso";
      userName = "login";
      realname = "Luke skywalker";
      address = "home-manager-rocks@gmail.com";
      store = "maildir/gmail";
      sendHost = "smtp.gmail.com";
      # getLogin = "";
      # getPass = "";
    }
    ];


   # TODO conditionnally define these
   programs.notmuch = {
     enable = true;
   };

   programs.msmtp = {
     enable = true;
   };

   programs.alot = {
     enable = true;
   };

```
For notmuch, I want to generate one config file per account aka sthg like
```
{ config, lib, pkgs, mailAccounts, ... } @ top:
{
  config = mkIf cfg.enable ({

    xdg.configFile."notmuch/${accoun0.name}".text = configFile account0; 
   ....
    xdg.configFile."notmuch/${accountN.name}".text = configFile accountN; 
  } );
}
```
so I tried
```
{ config, lib, pkgs, mailAccounts, ... } @ top:
{ 
 config = mkIf cfg.enable ({
  } // genRcFiles top.config.home.mailAccounts;);
}
```
but this ends up with  in a recusion loop:
```
error: while evaluating the attribute 'text' of the derivation 'news-info.sh' at /home/teto/nixpkgs2/pkgs/stdenv/generic/make-derivation.nix:148:11:
while evaluating the attribute 'newsEntries' at /home/teto/dotfiles/home-manager/modules/default.nix:49:3:
while evaluating the attribute 'config.news.entries' at /home/teto/nixpkgs2/lib/modules.nix:87:25:
while evaluating 'yieldConfig' at /home/teto/nixpkgs2/lib/modules.nix:74:29, called from /home/teto/nixpkgs2/lib/modules.nix:73:16:
while evaluating the attribute '_module.check.value' at /home/teto/nixpkgs2/lib/modules.nix:312:9:
while evaluating the option `_module.check':
while evaluating the attribute 'isDefined' at /home/teto/nixpkgs2/lib/modules.nix:344:5:
while evaluating 'filterOverrides' at /home/teto/nixpkgs2/lib/modules.nix:419:21, called from /home/teto/nixpkgs2/lib/modules.nix:328:18:
while evaluating 'concatMap' at /home/teto/nixpkgs2/lib/lists.nix:102:18, called from /home/teto/nixpkgs2/lib/modules.nix:425:8:
while evaluating 'concatMap' at /home/teto/nixpkgs2/lib/lists.nix:102:18, called from /home/teto/nixpkgs2/lib/modules.nix:323:17:
while evaluating 'concatMap' at /home/teto/nixpkgs2/lib/lists.nix:102:18, called from /home/teto/nixpkgs2/lib/modules.nix:208:19:
while evaluating 'concatMap' at /home/teto/nixpkgs2/lib/lists.nix:102:18, called from /home/teto/nixpkgs2/lib/modules.nix:192:8:
while evaluating anonymous function at /home/teto/nixpkgs2/lib/modules.nix:192:19, called from undefined position:
while evaluating 'pushDownProperties' at /home/teto/nixpkgs2/lib/modules.nix:366:24, called from /home/teto/nixpkgs2/lib/modules.nix:192:75:
while evaluating 'concatMap' at /home/teto/nixpkgs2/lib/lists.nix:102:18, called from /home/teto/nixpkgs2/lib/modules.nix:368:7:
while evaluating 'pushDownProperties' at /home/teto/nixpkgs2/lib/modules.nix:366:24, called from undefined position:
while evaluating 'pushDownProperties' at /home/teto/nixpkgs2/lib/modules.nix:366:24, called from /home/teto/nixpkgs2/lib/modules.nix:370:52:
while evaluating the attribute 'content' at /home/teto/nixpkgs2/lib/modules.nix:467:14:
while evaluating 'notmuchRcFiles' at /home/teto/dotfiles/home-manager/modules/programs/notmuch.nix:45:20, called from /home/teto/dotfiles/home-manager/modules/programs/notmuch.nix:48:10:
while evaluating 'foldr' at /home/teto/nixpkgs2/lib/lists.nix:34:20, called from /home/teto/dotfiles/home-manager/modules/programs/notmuch.nix:46:5:
while evaluating 'fold'' at /home/teto/nixpkgs2/lib/lists.nix:37:15, called from /home/teto/nixpkgs2/lib/lists.nix:41:8:
while evaluating the attribute 'config.home.mailAccounts' at /home/teto/nixpkgs2/lib/modules.nix:162:9:
while evaluating the module argument `config' in "/home/teto/dotfiles/home-manager/modules/programs/notmuch.nix":
while evaluating the attribute 'config' at /home/teto/nixpkgs2/lib/modules.nix:62:71:
infinite recursion encountered, at /home/teto/nixpkgs2/lib/modules.nix:62:71
```

How can I work around that ?