### PR TITLE
zsh: allow (f)path-only plugins

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -80,7 +80,7 @@ let
       };
 
       file = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
         description = "The plugin script to source.";
       };
     };
@@ -319,7 +319,7 @@ in
             source $ZSH/oh-my-zsh.sh
         ''}
 
-        ${concatStrings (map (plugin: ''
+        ${concatStrings (map (plugin: lib.optionalString (plugin.file != null) ''
           source "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}"
         '') cfg.plugins)}
 


### PR DESCRIPTION
Some zsh plugins do not have a main file to be sourced and only need their path to be added to `fpath`. For example completion-only plugins can work that way.
I add the possibility to define a zsh plugin with `file = null` so that it only gets added to fpath without trying to source a nonexistent file. This does not change current behaviour.