### PR TITLE
xresources: add option extraConfig

### DIFF
--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -28,17 +28,40 @@ in
         "Emacs*toolBar" = 0;
       };
       description = ''
-        X server resources that should be set. If <code>null</code>,
-        then this feature is disabled and no
+        X server resources that should be set.
+        If this and all other xresources options are
+        <code>null</code>, then this feature is disabled and no
+        <filename>~/.Xresources</filename> link is produced.
+      '';
+    };
+
+    xresources.extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = literalExample ''
+        builtins.readFile (
+            pkgs.fetchFromGitHub {
+                owner = "solarized";
+                repo = "xresources";
+                rev = "025ceddbddf55f2eb4ab40b05889148aab9699fc";
+                sha256 = "0lxv37gmh38y9d3l8nbnsm1mskcv10g3i83j0kac0a2qmypv1k9f";
+            } + "/Xresources.dark"
+        )
+      '';
+      description = ''
+        Additional X server resources contents.
+        If this and all other xresources options are
+        <code>null</code>, then this feature is disabled and no
         <filename>~/.Xresources</filename> link is produced.
       '';
     };
   };
 
-  config = mkIf (cfg.properties != null) {
+  config = mkIf (cfg.properties != null || cfg.extraConfig != "") {
     home.file.".Xresources".text =
-      concatStringsSep "\n" (
-        mapAttrsToList formatLine cfg.properties
+      concatStringsSep "\n" ([]
+        ++ (optional (cfg.extraConfig != "") cfg.extraConfig)
+        ++ (optionals (cfg.properties != null) (mapAttrsToList formatLine cfg.properties))
       ) + "\n";
   };
 }


### PR DESCRIPTION
This adds an option xresources.include - this way bigger xresources file can easily included.

I added an example for solarized dark, directly from github.

A fair warning: I'm not very adept at nix yet, so I might have missed a thing or two, but I did my best. 

I'm not really sure if the example I've included is something that "works by accident" or something that "works by design" in nix, so I'd like your input on that :)