### PR TITLE
Fix typo: compton.shadowOffsets description

### DIFF
--- a/modules/services/compton.nix
+++ b/modules/services/compton.nix
@@ -94,7 +94,7 @@ in {
       default = [ (-15) (-15) ];
       example = [ (-10) (-15) ];
       description = ''
-        Left and right offset for shadows (in pixels).
+        Horizontal and vertical offsets for shadows (in pixels).
       '';
     };
 


### PR DESCRIPTION
Correction: compton's `shadow-offset-x` and `shadow-offset-y` options refer to horizontal and vertical offsets, not left and right offsets.