### PR TITLE
zsh: only source plugin file if it exists

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -320,7 +320,9 @@ in
         ''}
 
         ${concatStrings (map (plugin: ''
-          source "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}"
+          if [ -f "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}" ]; then
+            source "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}"
+          fi
         '') cfg.plugins)}
 
         # History options should be set in .zshrc and after oh-my-zsh sourcing.


### PR DESCRIPTION
This allows adding plugins to fpath without sourcing anything

My usecase is adding just the single plugin [pass](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/pass/_pass) from oh-my-zsh by doing:

```nix
{
  programs.zsh.plugins = [
    {
      name = "pass";
      src = "${pkgs.oh-my-zsh}/share/oh-my-zsh/plugins/pass";
    }
  ];
}
```

Edit: Nothing gets sourced because the default used file `pass.plugin.zsh` doesn't exist. Before this change it would've given an error.