### PR TITLE
kbfs: fix systemd service PATH

### DIFF
--- a/modules/services/kbfs.nix
+++ b/modules/services/kbfs.nix
@@ -48,7 +48,7 @@ in
         let
           mountPoint = "\"%h/${cfg.mountPoint}\"";
         in {
-          Environment = "PATH=/run/wrappers KEYBASE_SYSTEMD=1";
+          Environment = "PATH=/run/wrappers/bin KEYBASE_SYSTEMD=1";
           ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${mountPoint}";
           ExecStart ="${pkgs.kbfs}/bin/kbfsfuse ${toString cfg.extraFlags} ${mountPoint}";
           ExecStopPost = "/run/wrappers/bin/fusermount -u ${mountPoint}";


### PR DESCRIPTION
Not sure if this changed, but wrapper binaries are now in `/run/wrappers/bin` instead of `/run/wrappers`. This just fixes the service environment such that `kbfsfuse` can find the `fusermount` binary.