### PR TITLE
xcursor: add default cursor file option

### DIFF
--- a/modules/xcursor.nix
+++ b/modules/xcursor.nix
@@ -26,6 +26,13 @@ let
         example = 64;
         description = "The cursor size.";
       };
+
+      cursor = mkOption {
+        type = types.str;
+        default = "X_cursor";
+        example = "left_ptr";
+        description = "The default cursor file to use within the package.";
+      };
     };
   };
 
@@ -54,7 +61,7 @@ in
     home.packages = [cfg.package];
 
     xsession.initExtra = ''
-      ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cfg.package}/share/icons/${cfg.name}/cursors/X_cursor ${toString cfg.size}
+      ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cfg.package}/share/icons/${cfg.name}/cursors/${cfg.cursor} ${toString cfg.size}
     '';
 
     xresources.properties = {

--- a/modules/xcursor.nix
+++ b/modules/xcursor.nix
@@ -27,10 +27,10 @@ let
         description = "The cursor size.";
       };
 
-      cursor = mkOption {
+      defaultCursor = mkOption {
         type = types.str;
-        default = "X_cursor";
-        example = "left_ptr";
+        default = "left_ptr";
+        example = "X_cursor";
         description = "The default cursor file to use within the package.";
       };
     };
@@ -61,7 +61,7 @@ in
     home.packages = [cfg.package];
 
     xsession.initExtra = ''
-      ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cfg.package}/share/icons/${cfg.name}/cursors/${cfg.cursor} ${toString cfg.size}
+      ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cfg.package}/share/icons/${cfg.name}/cursors/${cfg.defaultCursor} ${toString cfg.size}
     '';
 
     xresources.properties = {


### PR DESCRIPTION
Using the xcursor module to configure the cursor within an XMonad environment I noticed that the default cursor [1] is a X symbol.

This can be changed to a normal arrow using: `xsetroot -cursor_name left_ptr`.

Sadly this approach only works when executed after the module has set the cursor. As I could not find a sensible way to control the sequence of lines added to `~/.xsession` via `xsession.initExtra` adding this small option seems to be the most straight forward way of changing the default cursor.

[1]: i.e. the cursor used when hovering over the wallpaper as well as over applications that do not define a cursor