### PR TITLE
add qtbase to PATH of flameshot

### DIFF
--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -33,6 +33,7 @@ in
       };
 
       Service = {
+        Environment = "PATH=%h/.nix-profile/bin";
         ExecStart = "${package}/bin/flameshot";
         Restart = "on-abort";
       };


### PR DESCRIPTION
I've found the flameshot service not working for me.

After some debugging, it seems that flameshot requires qtbase to be in PATH. (which on my system, as I don't have kde installed, is not the default)

This patch is working, but I'm not 100% sure if this is the right approach. This might also be regarded as an impurity in the flameshot dervation. What do you think?