### PR TITLE
i3: fix reloading for nixos module

### DIFF
--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -763,9 +763,10 @@ in
       '';
 
       home.activation.reloadI3 = dag.entryAfter [ "linkGeneration" ] ''
-        if [[ -v i3Changed && -v DISPLAY ]]; then
+        SOCKET=''${XDG_RUNTIME_DIR:-/run/user/$UID}/i3/ipc-socket.*
+        if [ -v i3Changed ] && [ -S $SOCKET ]; then
           echo "Reloading i3"
-          ${cfg.package}/bin/i3-msg reload 1>/dev/null
+          ${cfg.package}/bin/i3-msg -s $SOCKET reload 1>/dev/null
         fi
       '';
     }


### PR DESCRIPTION
By default, i3-msg gets socket from X11 property
which is not available when home manager is running
as nixos module.

This patch changes i3-msg command call by specifying
all i3 sockets found in /var/run/user/$UID/i3 folder.

Fixes #252.