### PR TITLE
bash: escape alias values

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -130,7 +130,7 @@ in
   config = (
     let
       aliasesStr = concatStringsSep "\n" (
-        mapAttrsToList (k: v: "alias ${k}='${v}'") cfg.shellAliases
+        mapAttrsToList (k: v: "alias ${k}=${escapeShellArg v}") cfg.shellAliases
       );
 
       shoptsStr = concatStringsSep "\n" (


### PR DESCRIPTION
This should allow use of the apostrophe character within aliases without having to escape them manually.

Fixes #273