### PR TITLE
Fix fontconfig paths for install as nixos-module

### DIFF
--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -50,8 +50,8 @@ in
         <?xml version='1.0'?>
         <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
         <fontconfig>
-          <dir>/etc/per-user-pkgs/${config.home.username}/lib/X11/fonts</dir>
-          <dir>/etc/per-user-pkgs/${config.home.username}/share/fonts</dir>
+          <dir>/etc/profiles/per-user/${config.home.username}/lib/X11/fonts</dir>
+          <dir>/etc/profiles/per-user/${config.home.username}/share/fonts</dir>
         </fontconfig>
       '';
     })


### PR DESCRIPTION
This fixes fonts breaking as a result of this change in nixos:

https://github.com/NixOS/nixpkgs/commit/55344df0893d008c709ae7036df5145df857ce0a