### PR TITLE
Fix path to profile dir when using as nixos submodule

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -121,6 +121,17 @@ in
       description = "The user's home directory.";
     };
 
+    home.profileDirectory = mkOption {
+      type = types.path;
+      defaultText = "~/.nix-profile";
+      internal = true;
+      readOnly = true;
+      description = ''
+        The profile directory where Home Manager generations are
+        installed.
+      '';
+    };
+
     home.language = mkOption {
       type = languageSubModule;
       default = {};
@@ -248,6 +259,9 @@ in
 
     home.username = mkDefault (builtins.getEnv "USER");
     home.homeDirectory = mkDefault (builtins.getEnv "HOME");
+    home.profileDirectory = mkDefault (if config.nixosSubmodule
+      then "/etc/profiles/per-user/${cfg.username}"
+      else cfg.homeDirectory + "/.nix-profile");
 
     home.sessionVariables =
       let

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -95,6 +95,17 @@ in
             are symbolic links to the files of the source directory.
           '';
         };
+
+        onChange = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            Shell commands to run when file has changed between
+            generations. The script will be run
+            <emphasis>after</emphasis> the new files have been linked
+            into place.
+          '';
+        };
       };
 
       config = {

--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -33,8 +33,8 @@ in
       <?xml version='1.0'?>
       <!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
       <fontconfig>
-        <dir>~/.nix-profile/lib/X11/fonts</dir>
-        <dir>~/.nix-profile/share/fonts</dir>
+        <dir>${config.home.profileDirectory}/lib/X11/fonts</dir>
+        <dir>${config.home.profileDirectory}/share/fonts</dir>
       </fontconfig>
     '';
   };

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -182,7 +182,7 @@ in
       home.file.".profile".text = ''
         # -*- mode: sh -*-
 
-        . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+        . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
         ${sessionVarsStr}
 

--- a/modules/programs/info.nix
+++ b/modules/programs/info.nix
@@ -29,7 +29,7 @@ let
   dag = config.lib.dag;
 
   # Indexes info files found in this location
-  homeInfoPath = "$HOME/.nix-profile/share/info";
+  homeInfoPath = "${config.home.profileDirectory}/share/info";
 
   # Installs this package -- the interactive just means that it
   # includes the curses `info` program. We also use `install-info`

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -314,7 +314,7 @@ in
         }
 
         # Environment variables
-        . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+        . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
         ${envVarsStr}
 
         ${optionalString cfg.oh-my-zsh.enable ''

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -99,7 +99,7 @@ in
 
             basePaths = [
               "/run/current-system/sw"
-              "${config.home.homeDirectory}/.nix-profile"
+              config.home.profileDirectory
               cfg.iconTheme.package
             ] ++ optional useCustomTheme hicolorTheme.package;
 

--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -33,7 +33,7 @@ in
       };
 
       Service = {
-        Environment = "PATH=%h/.nix-profile/bin";
+        Environment = "PATH=${config.home.profileDirectory}/bin";
         ExecStart = "${package}/bin/flameshot";
         Restart = "on-abort";
       };

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -41,7 +41,7 @@ in
         };
 
         Service = {
-          Environment = "PATH=%h/.nix-profile/bin";
+          Environment = "PATH=${config.home.profileDirectory}/bin";
           ExecStart = "${package}/lib/libexec/kdeconnectd";
           Restart = "on-abort";
         };
@@ -64,7 +64,7 @@ in
         };
 
         Service = {
-          Environment = "PATH=%h/.nix-profile/bin";
+          Environment = "PATH=${config.home.profileDirectory}/bin";
           ExecStart = "${package}/bin/kdeconnect-indicator";
           Restart = "on-abort";
         };

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -131,13 +131,13 @@ in {
         After = [ "network.target" "sound.target" ];
         Description = "Music Player Daemon";
       };
- 
+
       Install = {
         WantedBy = [ "default.target" ];
       };
 
       Service = {
-        Environment = "PATH=%h/.nix-profile/bin";
+        Environment = "PATH=${config.home.profileDirectory}/bin";
         ExecStart = "${pkgs.mpd}/bin/mpd --no-daemon ${mpdConf}";
         Type = "notify";
         ExecStartPre = ''${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg.dataDir}' '${cfg.playlistDirectory}'"'';

--- a/modules/services/network-manager-applet.nix
+++ b/modules/services/network-manager-applet.nix
@@ -2,6 +2,12 @@
 
 with lib;
 
+let
+
+  cfg = config.services.network-manager-applet;
+
+in
+
 {
   meta.maintainers = [ maintainers.rycee ];
 
@@ -11,7 +17,7 @@ with lib;
     };
   };
 
-  config = mkIf config.services.network-manager-applet.enable {
+  config = mkIf cfg.enable {
     systemd.user.services.network-manager-applet = {
         Unit = {
           Description = "Network Manager applet";
@@ -24,7 +30,12 @@ with lib;
         };
 
         Service = {
-          ExecStart = "${pkgs.networkmanagerapplet}/bin/nm-applet --sm-disable";
+          ExecStart = toString (
+            [
+              "${pkgs.networkmanagerapplet}/bin/nm-applet"
+              "--sm-disable"
+            ] ++ optional config.xsession.preferStatusNotifierItems "--indicator"
+          );
         };
     };
   };

--- a/modules/services/owncloud-client.nix
+++ b/modules/services/owncloud-client.nix
@@ -18,7 +18,7 @@ with lib;
       };
 
       Service = {
-        Environment = "PATH=%h/.nix-profile/bin";
+        Environment = "PATH=${config.home.profileDirectory}/bin";
         ExecStart = "${pkgs.owncloud-client}/bin/owncloud";
       };
 

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -119,6 +119,7 @@ in
         Description = "Polybar status bar";
         After = [ "graphical-session-pre.target" ];
         PartOf = [ "graphical-session.target" ];
+        X-Restart-Triggers = [ config.xdg.configFile."polybar/config".source ];
       };
 
       Service = {
@@ -131,21 +132,6 @@ in
         WantedBy = [ "graphical-session.target" ];
       };
     };
-
-    home.activation.checkPolybar = dag.entryBefore [ "linkGeneration" ] ''
-      if ! cmp --quiet \
-          "${configFile}" \
-          "$HOME/.config/polybar/config"; then
-        polybarChanged=1
-      fi
-    '';
-
-    home.activation.applyPolybar = dag.entryAfter [ "reloadSystemD" ] ''
-      if [[ -v polybarChanged && -v DISPLAY ]]; then
-        echo "Restarting polybar"
-        ${config.systemd.user.systemctlPath} --user restart polybar.service
-      fi
-    '';
   };
 
 }

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -54,7 +54,7 @@ with lib;
           };
 
           Service = {
-            Environment = "PATH=%h/.nix-profile/bin";
+            Environment = "PATH=${config.home.profileDirectory}/bin";
             ExecStart = "${pkgs.qsyncthingtray}/bin/QSyncthingTray";
           };
 

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -13,13 +13,23 @@ let
         (if cfg.notify then "n" else "N")
         ({ always = "t"; auto = "s"; never = "T"; }.${cfg.tray})
       ]
-      ++ optional cfg.sni "--appindicator"
+      ++ optional config.xsession.preferStatusNotifierItems "--appindicator"
     );
 
 in
 
 {
   meta.maintainers = [ maintainers.rycee ];
+
+  imports = [
+    (mkRemovedOptionModule [ "services" "udiskie" "sni" ] ''
+      Support for Status Notifier Items is now configured globally through the
+
+        xsession.preferStatusNotifierItems
+
+      option. Please change to use that instead.
+    '')
+  ];
 
   options = {
     services.udiskie = {
@@ -35,12 +45,6 @@ in
         type = types.bool;
         default = true;
         description = "Whether to show pop-up notifications.";
-      };
-
-      sni = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable sni (appindicator) support.";
       };
 
       tray = mkOption {

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -13,6 +13,7 @@ let
         (if cfg.notify then "n" else "N")
         ({ always = "t"; auto = "s"; never = "T"; }.${cfg.tray})
       ]
+      ++ optional cfg.sni "--appindicator"
     );
 
 in
@@ -34,6 +35,12 @@ in
         type = types.bool;
         default = true;
         description = "Whether to show pop-up notifications.";
+      };
+
+      sni = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable sni (appindicator) support.";
       };
 
       tray = mkOption {

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -90,23 +90,14 @@ in
 
     (mkIf (cfg.config != null) {
       home.file.".xmonad/xmonad.hs".source = cfg.config;
+      home.file.".xmonad/xmonad.hs".onChange = ''
+        echo "Recompiling xmonad"
+        $DRY_RUN_CMD ${config.xsession.windowManager.command} --recompile
 
-      home.activation.checkXmonad = dag.entryBefore [ "linkGeneration" ] ''
-        if ! cmp --quiet "${cfg.config}" "$HOME/.xmonad/xmonad.hs"; then
-          xmonadChanged=1
-        fi
-      '';
-
-      home.activation.applyXmonad = dag.entryAfter [ "linkGeneration" ] ''
-        if [[ -v xmonadChanged ]]; then
-          echo "Recompiling xmonad"
-          ${config.xsession.windowManager.command} --recompile
-
-          # Attempt to restart xmonad if X is running.
-          if [[ -v DISPLAY ]] ; then
-            echo "Restarting xmonad"
-            ${config.xsession.windowManager.command} --restart
-          fi
+        # Attempt to restart xmonad if X is running.
+        if [[ -v DISPLAY ]] ; then
+          echo "Restarting xmonad"
+          $DRY_RUN_CMD ${config.xsession.windowManager.command} --restart
         fi
       '';
     })

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -8,11 +8,17 @@ let
 
   formatLine = n: v:
     let
-      v' =
+      formatList = x:
+        if isList x
+        then throw "can not convert 2-dimensional lists to Xresources format"
+        else formatValue x;
+
+      formatValue = v:
         if isBool v then (if v then "true" else "false")
+        else if isList v then concatMapStringsSep ", " formatList v
         else toString v;
     in
-      "${n}: ${v'}";
+      "${n}: ${formatValue v}";
 
 in
 
@@ -24,11 +30,16 @@ in
       type = types.nullOr types.attrs;
       default = null;
       example = {
-        "XTerm*faceName" = "dejavu sans mono";
         "Emacs*toolBar" = 0;
+        "XTerm*faceName" = "dejavu sans mono";
+        "XTerm*charClass" = [ "37:48" "45-47:48" "58:48" "64:48" "126:48" ];
       };
       description = ''
         X server resources that should be set.
+        Booleans are formatted as "true" or "false" respectively.
+        List elements are recursively formatted as a string and joined by commas.
+        All other values are directly formatted using builtins.toString. 
+        Note, that 2-dimensional lists are not supported and specifying one will throw an exception.
         If this and all other xresources options are
         <code>null</code>, then this feature is disabled and no
         <filename>~/.Xresources</filename> link is produced.

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -93,7 +93,7 @@ in
     };
 
     home.file.".xprofile".text = ''
-        . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+        . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
         if [[ -e "$HOME/.profile" ]]; then
           . "$HOME/.profile"

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -30,6 +30,17 @@ in
         '';
       };
 
+      preferStatusNotifierItems = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether tray applets should prefer using the Status Notifier
+          Items (SNI) protocol, commonly called App Indicators. Note,
+          not all tray applets or status bars support SNI.
+        '';
+      };
+
       profileExtra = mkOption {
         type = types.lines;
         default = "";

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -32,6 +32,10 @@ in
   };
 
   config = mkIf (cfg.users != {}) {
+    users.users = mapAttrs (username: usercfg: {
+      packages = usercfg.home.packages;
+    }) cfg.users;
+
     systemd.services = mapAttrs' (username: usercfg:
       nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {
         description = "Home Manager environment for ${username}";


### PR DESCRIPTION
The normal session-variable management with 
```
. "$HOME/.nix-profile/etc/profile.de/hm-session-vars.sh"
```
does not work when using the nixos-module. I have fixed all occasions of `~/.nix-profile` i found by using `grep`.

I don't know, if this is the best way. I would actually prefer just replacing `$HOME/.nix-profile` with `${config.home.path}` everywhere. Don't know if that would break anything.