### PR TITLE
qt: add option `qt.systemdServicePath`

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -24,6 +24,22 @@ in
           settings.
         '';
       };
+
+      systemdServicePath = mkOption {
+        type = types.envVar;
+        default = lib.makeSearchPath "bin" [
+          "/etc/profiles/per-user/%u"
+          "%h/.nix-profile"
+          "/nix/var/nix/profiles/default"
+          "/run/current-system/sw"
+        ];
+        visible = false;
+        description = ''
+          Path to use for systemd services that run Qt 5 applications.
+          This is to ensure that the application is able to locate any
+          necessary Qt plugins.
+        '';
+      };
     };
   };
 

--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -33,7 +33,7 @@ in
       };
 
       Service = {
-        Environment = "PATH=%h/.nix-profile/bin";
+        Environment = "PATH=${config.qt.systemdServicePath}";
         ExecStart = "${package}/bin/flameshot";
         Restart = "on-abort";
       };

--- a/modules/services/owncloud-client.nix
+++ b/modules/services/owncloud-client.nix
@@ -18,7 +18,7 @@ with lib;
       };
 
       Service = {
-        Environment = "PATH=%h/.nix-profile/bin";
+        Environment = "PATH=${config.qt.systemdServicePath}";
         ExecStart = "${pkgs.owncloud-client}/bin/owncloud";
       };
 

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -54,7 +54,7 @@ with lib;
           };
 
           Service = {
-            Environment = "PATH=%h/.nix-profile/bin";
+            Environment = "PATH=${config.qt.systemdServicePath}";
             ExecStart = "${pkgs.qsyncthingtray}/bin/QSyncthingTray";
           };
 


### PR DESCRIPTION
This option contains a string suitable as value for the PATH environment variable in systemd services that run Qt 5 applications.

Qt applications need this special treatment because they use PATH to locate plugins that sometimes are necessary for proper functioning.

For now the option is not visible in the manual since the default value is expected to work in most, if not all, cases.