### PR TITLE
kdeconnect: Add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -657,6 +657,14 @@ in
           GTK+ theme, and not much else.
         '';
       }
+
+      {
+        time = "2018-06-05T01:36:45+00:00";
+        message = ''
+          A new module is available: 'services.kdeconnect'.
+        '';
+      }
+
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -56,6 +56,7 @@ let
     ./services/gnome-keyring.nix
     ./services/gpg-agent.nix
     ./services/kbfs.nix
+    ./services/kdeconnect.nix
     ./services/keepassx.nix
     ./services/keybase.nix
     ./services/mbsync.nix

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -1,0 +1,75 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.kdeconnect;
+  package = pkgs.kdeconnect;
+
+in
+
+{
+  meta.maintainers = [ maintainers.adisbladis ];
+
+  options = {
+    services.kdeconnect = {
+      enable = mkEnableOption "KDE connect";
+
+      indicator = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable kdeconnect-indicator service.";
+      };
+
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      home.packages = [ package ];
+
+      systemd.user.services.kdeconnect = {
+        Unit = {
+          Description = "Adds communication between your desktop and your smartphone";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          Environment = "PATH=%h/.nix-profile/bin";
+          ExecStart = "${package}/lib/libexec/kdeconnectd";
+          Restart = "on-abort";
+        };
+      };
+    })
+
+    (mkIf cfg.indicator {
+      systemd.user.services.kdeconnect-indicator = {
+        Unit = {
+          Description = "kdeconnect-indicator";
+          After = [ "graphical-session-pre.target"
+                    "polybar.service"
+                    "taffybar.service"
+                    "stalonetray.service" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          Environment = "PATH=%h/.nix-profile/bin";
+          ExecStart = "${package}/bin/kdeconnect-indicator";
+          Restart = "on-abort";
+        };
+      };
+    })
+
+  ];
+}


### PR DESCRIPTION
KDE connect is a tool for integrating Linux desktops, for example receiving notifications, control music players etc etc. 

This module is useful for non-KDE desktops where you want smartphone integration.