### PR TITLE
bash: fix shellAliases description

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -84,8 +84,7 @@ in
         example = { ll = "ls -l"; ".." = "cd .."; };
         description = ''
           An attribute set that maps aliases (the top level attribute names in
-          this option) to command strings or directly to build outputs. The
-          aliases are added to all users' shells.
+          this option) to command strings or directly to build outputs.
         '';
         type = types.attrs;
       };


### PR DESCRIPTION
The aliases aren't added to _all_ users' shells (this was probably copied from the NixOS `environment.shellAliases` option).