### PR TITLE
i3: use null to disable a keybinding

### DIFF
--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -637,11 +637,11 @@ let
   };
 
   keybindingsStr = keybindings: concatStringsSep "\n" (
-    mapAttrsToList (keycomb: action: "bindsym ${keycomb} ${action}") keybindings
+    mapAttrsToList (keycomb: action: optionalString (action != null) "bindsym ${keycomb} ${action}") keybindings
   );
 
   keycodebindingsStr = keycodebindings: concatStringsSep "\n" (
-    mapAttrsToList (keycomb: action: "bindcode ${keycomb} ${action}") keycodebindings
+    mapAttrsToList (keycomb: action: optionalString (action != null) "bindcode ${keycomb} ${action}") keycodebindings
   );
 
   colorSetStr = c: concatStringsSep " " [ c.border c.background c.text c.indicator c.childBorder ];


### PR DESCRIPTION
When overriding i3 default keybindings with `lib.mkOptionDefault`, it is currently impossible to disable an default keybinding without replacing it with something else. This PR allows setting the keybinding to `null` for that purpose.