### PR TITLE
compton: fix syntax error

### DIFF
--- a/modules/services/compton.nix
+++ b/modules/services/compton.nix
@@ -30,7 +30,7 @@ let
       # blur
       blur-background         = true;
       blur-background-exclude = ${toJSON cfg.blurExclude};
-      no-dock-blur            = ${toString cfg.noDockBlur};
+      no-dock-blur            = ${toJSON cfg.noDockBlur};
     '' + ''
 
       # opacity


### PR DESCRIPTION
`builtins.toString` returns the empty string or `1` for boolean values, so `toJSON` is required instead.

In other places this was done correctly so this just seems to be a missed case.