### PR TITLE
nixpkgs: replace use of `traceValIfNot`

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -34,7 +34,11 @@ let
   configType = mkOptionType {
     name = "nixpkgs-config";
     description = "nixpkgs config";
-    check = traceValIfNot isConfig;
+    check = x:
+      let traceXIfNot = c:
+            if c x then true
+            else lib.traceSeqN 1 x false;
+      in traceXIfNot isConfig;
     merge = args: fold (def: mergeConfig def.value) {};
   };
 


### PR DESCRIPTION
The `traceValIfNot` function is deprecated in Nixpkgs master. Instead use `traceSeqN`.

Fixes #301