### PR TITLE
awesome: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -77,6 +77,7 @@ let
     ./services/tahoe-lafs.nix
     ./services/udiskie.nix
     ./services/unclutter.nix
+    ./services/window-managers/awesome.nix
     ./services/window-managers/i3.nix
     ./services/window-managers/xmonad.nix
     ./services/xscreensaver.nix

--- a/modules/services/window-managers/awesome.nix
+++ b/modules/services/window-managers/awesome.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.xsession.windowManager.awesome;
+  awesome = cfg.package;
+  getLuaPath = lib: dir: "${lib}/${dir}/lua/${pkgs.luaPackages.lua.luaversion}";
+  makeSearchPath = lib.concatMapStrings (path:
+    " --search ${getLuaPath path "share"}"
+    " --search ${getLuaPath path "lib"}"
+  );
+
+in
+
+{
+  options = {
+    xsession.windowManager.awesome = {
+      enable = mkEnableOption "Awesome window manager.";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.awesome;
+        defaultText = "pkgs.awesome";
+        description = "Package to use for running the Awesome WM.";
+      };
+
+      luaModules = mkOption {
+          default = [];
+          type = types.listOf types.package;
+          description = ''
+            List of lua packages available for being
+            used in the Awesome configuration.
+          '';
+          example = literalExample "[ luaPackages.oocairo ]";
+      };
+
+      noArgb = mkOption {
+          default = false;
+          type = types.bool;
+          description = ''
+            Disable client transparency support, which can be greatly
+            detrimental to performance in some setups
+          '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ awesome ];
+    xsession.windowManager.command = 
+      "${awesome}/bin/awesome "
+      + optionalString cfg.noArgb "--no-argb "
+      + makeSearchPath cfg.luaModules;
+  };
+}


### PR DESCRIPTION
From the [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/x11/window-managers/awesome.nix) repository and adapted for home-manager.

~~I don't know if we should create a [default configuration](https://awesomewm.org/doc/api/sample%20files/rc.lua.html) like the i3 module ?~~
I tested locally and it works without a configuration file