### PR TITLE
home-manager: resolve default configuration file path

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -32,7 +32,7 @@ function setConfigFile() {
     for confFile in "$defaultConfFile" \
                     "$HOME/.nixpkgs/home.nix" ; do
         if [[ -e "$confFile" ]] ; then
-            HOME_MANAGER_CONFIG="$confFile"
+            HOME_MANAGER_CONFIG="$(realpath "$confFile")"
             return
         fi
     done


### PR DESCRIPTION
Home Manager needs an absolute and resolved path to its configuration file. The default configuration path is absolute but not necessarily resolved. For example, some users may have `~/.config` be a symbolic link to somewhere else. We therefore run the default configuration path through the `realpath` tool to resolve it.

Fixes #304