### PR TITLE
nixpkgs: Only pass pkgs_i686 argument on Linux

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -144,7 +144,7 @@ in
   config = {
     _module.args = {
       pkgs = _pkgs;
-      pkgs_i686 = _pkgs.pkgsi686Linux;
+      pkgs_i686 = if _pkgs.stdenv.isLinux then _pkgs.pkgsi686Linux else {};
     };
   };
 }


### PR DESCRIPTION
nixpkgs added an assertion on pkgsi686Linux [1] to avoid evaluating it
pkgsi686Linux on non-Linux systems.

This change is needed for home-manager work on darwin.

[1] https://github.com/nixos/nixpkgs/commit/ad20a4a1c328967c7e4abe211f3dd63bb68bf966