### PR TITLE
status-notifier-watcher: add service

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -73,6 +73,7 @@ let
     ./services/redshift.nix
     ./services/screen-locker.nix
     ./services/stalonetray.nix
+    ./services/status-notifier-watcher.nix
     ./services/syncthing.nix
     ./services/taffybar.nix
     ./services/tahoe-lafs.nix

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.status-notifier-watcher;
+
+in
+
+{
+  meta.maintainers = [ maintainers.pltanton ];
+
+  options = {
+    services.status-notifier-watcher = {
+      enable = mkEnableOption "Status Notifier Watcher";
+
+      package = mkOption {
+        default = pkgs.haskellPackages.status-notifier-item;
+        defaultText = "pkgs.haskellPackages.status-notifier-item";
+        type = types.package;
+        example = literalExample "pkgs.haskellPackages.status-notifier-item";
+        description = "The package to use for the status notifier watcher binary.";
+      };
+    };
+  };
+
+  config = mkIf config.services.status-notifier-watcher.enable {
+    systemd.user.services.status-notifier-watcher = {
+        Unit = {
+          Description = "SNI watcher";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          ExecStart = "${cfg.package}/bin/status-notifier-watcher";
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+    };
+  };
+}

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -25,7 +25,7 @@ in
     };
   };
 
-  config = mkIf config.services.status-notifier-watcher.enable {
+  config = mkIf cfg.enable {
     systemd.user.services.status-notifier-watcher = {
         Unit = {
           Description = "SNI watcher";

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -31,6 +31,7 @@ in
           Description = "SNI watcher";
           After = [ "graphical-session-pre.target" ];
           PartOf = [ "graphical-session.target" ];
+          Before = [ "taffybar.service" ];
         };
 
         Service = {
@@ -38,7 +39,10 @@ in
         };
 
         Install = {
-          WantedBy = [ "graphical-session.target" ];
+          WantedBy = [ 
+            "graphical-session.target"
+            "graphical-session-pre.target"
+          ];
         };
     };
   };

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -29,6 +29,7 @@ in
     systemd.user.services.taffybar = {
         Unit = {
           Description = "Taffybar desktop bar";
+          Wanted = [ "graphical-session-pre.target" ];
           After = [ 
             "graphical-session-pre.target" 
             "status-notifier-watcher.service"

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -29,11 +29,7 @@ in
     systemd.user.services.taffybar = {
         Unit = {
           Description = "Taffybar desktop bar";
-          Wanted = [ "graphical-session-pre.target" ];
-          After = [ 
-            "graphical-session-pre.target" 
-            "status-notifier-watcher.service"
-          ];
+          After = [ "graphical-session-pre.target" ];
           PartOf = [ "graphical-session.target" ];
         };
 

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -29,7 +29,10 @@ in
     systemd.user.services.taffybar = {
         Unit = {
           Description = "Taffybar desktop bar";
-          After = [ "graphical-session-pre.target" ];
+          After = [ 
+            "graphical-session-pre.target" 
+            "status-notifier-watcher.service"
+          ];
           PartOf = [ "graphical-session.target" ];
         };
 


### PR DESCRIPTION
According to [that issue](https://github.com/taffybar/taffybar/issues/355). It is recommended for taffybars's sni tray widget to run separate daemon, that supports sni protocol.

haskellPackages.status-notifier-item is dependency of taffybar, so it should be quite conivenient to have a service for it.