### PR TITLE
udiskie: add sni support

### DIFF
--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -36,6 +36,12 @@ in
         description = "Whether to show pop-up notifications.";
       };
 
+      sni = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable sni (appindicator) support.";
+      };
+
       tray = mkOption {
         type = types.enum [ "always" "auto" "never" ];
         default = "auto";
@@ -73,7 +79,7 @@ in
         };
 
         Service = {
-          ExecStart = "${pkgs.udiskie}/bin/udiskie -2 ${commandArgs}";
+          ExecStart = "${pkgs.udiskie}/bin/udiskie -2 ${commandArgs} ${if cfg.sni then "--appindicator" else ""}";
         };
 
         Install = {

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -12,6 +12,8 @@ let
         (if cfg.automount then "a" else "A")
         (if cfg.notify then "n" else "N")
         ({ always = "t"; auto = "s"; never = "T"; }.${cfg.tray})
+      ] ++ [
+        (if cfg.sni then "--appindicator" else "")
       ]
     );
 
@@ -79,7 +81,7 @@ in
         };
 
         Service = {
-          ExecStart = "${pkgs.udiskie}/bin/udiskie -2 ${commandArgs} ${if cfg.sni then "--appindicator" else ""}";
+          ExecStart = "${pkgs.udiskie}/bin/udiskie -2 ${commandArgs}";
         };
 
         Install = {


### PR DESCRIPTION
Adds support of `--appindicator` flag, that starts `udiskie` in sni compatible mode.