### PR TITLE
xdg: create $XDG_CACHE_HOME

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.xdg;
 
+  dag = config.lib.dag;
+
   fileType = (import ../lib/file-type.nix {
     inherit (config.home) homeDirectory;
     inherit lib pkgs;
@@ -91,6 +93,9 @@ in
 
     {
       home.file = mkMerge [ cfg.configFile cfg.dataFile ];
+      home.activation.xdgCreateCache = dag.entryAfter [ "linkGeneration" ] ''
+        mkdir -m=700 -p ${config.xdg.cacheHome}
+      '';
     }
   ];
 }


### PR DESCRIPTION
some programs fail silently (bash with HISTFILE for instance) when the
folder doesn't exist.

Addresses https://github.com/rycee/home-manager/issues/339 ?