### PR TITLE
fzf: add options for setting commands for all keys

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -12,21 +12,51 @@ in
   options.programs.fzf = {
     enable = mkEnableOption "fzf - a command-line fuzzy finder";
 
+    defaultCommand = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "fd --type f";
+      description = ''
+        The command that gets executed as the default source for fzf
+        when running.
+      '';
+    };
+
     defaultOptions = mkOption {
       type = types.listOf types.str;
       default = [];
-      example = [ "--height 40%" "--border" ];
+      example = "--height 40% --border";
       description = ''
         Extra command line options given to fzf by default.
+      '';
+    };
+
+    fileWidgetCommand = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "fd --type f";
+      description = ''
+        The command that gets executed as the source for fzf for the
+        CTRL-T keybinding.
       '';
     };
 
     fileWidgetOptions = mkOption {
       type = types.listOf types.str;
       default = [];
-      example = [ "--preview 'head {}'" ];
+      example = [ "--preview" "'head {}'" ];
       description = ''
         Command line options for the CTRL-T keybinding.
+      '';
+    };
+
+    changeDirWidgetCommand = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "fd --type d" ;
+      description = ''
+        The command that gets executed as the source for fzf for the
+        ALT-C keybinding.
       '';
     };
 
@@ -36,6 +66,15 @@ in
       example = [ "--preview 'tree -C {} | head -200'" ];
       description = ''
         Command line options for the ALT-C keybinding.
+      '';
+    };
+
+    historyWidgetCommand = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The command that gets executed as the source for fzf for the
+        CTRL-R keybinding.
       '';
     };
 
@@ -70,10 +109,14 @@ in
 
     home.sessionVariables =
       mapAttrs (n: v: toString v) (
-        filterAttrs (n: v: v != []) {
+        filterAttrs (n: v: v != [] && v != null) {
+          FZF_ALT_C_COMMAND = cfg.changeDirWidgetCommand;
           FZF_ALT_C_OPTS = cfg.changeDirWidgetOptions;
+          FZF_CTRL_R_COMMAND = cfg.historyWidgetCommand;
           FZF_CTRL_R_OPTS = cfg.historyWidgetOptions;
+          FZF_CTRL_T_COMMAND = cfg.fileWidgetCommand;
           FZF_CTRL_T_OPTS = cfg.fileWidgetOptions;
+          FZF_DEFAULT_COMMAND = cfg.defaultCommand;
           FZF_DEFAULT_OPTS = cfg.defaultOptions;
         }
       );


### PR DESCRIPTION
This allows you to specify your own custom commands
to be run when calling fzf. You might use tools like
`fd` to search faster and take `.gitignore` files into
consideration.