### PR TITLE
Use submodules for program email accounts

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -123,7 +123,7 @@ let
   # gpgModule = types.submodule {
   # };
 
-  mailAccount = types.submodule ({ name, config, ... }: {
+  mailAccountOpts = { name, config, ... }: {
     options = {
       name = mkOption {
         type = types.str;
@@ -272,7 +272,7 @@ let
         };
       })
     ];
-  });
+  };
 
 in
 
@@ -294,7 +294,11 @@ in
     };
 
     accounts = mkOption {
-      type = types.attrsOf mailAccount;
+      type = types.attrsOf (types.submodule [
+        mailAccountOpts
+        (import ../programs/mbsync-accounts.nix)
+        (import ../programs/notmuch-accounts.nix)
+      ]);
       default = {};
       description = "List of email accounts.";
     };

--- a/modules/programs/mbsync-accounts.nix
+++ b/modules/programs/mbsync-accounts.nix
@@ -1,0 +1,57 @@
+{ lib, ... }:
+
+with lib;
+
+{
+  options.mbsync = {
+    enable = mkEnableOption "synchronization using mbsync";
+
+    flatten = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = ".";
+      description = ''
+        If set, flattens the hierarchy within the maildir by
+        substituting the canonical hierarchy delimiter
+        <literal>/</literal> with this value.
+      '';
+    };
+
+    create = mkOption {
+      type = types.enum [ "none" "maildir" "imap" "both" ];
+      default = "none";
+      example = "maildir";
+      description = ''
+        Automatically create missing mailboxes within the
+        given mail store.
+      '';
+    };
+
+    remove = mkOption {
+      type = types.enum [ "none" "maildir" "imap" "both" ];
+      default = "none";
+      example = "imap";
+      description = ''
+        Propagate mailbox deletions to the given mail store.
+      '';
+    };
+
+    expunge = mkOption {
+      type = types.enum [ "none" "maildir" "imap" "both" ];
+      default = "none";
+      example = "both";
+      description = ''
+        Permanently remove messages marked for deletion from
+        the given mail store.
+      '';
+    };
+
+    patterns = mkOption {
+      type = types.listOf types.str;
+      default = [ "*" ];
+      description = ''
+        Pattern of mailboxes to synchronize.
+      '';
+    };
+  };
+}

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -132,64 +132,6 @@ in
         '';
       };
     };
-
-    accounts.email.accounts = mkOption {
-      options = [
-        {
-          mbsync = {
-            enable = mkEnableOption "synchronization using mbsync";
-
-            flatten = mkOption {
-              type = types.nullOr types.str;
-              default = null;
-              example = ".";
-              description = ''
-                If set, flattens the hierarchy within the maildir by
-                substituting the canonical hierarchy delimiter
-                <literal>/</literal> with this value.
-              '';
-            };
-
-            create = mkOption {
-              type = types.enum [ "none" "maildir" "imap" "both" ];
-              default = "none";
-              example = "maildir";
-              description = ''
-                Automatically create missing mailboxes within the
-                given mail store.
-              '';
-            };
-
-            remove = mkOption {
-              type = types.enum [ "none" "maildir" "imap" "both" ];
-              default = "none";
-              example = "imap";
-              description = ''
-                Propagate mailbox deletions to the given mail store.
-              '';
-            };
-
-            expunge = mkOption {
-              type = types.enum [ "none" "maildir" "imap" "both" ];
-              default = "none";
-              example = "both";
-              description = ''
-                Permanently remove messages marked for deletion from
-                the given mail store.
-              '';
-            };
-
-            patterns = mkOption {
-              type = types.listOf types.str;
-              default = [ "*" ];
-              description = ''
-                Pattern of mailboxes to synchronize.
-              '';
-            };
-          };
-        }
-      ];
-    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/notmuch-accounts.nix
+++ b/modules/programs/notmuch-accounts.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+
+{
+  options.notmuch = {
+    enable = lib.mkEnableOption "notmuch indexing";
+  };
+}

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -129,16 +129,6 @@ in
         };
       };
     };
-
-    accounts.email.accounts = mkOption {
-      options = [
-        {
-          notmuch = {
-            enable = mkEnableOption "notmuch indexing";
-          };
-        }
-      ];
-    };
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
This reworks the way program specific email account options are specified. In particular, we no longer use the deprecated `options` field of `mkOption`. Instead submodules are used.