### PR TITLE
awesome: fix missing concatenation

### DIFF
--- a/modules/services/window-managers/awesome.nix
+++ b/modules/services/window-managers/awesome.nix
@@ -8,7 +8,7 @@ let
   awesome = cfg.package;
   getLuaPath = lib: dir: "${lib}/${dir}/lua/${pkgs.luaPackages.lua.luaversion}";
   makeSearchPath = lib.concatMapStrings (path:
-    " --search ${getLuaPath path "share"}"
+    " --search ${getLuaPath path "share"}" +
     " --search ${getLuaPath path "lib"}"
   );
 


### PR DESCRIPTION
The two strings weren't concatenated which had the effect of throwing an error (making the use of `luaModules` impossible).