### PR TITLE
gpg-agent: add extraConfig option

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -739,6 +739,17 @@ in
           A new module is available: 'programs.fish'.
         '';
       }
+
+      {
+        time = "2018-08-18T19:03:42+00:00";
+        condition = config.services.gpg-agent.enable;
+        message = ''
+          A new option is available: 'services.gpg-agent.extraConfig'.
+
+          Extra lines may be appended to $HOME/.gnupg/gpg-agent.conf
+          using this option.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -108,6 +108,19 @@ in
           <option>disable-scdaemon</option> setting to gpg-agent.
         '';
       };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          allow-emacs-pinentry
+          allow-loopback-pinentry
+        '';
+        description = ''
+          Extra configuration lines to append to the gpg-agent
+          configuration file.
+        '';
+      };
     };
   };
 
@@ -131,6 +144,8 @@ in
         ++
         optional (cfg.maxCacheTtlSsh != null)
           "max-cache-ttl-ssh ${toString cfg.maxCacheTtlSsh}"
+        ++
+        [ cfg.extraConfig ]
       );
 
       home.sessionVariables =


### PR DESCRIPTION
Add a `services.gpg-agent.extraConfig` option to append additional configuration lines to `$HOME/.gnupg/gpg-agent.conf`.