### PR TITLE
chromium: parseDrvName quick fix

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -48,7 +48,7 @@ let
   browserConfig = cfg:
     let
 
-      browser = (builtins.parseDrvName cfg.package).name;
+      browser = (builtins.parseDrvName cfg.package.name).name;
 
       darwinDirs = {
         chromium = "Chromium";


### PR DESCRIPTION
Quick fix to the `parseDrvName` call in chromium.nix. With this, it works great.