### PR TITLE
home-manager: enable build output during switch

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -180,8 +180,7 @@ function doSwitch() {
     else
         doBuildAttr \
                     --out-link "$generation" \
-                    --no-build-output \
-                    --attr activationPackage > /dev/null \
+                    --attr activationPackage \
             && "$generation/activate" || exitCode=1
     fi
 


### PR DESCRIPTION
Fixes #352