### PR TITLE
Fix gmail STARTTLS port

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -269,7 +269,7 @@ let
 
         smtp = {
           host = "smtp.gmail.com";
-          port = 587;
+          port = if config.smtp.tls.useStartTls then 587 else 465;
         };
       })
 


### PR DESCRIPTION
gmail uses port 587 for STARTTLS: https://support.google.com/mail/answer/7126229