### PR TITLE
go: Add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -793,6 +793,13 @@ in
           A new module is available: 'programs.zathura'.
         '';
       }
+
+      {
+        time = "2018-09-19:50:07+00:00";
+        message = ''
+          A new module is available: 'programs.go'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -38,6 +38,7 @@ let
     ./programs/fzf.nix
     ./programs/git.nix
     ./programs/gnome-terminal.nix
+    ./programs/go.nix
     ./programs/home-manager.nix
     ./programs/htop.nix
     ./programs/info.nix

--- a/modules/programs/go.nix
+++ b/modules/programs/go.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.go;
+
+in
+
+{
+  meta.maintainers = [ maintainers.rvolosatovs ];
+
+  options = {
+    programs.go = {
+      enable = mkEnableOption "Go";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.go;
+        defaultText = "pkgs.go";
+        description = "The Go package to use.";
+      };
+
+      packages = mkOption {
+        type = with types; attrsOf path;
+        default = {};
+        example = literalExample ''
+          {
+            "golang.org/x/time/rate" = builtins.fetchGit "https://go.googlesource.com/text";
+          }
+        '';
+        description = "Packages to add to GOPATH.";
+      };
+
+      goPath = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = "go";
+        description = "GOPATH relative to HOME";
+      };
+
+      goBin = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = ".local/bin.go";
+        description = "GOBIN relative to HOME";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = [ cfg.package ];
+
+      home.file =
+        let
+          goPath = if cfg.goPath != null then cfg.goPath else "go";
+
+          mkSrc = n: v: {
+            target = "${goPath}/src/${n}";
+            source = v;
+          };
+        in
+        mapAttrsToList mkSrc cfg.packages;
+    }
+    (mkIf (cfg.goPath != null) {
+      home.sessionVariables.GOPATH = builtins.toPath "${config.home.homeDirectory}/${cfg.goPath}";
+    })
+    (mkIf (cfg.goBin != null) {
+      home.sessionVariables.GOBIN = builtins.toPath "${config.home.homeDirectory}/${cfg.goBin}";
+    })
+  ]);
+}


### PR DESCRIPTION
Added a very basic `programs.go` module. It can:
- set `GOPATH`
- set `GOBIN`
- install the (possibly custom) `go` package
- link packages into `GOPATH`