### PR TITLE
neovim: support new extraPython*Packages options, fix configure

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -59,7 +59,7 @@ in
       extraPythonPackages = mkOption {
         type = with types; either extraPythonPackageType (listOf package);
         default = (_: []);
-        example = literalExample "(ps: [ pandas jedi ])";
+        example = literalExample "(ps: with ps; [ pandas jedi ])";
         description = ''
           A function in python.withPackages format, which returns a 
           list of Python 2 packages required for your plugins to work.
@@ -86,7 +86,7 @@ in
       extraPython3Packages = mkOption {
         type = with types; either extraPython3PackageType (listOf package);
         default = (_: []);
-        example = literalExample "(ps: [ python-language-server ])";
+        example = literalExample "(ps: with ps; [ python-language-server ])";
         description = ''
           A function in python.withPackages format, which returns a 
           list of Python 3 packages required for your plugins to work.

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -6,6 +6,24 @@ let
 
   cfg = config.programs.neovim;
 
+  extraPythonPackageType = mkOptionType {
+    name = "extra-python-packages";
+    description = "python packages in python.withPackages format";
+    check = with types; (x: if isFunction x
+      then isList (x pkgs.pythonPackages)
+      else false);
+    merge = mergeOneOption;
+  };
+
+  extraPython3PackageType = mkOptionType {
+    name = "extra-python3-packages";
+    description = "python3 packages in python.withPackages format";
+    check = with types; (x: if isFunction x
+      then isList (x pkgs.python3Packages)
+      else false);
+    merge = mergeOneOption;
+  };
+
 in
 
 {
@@ -39,12 +57,12 @@ in
       };
 
       extraPythonPackages = mkOption {
-        type = types.listOf types.package;
-        default = [ ];
-        example = literalExample "with pkgs.python2Packages; [ pandas jedi ]";
+        type = with types; either extraPythonPackageType (listOf package);
+        default = (_: []);
+        example = literalExample "(ps: [ pandas jedi ])";
         description = ''
-          List here Python 2 packages required for your plugins to
-          work.
+          A function in python.withPackages format, which returns a 
+          list of Python 2 packages required for your plugins to work.
         '';
       };
 
@@ -66,18 +84,18 @@ in
       };
 
       extraPython3Packages = mkOption {
-        type = types.listOf types.package;
-        default = [ ];
-        example = literalExample
-          "with pkgs.python3Packages; [ python-language-server ]";
+        type = with types; either extraPython3PackageType (listOf package);
+        default = (_: []);
+        example = literalExample "(ps: [ python-language-server ])";
         description = ''
-          List here Python 3 packages required for your plugins to work.
+          A function in python.withPackages format, which returns a 
+          list of Python 3 packages required for your plugins to work.
         '';
       };
 
       configure = mkOption {
-        type = types.nullOr types.attrs;
-        default = null;
+        type = types.attrs;
+        default = {};
         example = literalExample ''
           configure = {
               customRC = $''''
@@ -92,7 +110,7 @@ in
             };
         '';
         description = ''
-          Generate your init file from your list of plugins and custom commands, 
+          Generate your init file from your list of plugins and custom commands,
           and loads it from the store via <command>nvim -u /nix/store/hash-vimrc</command>
         '';
       };


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/43388 changed the expected type of `extraPython{,3}Packages` parameters from list to a function, as well as stopped support of `configure` to be passed as `null`.
See the diff in https://github.com/NixOS/nixpkgs/pull/43388