### PR TITLE
i3 module: add missing pieces to default config

### DIFF
--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -408,6 +408,11 @@ let
           "${cfg.config.modifier}+Up" = "focus up";
           "${cfg.config.modifier}+Right" = "focus right";
 
+          "${cfg.config.modifier}+Shift+Left" = "move left";
+          "${cfg.config.modifier}+Shift+Down" = "move down";
+          "${cfg.config.modifier}+Shift+Up" = "move up";
+          "${cfg.config.modifier}+Shift+Right" = "move right";
+
           "${cfg.config.modifier}+h" = "split h";
           "${cfg.config.modifier}+v" = "split v";
           "${cfg.config.modifier}+f" = "fullscreen toggle";
@@ -417,6 +422,7 @@ let
           "${cfg.config.modifier}+e" = "layout toggle split";
 
           "${cfg.config.modifier}+Shift+space" = "floating toggle";
+          "${cfg.config.modifier}+space" = "focus mode_toggle";
 
           "${cfg.config.modifier}+1" = "workspace 1";
           "${cfg.config.modifier}+2" = "workspace 2";


### PR DESCRIPTION
Add two missing bindings that are present in config generated by i3-config-wizard
1. window moves
2. switching focus between floating window and tiling windows