### PR TITLE
neovim: update types of arguments passed to wrapper

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -76,8 +76,8 @@ in
       };
 
       configure = mkOption {
-        type = types.nullOr types.attrs;
-        default = null;
+        type = types.attrs;
+        default = {};
         example = literalExample ''
           configure = {
               customRC = $''''
@@ -103,9 +103,10 @@ in
     home.packages = [
       (pkgs.neovim.override {
         inherit (cfg)
-          extraPython3Packages withPython3
-          extraPythonPackages withPython
+          withPython3 withPython
           withRuby viAlias vimAlias configure;
+	  extraPython3Packages = (_: cfg.extraPython3Packages);
+	  extraPythonPackages = (_: cfg.extraPythonPackages);
       })
     ];
   };


### PR DESCRIPTION
The neovim wrapper seems to have been updated, and this broke the module's interface to the wrapper. To reproduce the error simply enable neovim in HM with an updated unstable channel.

In the case of extraPythonPackages & extraPython3Packages the wrapper now expects functions that return a list of packages; in order to preserve existing HM configurations I made the mapping to a function in the override call rather than changing the option type.

In the case of configure it seems a null value is no longer accepted; I therefore updated the default to the empty set {}.