### PR TITLE
gtk module: add support for wayland

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -8,6 +8,8 @@ let
   cfg2 = config.gtk.gtk2;
   cfg3 = config.gtk.gtk3;
 
+  dag = config.lib.dag;
+
   toGtk3Ini = generators.toINI {
     mkKeyValue = key: value:
       let
@@ -26,6 +28,16 @@ let
         else toString v;
     in
       "${n} = ${v'}";
+
+  toDconfIni = generators.toINI {
+    mkKeyValue = key: value:
+      let
+        tweakVal = v:
+          if isString v then "'${v}'"
+          else toString v;
+      in
+        "${key}=${tweakVal value}";
+  };
 
   fontType = types.submodule {
     options = {
@@ -141,6 +153,16 @@ in
                 <filename>~/.config/gtk-3.0/gtk.css</filename>.
               '';
             };
+            waylandSupport = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Support GSettings provider (dconf) in addition
+                to GtkSettings (ini file). Needed for Wayland.
+                The following line is needed in system configuration:
+                  services.dbus.packages = [ pkgs.gnome3.dconf ];
+              '';
+            };
           };
         };
       };
@@ -158,6 +180,16 @@ in
         //
         optionalAttrs (cfg.iconTheme != null)
           { gtk-icon-theme-name = cfg.iconTheme.name; };
+
+      dconfIni =
+        optionalAttrs (cfg.font != null)
+          { font-name = cfg.font.name; }
+        //
+        optionalAttrs (cfg.theme != null)
+          { gtk-theme = cfg.theme.name; }
+        //
+        optionalAttrs (cfg.iconTheme != null)
+          { icon-theme = cfg.iconTheme.name; };
 
       optionalPackage = opt:
         optional (opt != null && opt.package != null) opt.package;
@@ -178,6 +210,23 @@ in
           toGtk3Ini { Settings = ini // cfg3.extraConfig; };
 
         xdg.configFile."gtk-3.0/gtk.css".text = cfg3.extraCss;
+
+        home.activation = optionalAttrs cfg3.waylandSupport {
+          gtk3 = dag.entryAfter ["installPackages"] (
+          let
+            iniText = toDconfIni { "/" = dconfIni; };
+            iniFile = pkgs.writeText "gtk3.ini" iniText;
+            dconfPath = "/org/gnome/desktop/interface/";
+          in
+            ''
+              if [[ -v DRY_RUN ]]; then
+                echo ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
+              else
+                ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
+              fi
+            ''
+          );
+        };
       }
     );
 }


### PR DESCRIPTION
Without this option styling options for gtk3 (font, theme) are not applied under wayland environments (I believe except gnome).

Some background info: https://bugzilla.gnome.org/show_bug.cgi?id=790201#c2