### PR TITLE
Make manual fully reproducible

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -6,7 +6,7 @@ let
   lib = pkgs.lib;
 
   # Remove invisible and internal options.
-  optionsListVisible = lib.filter (opt: opt.visible && !opt.internal) (lib.optionAttrSetToDocList options);
+  optionsListVisible = lib.filter (opt: opt.visible && !opt.internal && opt.name != "lib") (lib.optionAttrSetToDocList options);
 
   # Replace functions by the string <function>
   substFunction = x:


### PR DESCRIPTION
While investigating why I can't build exactly the same system configuration on different machines, I've discovered that `lib` option in manual is causing problems. Here is the picture:
![_003](https://user-images.githubusercontent.com/185443/46140743-33fb1580-c252-11e8-9031-d23c03f8f9e5.jpg)

`Declared by` is invalid and even references a path specific for a local machine. 

This patch is a proof-of-concept, when it is applied my system configuration is fully reproducible. Maybe there is a possible proper fix around `homeManagerManual` / `scrubbedEval`, but I don't know how to do it.


