### PR TITLE
dbus module: init

### DIFF
--- a/modules/dbus.nix
+++ b/modules/dbus.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.dbus;
+  dag = config.lib.dag;
+in
+{
+  meta.maintainers = [ maintainers.gnidorah ];
+
+  options = {
+    dbus.activation = mkOption {
+      default = {};
+      type = types.attrs;
+      description = ''
+        Activation scripts for the home environment involving dbus.
+        </para><para>
+        If dbus user service if available then it will be used,
+        otherwise home-manager activation will be used. Helps with
+        case when home-manager is used as NixOS module.
+        Same rules apply as for <option>home.activation</option>.
+      '';
+    };
+  };
+
+  config = {
+    systemd.user.services = mapAttrs (n: v:
+      let
+        script = pkgs.writeShellScriptBin n v;
+      in
+      {
+        Unit = {
+          Description = n;
+          Requires = [ "dbus.socket" ];
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${script}/bin/${n}";
+        };
+      }
+    ) cfg.activation;
+
+    home.activation = mapAttrs (n: v:
+      dag.entryAfter ["reloadSystemD"] (
+      let
+        ensureRuntimeDir = "XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR:-/run/user/$(id -u)}";
+      in
+      ''
+        if ${ensureRuntimeDir} ${config.systemd.user.systemctlPath} --quiet --user start dbus 2> /dev/null; then
+          echo "dbus module: starting user service for ${n}"
+          ${ensureRuntimeDir} ${config.systemd.user.systemctlPath} --user start ${n}
+        else
+          echo "dbus module: dbus user service is not available, using home-manager activation for ${n}"
+          ${v}
+        fi
+      ''
+      )
+    ) cfg.activation;
+  };
+}

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -90,7 +90,14 @@ in
 
   options = {
     gtk = {
-      enable = mkEnableOption "GTK 2/3 configuration";
+      enable = mkEnableOption ''GTK 2/3 configuration
+        </para><para>
+        In case of Wayland you should also use the
+        following option:
+        <programlisting>
+        systemd.user.startServices = true;
+        </programlisting>
+      '';
 
       font = mkOption {
         type = types.nullOr fontType;
@@ -153,21 +160,6 @@ in
                 <filename>~/.config/gtk-3.0/gtk.css</filename>.
               '';
             };
-
-            waylandSupport = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Support GSettings provider (dconf) in addition to
-                GtkSettings (INI file). This is needed for Wayland.
-                </para><para>
-                Note, on NixOS the following line must be in the
-                system configuration:
-                <programlisting>
-                services.dbus.packages = [ pkgs.gnome3.dconf ];
-                </programlisting>
-              '';
-            };
           };
         };
       };
@@ -216,22 +208,29 @@ in
 
         xdg.configFile."gtk-3.0/gtk.css".text = cfg3.extraCss;
 
-        home.activation = mkIf cfg3.waylandSupport {
-          gtk3 = dag.entryAfter ["installPackages"] (
-            let
-              iniText = toDconfIni { "/" = dconfIni; };
-              iniFile = pkgs.writeText "gtk3.ini" iniText;
-              dconfPath = "/org/gnome/desktop/interface/";
-            in
-              ''
-                if [[ -v DRY_RUN ]]; then
-                  echo ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
-                else
-                  ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
-                fi
-              ''
-          );
-        };
+        # Support GSettings provider (dconf) in addition to
+        # GtkSettings (INI file). This is needed for Wayland.
+        systemd.user.services.gtk3 =
+          let
+            iniText = toDconfIni { "/" = dconfIni; };
+            iniFile = pkgs.writeText "gtk3.ini" iniText;
+            dconfPath = "/org/gnome/desktop/interface/";
+          in {
+            Unit = {
+              Description = "GTK3 daemon";
+              Requires = [ "dbus.socket" ];
+            };
+
+            Service = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = "${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}";
+            };
+
+            Install = {
+              WantedBy = [ "default.target" ];
+            };
+          };
       }
     );
 }

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -8,8 +8,6 @@ let
   cfg2 = config.gtk.gtk2;
   cfg3 = config.gtk.gtk3;
 
-  dag = config.lib.dag;
-
   toGtk3Ini = generators.toINI {
     mkKeyValue = key: value:
       let
@@ -154,20 +152,6 @@ in
               '';
             };
 
-            waylandSupport = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Support GSettings provider (dconf) in addition to
-                GtkSettings (INI file). This is needed for Wayland.
-                </para><para>
-                Note, on NixOS the following line must be in the
-                system configuration:
-                <programlisting>
-                services.dbus.packages = [ pkgs.gnome3.dconf ];
-                </programlisting>
-              '';
-            };
           };
         };
       };
@@ -216,22 +200,19 @@ in
 
         xdg.configFile."gtk-3.0/gtk.css".text = cfg3.extraCss;
 
-        home.activation = mkIf cfg3.waylandSupport {
-          gtk3 = dag.entryAfter ["installPackages"] (
-            let
-              iniText = toDconfIni { "/" = dconfIni; };
-              iniFile = pkgs.writeText "gtk3.ini" iniText;
-              dconfPath = "/org/gnome/desktop/interface/";
-            in
-              ''
-                if [[ -v DRY_RUN ]]; then
-                  echo ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
-                else
-                  ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
-                fi
-              ''
-          );
-        };
+        dbus.activation.gtk3 =
+          let
+            iniText = toDconfIni { "/" = dconfIni; };
+            iniFile = pkgs.writeText "gtk3.ini" iniText;
+            dconfPath = "/org/gnome/desktop/interface/";
+          in
+            ''
+              if [[ -v DRY_RUN ]]; then
+                echo ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
+              else
+                ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
+              fi
+            '';
       }
     );
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -95,6 +95,7 @@ let
     ./services/window-managers/i3.nix
     ./services/window-managers/xmonad.nix
     ./services/xscreensaver.nix
+    ./dbus.nix
     ./systemd.nix
     ./xcursor.nix
     ./xresources.nix

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.programs.gnome-terminal;
 
-  dag = config.lib.dag;
-
   profileColorsSubModule = types.submodule (
     { ... }: {
       options = {
@@ -182,7 +180,7 @@ in
     home.packages = [ pkgs.gnome3.gnome_terminal ];
 
     # The dconf service needs to be installed and prepared.
-    home.activation.gnomeTerminal = dag.entryAfter ["installPackages"] (
+    dbus.activation.gnomeTerminal =
       let
         iniText = toDconfIni (buildIniSet cfg);
         iniFile = pkgs.writeText "gnome-terminal.ini" iniText;
@@ -194,7 +192,6 @@ in
           else
             ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
           fi
-        ''
-    );
+        '';
   };
 }


### PR DESCRIPTION
@rycee 
> Ah yeah, that old dbus thing coming back to haunt me again! :angry:

So idea is to switch modules that call dconf, from use of main home-manager systemd service, to user services. Because there is dbus.socket **user** service which propagates DBUS_SESSION_BUS_ADDRESS to other user services. Just compare 
`systemctl status dbus.socket`
and
`systemctl --user status dbus.socket`
Here's details https://serverfault.com/a/906224