### PR TITLE
home-manager: Add generation expiration command.

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -238,31 +238,19 @@ function doRmGenerations() {
 }
 
 function doExpireGenerations() {
-    local before
-    before=$(date -d "$@" +%s)
+    local profileDir="/nix/var/nix/profiles/per-user/$USER"
 
     local generations
-    generations=$(doListGens)
+    generations="$( \
+        find "$profileDir" -name 'home-manager-*-link' -not -newermt "$1" \
+        | sed 's/^.*-\([0-9]*\)-link$/\1/' \
+    )"
 
-    local count=0
-    for current in $(echo "$generations" | awk '{ print $1" "$2 }' | xargs -i date -d {} +%s); do
-        if [[ "$current" -ge "$before" ]]; then
-            count=$(( count + 1 ))
-        else
-            break
-        fi
-    done
-
-    if [[ "$count" -le "1" ]]; then
-        count=2
-    fi
-
-    if [ "$count" -lt $(echo "$generations" | wc -l) ]; then
-        doRmGenerations $(echo "$generations" | awk '{ print $5 }' | sed -n "$(( count + 1 )),$ p")
-    else
-        if [[ -v VERBOSE ]]; then
-            echo "No generations to expire"
-        fi
+    if [[ -n $generations ]]; then
+        # shellcheck disable=2086
+        doRmGenerations $generations
+    elif [[ -v VERBOSE ]]; then
+        echo "No generations to expire"
     fi
 }
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -237,6 +237,35 @@ function doRmGenerations() {
     popd > /dev/null
 }
 
+function doExpireGenerations() {
+    local before
+    before=$(date -d "$@" +%s)
+
+    local generations
+    generations=$(doListGens)
+
+    local count=0
+    for current in $(echo "$generations" | awk '{ print $1" "$2 }' | xargs -i date -d {} +%s); do
+        if [[ "$current" -ge "$before" ]]; then
+            count=$(( count + 1 ))
+        else
+            break
+        fi
+    done
+
+    if [[ "$count" -le "1" ]]; then
+        count=2
+    fi
+
+    if [ "$count" -lt $(echo "$generations" | wc -l) ]; then
+        doRmGenerations $(echo "$generations" | awk '{ print $5 }' | sed -n "$(( count + 1 )),$ p")
+    else
+        if [[ -v VERBOSE ]]; then
+            echo "No generations to expire"
+        fi
+    fi
+}
+
 function doListPackages() {
     local outPath
     outPath="$(nix-env -q --out-path | grep -o '/.*home-manager-path$')"
@@ -349,6 +378,9 @@ function doHelp() {
     echo "      Remove indicated generations. Use 'generations' command to"
     echo "      find suitable generation numbers."
     echo
+    echo "  expire-generations TIMESTAMP"
+    echo "      Remove generations older than TIMESTAMP (e.g., -2 days)."
+    echo
     echo "  packages     List all packages installed in home-manager-path"
     echo
     echo "  news         Show news entries in a pager"
@@ -421,6 +453,9 @@ case "$cmd" in
         ;;
     remove-generations)
         doRmGenerations "$@"
+        ;;
+    expire-generations)
+        doExpireGenerations "$@"
         ;;
     packages)
         doListPackages


### PR DESCRIPTION
This adds a rudimentary generation expiration command to the repertoire of home-manager.  This way we can remove generations older than a specified absolute or relative date independently of the system wide garbage collection.