### PR TITLE
mbsync: change service unit type to 'oneshot'

### DIFF
--- a/modules/services/mbsync.nix
+++ b/modules/services/mbsync.nix
@@ -87,7 +87,7 @@ in
       };
 
       Service = {
-        Type = "simple";
+        Type = "oneshot";
         ExecStart = "${cfg.package}/bin/mbsync ${concatStringsSep " " mbsyncOptions}";
       } // (optionalAttrs (cfg.postExec != null) { ExecStartPost = cfg.postExec; })
         // (optionalAttrs (cfg.preExec  != null) { ExecStartPre  = cfg.preExec;  });


### PR DESCRIPTION
The ExecStartPost command is currently started when the mbsync is
invoked succesfully. However, we typically want to run something like
'mu index' or 'notmuch new' after mbsync completes.  This changes the
unit type to oneshot, so that the ExecStartPost command is run after
mbsync finishes succesfully.