### PR TITLE
Add more detail to systemd user unit documentation.

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -55,6 +55,25 @@ let
     merge = loc: foldl' (res: def: recursiveUpdate res def.value) {};
   };
 
+  unitDescription = type: ''
+    Definition of systemd per-user ${type} units.  Attributes are merged
+    recursively.
+
+    Note that the attributes follow the capitalization and naming used by
+    systemd.  More details can be found in the man pages found at:
+    https://freedesktop.org/software/systemd/man/.
+  '';
+
+  unitExample = type: ''
+    {
+      Unit = {
+        Description = "Example Description";
+      };
+
+      ${type} = {};
+    };
+  '';
+
 in
 
 {
@@ -76,46 +95,36 @@ in
       services = mkOption {
         default = {};
         type = attrsRecursivelyMerged;
-        description = ''
-          Definition of systemd per-user service units. Attributes are
-          merged recursively.
-        '';
+        description = unitDescription "service";
+        example = unitExample "Service";
       };
 
       sockets = mkOption {
         default = {};
         type = attrsRecursivelyMerged;
-        description = ''
-          Definition of systemd per-user sockets. Attributes are
-          merged recursively.
-        '';
+        description = unitDescription "socket";
+        example = unitExample "Socket";
       };
 
       targets = mkOption {
         default = {};
         type = attrsRecursivelyMerged;
-        description = ''
-          Definition of systemd per-user targets. Attributes are
-          merged recursively.
-        '';
+        description = unitDescription "target";
+        example = unitExample "Target";
       };
 
       timers = mkOption {
         default = {};
         type = attrsRecursivelyMerged;
-        description = ''
-          Definition of systemd per-user timers. Attributes are merged
-          recursively.
-        '';
+        description = unitDescription "timer";
+        example = unitExample "Timer";
       };
 
       paths = mkOption {
         default = {};
         type = attrsRecursivelyMerged;
-        description = ''
-          Definition of systemd per-user path units. Attributes are
-          merged recursively.
-        '';
+        description = unitDescription "path";
+        example = unitExample "Path";
       };
 
       startServices = mkOption {


### PR DESCRIPTION
The current documentation doesn't provide guidance to users on how
systemd units are defined in home-manager.  The expectation may be that
the configuration is similar to NixOS which it most definitively is not.

This is a first draft at improving that situation but further improvements could easily be made.  Let me know if this is sufficient for the next iteration or if we should fill out more specific details for each unit type individually.

issues: #418