### PR TITLE
[WIP] zsh: fix history default path

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -36,8 +36,7 @@ let
 
       path = mkOption {
         type = types.str;
-        default = relToDotDir ".zsh_history";
-        defaultText = ".zsh_history";
+        default = ".zsh_history";
         description = "History file location";
       };
 
@@ -339,6 +338,7 @@ in
 
         # History options should be set in .zshrc and after oh-my-zsh sourcing.
         # See https://github.com/rycee/home-manager/issues/177.
+        mkdir -p `dirname ${cfg.history.path}`
         HISTSIZE="${toString cfg.history.size}"
         HISTFILE="$HOME/${cfg.history.path}"
         SAVEHIST="${toString cfg.history.save}"


### PR DESCRIPTION
ZSH history path shouldn't be relative to $ZDOTDIR
since it's not a configuration file.
This change also creates a directory for history file if it
doesn't exist.

Although I think this is a right thing to do, there is one problem with backward compatibility.
The change is harmless for those who haven't set `dotDir` option since then history file resides in the home directory. However, if someone set this option, then they will suddenly lose all their zsh history until they will copy it to `~/.zsh_history`, or will set `zsh.history.path` option to the desired location.