### PR TITLE
home-manager: remove uninstall activation phase

### DIFF
--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -39,17 +39,5 @@ in
         inherit (cfg) path;
       })
     ];
-
-    # Uninstall manually installed home-manager, if such exists.
-    # Without this a file collision error will be printed.
-    home.activation.uninstallHomeManager =
-      dag.entryBetween [ "installPackages" ] [ "writeBoundary" ] ''
-        if nix-env -q | grep -q "^home-manager$" ; then
-          $DRY_RUN_CMD nix-env -e home-manager
-
-          echo "You can now remove the 'home-manager' packageOverride"
-          echo "or overlay in '~/.config/nixpkgs/', if you want."
-        fi
-      '';
   };
 }


### PR DESCRIPTION
The manual install has been long deprecated so it should be safe to no longer attempt to do an uninstall on each activation.