### PR TITLE
README: Gently suggest managing home.nix with git

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ Currently the easiest way to install Home Manager is as follows:
     }
     EOF
     ```
+    
+    Or, if you wish to manage it with a Git repository:
+    
+    ```console
+    $ mkdir -p ~/.config/nixpkgs
+    $ ln -s /path/to/home.nix ~/.config/nixpkgs/home.nix
+    ```
 
 4.  Install Home Manager and create the first Home Manager generation:
 


### PR DESCRIPTION
While using a symlink for home.nix is obvious to Unix veterans, it won't be obvious to everyone, and using Git for this should be the default configuration anyway. Reducing friction is good.