### PR TITLE
programs.offlineimap: add an extraConfig to the account section

### DIFF
--- a/modules/programs/offlineimap-accounts.nix
+++ b/modules/programs/offlineimap-accounts.nix
@@ -12,6 +12,17 @@ in
   options.offlineimap = {
     enable = mkEnableOption "OfflineIMAP";
 
+    extraConfig.account = mkOption {
+      type = extraConfigType;
+      default = {};
+      example = {
+        autorefresh = 20;
+      };
+      description = ''
+        Extra configuration options to add to the account section.
+      '';
+    };
+
     extraConfig.local = mkOption {
       type = extraConfigType;
       default = {};

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -88,7 +88,8 @@ let
           localrepository = "${name}-local";
           remoterepository = "${name}-remote";
         }
-        // postSyncHook;
+        // postSyncHook
+        // offlineimap.extraConfig.account;
 
         "Repository ${name}-local" = {
           type = localType;


### PR DESCRIPTION
I currently have the following config in my offlineimap (working on converting it to nix, finally!)

```ini
[Account personal]
localrepository = personal_local
remoterepository = personal_remote
autorefresh = 20
quick = 0
synclabels = yes
labelsheader = X-Keywords
```

This changeset proposes `programs.offlineimap.extraConfig.account` similar to `programs.offlineimap.extraConfig.local` for adding additional config to the account section.