### PR TITLE
astroid should default required notmuch setting

### DIFF
--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -127,5 +127,7 @@ in
         ${cfg.pollScript}
       '';
     };
+
+    programs.notmuch.extraConfig.maildir.synchronize_flags = mkDefault "true";
   };
 }


### PR DESCRIPTION
I had this in my home configuration:

```nix
  programs.notmuch = {
    extraConfig = {
      search = {
        exclude_tags = "deleted;spam;killed;";
      };
    };
  };
```

which over-wrote the default value of the extraConfig and exposed an issue where astroid requires maildir.synchronize_flags to be set to true. This changeset defaults it to true.