### PR TITLE
ssh: tweak default controlPath

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -219,7 +219,7 @@ in
 
     controlPath = mkOption {
       type = types.str;
-      default = "~/.ssh/master-%r@%h:%p";
+      default = "~/.ssh/master-%r@%n:%p";
       description = ''
         Specify path to the control socket used for connection sharing.
       '';


### PR DESCRIPTION
Instead of using the hostname `%h`, which can be changed by the
~/.ssh/config file, use the commandline-given hostname `%c`.

This allows to alias a host with different hostnames, which then point
to different configurations. A common use-case for this is if you have
multiple accounts on github with each access to different private repos:

    Host github.com
      IdentitiesOnly yes
      User git
      IdentityFile ~/.ssh/id_rsa

    Host customer.github.com
      IdentitiesOnly yes
      User git
      IdentityFile ~/.ssh/customer
      HostName github.com

Without this change, if a connection was established with the first
github.com alias, then the user would try to pull a repo from the second
account, ssh would re-use the SSH connection which doesn't have access
to that repository.