### PR TITLE
pasystray: add paprefs and pavucontrol

### DIFF
--- a/modules/services/pasystray.nix
+++ b/modules/services/pasystray.nix
@@ -24,6 +24,11 @@ with lib;
         };
 
         Service = {
+          Environment =
+            let
+              toolPaths = makeBinPath [ pkgs.paprefs pkgs.pavucontrol ];
+            in
+              [ "PATH=${toolPaths}" ];
           ExecStart = "${pkgs.pasystray}/bin/pasystray";
         };
     };


### PR DESCRIPTION
This enables the "volume control" and "control local sound server" menu options.

Fixes #461