### PR TITLE
home-manager: import modules relative to the location

### DIFF
--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -9,7 +9,7 @@ with pkgs.lib;
 
 let
 
-  env = import <home-manager/modules> {
+  env = import ../modules {
     configuration =
       if confAttr == ""
       then confPath


### PR DESCRIPTION
I pin the home-manager [in my configuration](https://github.com/kalbasit/shabka/blob/master/external/home-manager.nix) and there's no home-manager channel available, this PR removes the dependency on the channel.