### PR TITLE
export nix-darwin on default

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,4 +11,6 @@ rec {
   };
 
   nixos = import ./nixos;
+
+  nix-darwin = import ./nix-darwin;
 }


### PR DESCRIPTION
nix-darwin module was introduced in https://github.com/rycee/home-manager/commit/a9a4fb641feb89da9f9d9140b5299cbb4c433d29. It was documented to be used the same way nixos module is used by adding `(import <home-manager> {}).nix-darwin` to `config.imports`, but the module was not actually exported.