### PR TITLE
Change installation instructions to use nix-channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ os:
 
 before_script:
   - mkdir -m 0755 -p /nix/var/nix/{profiles,gcroots}/per-user/$USER
-  - mkdir -p ~/.config/nixpkgs
-  - echo "{}" > ~/.config/nixpkgs/home.nix
 
 script:
   nix-shell . -A install

--- a/README.md
+++ b/README.md
@@ -54,42 +54,32 @@ Currently the easiest way to install Home Manager is as follows:
     NixOS you can control this option using the
     [`nix.allowedUsers`][nixosAllowedUsers] system option.
 
-2.  Assign a temporary variable holding the URL to the appropriate
-    archive. Typically this is
+2.  Add the appropriate Home Manager channel. Typically this is
 
     ```console
-    $ HM_PATH=https://github.com/rycee/home-manager/archive/master.tar.gz
+    $ nix-channel --add https://github.com/rycee/home-manager/archive/master.tar.gz home-manager
+    $ nix-channel --update
     ```
 
     if you are following Nixpkgs master or an unstable channel and
 
     ```console
-    $ HM_PATH=https://github.com/rycee/home-manager/archive/release-18.09.tar.gz
+    $ nix-channel --add https://github.com/rycee/home-manager/archive/release-18.09.tar.gz home-manager
+    $ nix-channel --update
     ```
 
     if you follow a Nixpkgs version 18.09 channel.
 
-3.  Create an initial Home Manager configuration file:
+3.  Install Home Manager and create the first Home Manager generation:
 
     ```console
-    $ cat > ~/.config/nixpkgs/home.nix <<EOF
-    {
-      programs.home-manager.enable = true;
-      programs.home-manager.path = $HM_PATH;
-    }
-    EOF
+    $ nix-shell '<home-manager>' -A install
     ```
 
-4.  Install Home Manager and create the first Home Manager generation:
+    Once finished, Home Manager should be active and available in your
+    user environment.
 
-    ```console
-    $ nix-shell $HM_PATH -A install
-    ```
-
-    Home Manager should now be active and available in your user
-    environment.
-
-5.  If you do not plan on having Home Manager manage your shell
+3.  If you do not plan on having Home Manager manage your shell
     configuration then you must source the
 
     ```
@@ -107,11 +97,10 @@ Currently the easiest way to install Home Manager is as follows:
 
     to your `~/.profile` file.
 
-Note, because the `HM_PATH` variable above points to the live Home
-Manager repository you will automatically get updates whenever you
-build a new generation. If you dislike automatic updates then perform
-a Git clone of the desired branch and instead do the above steps with
-`HM_PATH` set to the _absolute path_ of your clone.
+If instead of using channels you want to run Home Manager from a Git
+checkout of the repository then you can use the
+`programs.home-manager.path` option to specify the absolute path to
+the repository.
 
 Usage
 -----

--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -7,6 +7,23 @@ pkgs.runCommand
     preferLocalBuild = true;
     allowSubstitutes = false;
     shellHook = ''
+      confFile="''${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home.nix"
+
+      if [[ ! -e $confFile ]]; then
+        echo
+        echo "Creating initial Home Manager configuration..."
+
+        mkdir -p "$(dirname "$confFile")"
+        cat > $confFile <<EOF
+      { config, pkgs, ... }:
+
+      {
+        # Let Home Manager install and manage itself.
+        programs.home-manager.enable = true;
+      }
+      EOF
+      fi
+
       echo
       echo "Creating initial Home Manager generation..."
       echo
@@ -17,7 +34,7 @@ pkgs.runCommand
       All done! The home-manager tool should now be installed and you
       can edit
 
-          ''${XDG_CONFIG_HOME:-~/.config}/nixpkgs/home.nix
+          $confFile
 
       to configure Home Manager. Run 'man home-configuration.nix' to
       see all available options.


### PR DESCRIPTION
This avoids the uncontrollable nature of fetching the tarball as part of the evaluation. Instead the user can decide when to update and also perform rollbacks, if necessary.