### PR TITLE
home-manager: add edit command

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -129,6 +129,17 @@ function presentNews() {
     fi
 }
 
+function doEdit() {
+    setConfigFile
+
+    if [[ -z $EDITOR ]]; then
+        errorEcho "Please set the \$EDITOR environment variable"
+        return 1
+    fi
+
+    exec $EDITOR $HOME_MANAGER_CONFIG
+}
+
 function doBuild() {
     if [[ ! -w . ]]; then
         errorEcho "Cannot run build in read-only directory";
@@ -354,6 +365,8 @@ function doHelp() {
     echo
     echo "  help         Print this help"
     echo
+    echo "  edit         Open the home configuration in \$EDITOR"
+    echo
     echo "  build        Build configuration into result directory"
     echo
     echo "  switch       Build and activate configuration"
@@ -430,6 +443,9 @@ cmd="$1"
 shift 1
 
 case "$cmd" in
+    edit)
+        doEdit
+        ;;
     build)
         doBuild
         ;;


### PR DESCRIPTION
    home-manager edit

Opens the $HOME_MANAGER_CONFIG into $EDITOR.

It's mainly for convenience. Users shouldn't have to remember where the
home manager configuration exists exactly.