### PR TITLE
dunst: 'icon_folders' is deprecated, please use 'icon_path' instead

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -90,7 +90,7 @@ in
         xdg.dataFile."dbus-1/services/org.knopwob.dunst.service".source =
           "${pkgs.dunst}/share/dbus-1/services/org.knopwob.dunst.service";
 
-        services.dunst.settings.global.icon_folders =
+        services.dunst.settings.global.icon_path =
           let
             useCustomTheme =
               cfg.iconTheme.package != hicolorTheme.package


### PR DESCRIPTION
Dunst renamed «icon_folders» to «icon_path». I'm not sure how to properly handle this transition and support backward compatibility.