### PR TITLE
Sitch from attrs to attrsOf

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -5,6 +5,9 @@ with lib;
 let
 
   cfg = config.services.dunst;
+
+  eitherStrBoolIntList = with types; either str (either bool (either int (listOf str)));
+
   toDunstIni = generators.toINI {
     mkKeyValue = key: value:
     let
@@ -61,7 +64,7 @@ in
       };
 
       settings = mkOption {
-        type = types.attrsOf types.attrs;
+        type = with types; attrsOf (attrsOf eitherStrBoolIntList);
         default = {};
         description = "Configuration written to ~/.config/dunstrc";
         example = literalExample ''

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.services.polybar;
 
+  eitherStrBoolIntList = with types; either str (either bool (either int (listOf str)));
+
   toPolybarIni = generators.toINI {
     mkKeyValue = key: value:
       let
@@ -57,7 +59,7 @@ in
         type = types.coercedTo
           types.path
           (p: { "section/base" = { include-file = "${p}"; }; })
-          (types.attrsOf types.attrs);
+          (types.attrsOf (types.attrsOf eitherStrBoolIntList));
         description = ''
           Polybar configuration. Can be either path to a file, or set of attributes
           that will be used to create the final configuration.

--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -255,7 +255,7 @@ let
     };
   };
 
-  criteriaModule = types.attrs;
+  criteriaModule = types.attrsOf types.str;
 
   configModule = types.submodule {
     options = {
@@ -411,7 +411,7 @@ let
       };
 
       keybindings = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.str;
         default = {
           "${cfg.config.modifier}+Return" = "exec i3-sensible-terminal";
           "${cfg.config.modifier}+Shift+q" = "kill";
@@ -486,7 +486,7 @@ let
       };
 
       keycodebindings = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.str;
         default = {};
         description = ''
           An attribute set that assigns keypress to an action using key code.
@@ -571,7 +571,7 @@ let
       };
 
       modes = mkOption {
-        type = types.attrsOf types.attrs;
+        type = types.attrsOf (types.attrsOf types.str);
         default = {
           resize = {
             "Left" = "resize shrink width 10 px or 10 ppt";


### PR DESCRIPTION
Unlike `attrs` type, `attrsOf` uses `mergeDefinitions` function when merging multiple declarations, see [nixpkgs/lib/types.nix#L284](https://github.com/NixOS/nixpkgs/blob/3873f43fc39d6662ffedc3e0413a8741558e5952/lib/types.nix#L284). This allows to override attribute values defined in another module.

The changes in the i3 module are trivial. Polybar and dust modules, however, use attributes to further transform it to INI format which makes the type definition quite advanced:

```
with types; either str (either bool (either int (listOf str)));
```

It would be nice to give users a possibility to override the values, especially because in the current implementation, nix will just choose one of the definitions (randomly?) and will silently ignore the other one.

Do you think it would be possible patch nixpkgs to use `mergeDefinitions` option in a merge function of `attrs` type? I might be mistaken, but it looks like a bug to me.

Another alternative would be to create our own `ini` type with the appropriate definition (something like proposed `eitherStrBoolIntList` type).