### PR TITLE
i3: fix default keybindings override

### DIFF
--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -412,7 +412,7 @@ let
 
       keybindings = mkOption {
         type = types.attrsOf types.str;
-        default = {
+        default = mapAttrs (n: v: mkOptionDefault v) {
           "${cfg.config.modifier}+Return" = "exec i3-sensible-terminal";
           "${cfg.config.modifier}+Shift+q" = "kill";
           "${cfg.config.modifier}+d" = "exec ${pkgs.dmenu}/bin/dmenu_run";


### PR DESCRIPTION
All default keybindings should have a default priority attached to them.
This will allow users to redefine some of the default keybindings
without using mkForce. Fixes #485.