### PR TITLE
readme: fix .gitconfig example

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ such collision is detected the activation will terminate before
 changing anything on your computer.
 
 For example, suppose you have a wonderful, painstakingly created
-`~/.gitconfig` and add
+`~/.config/git/config` and add
 
 ```nix
 {


### PR DESCRIPTION
The example was referencing `~/.gitconfig`, which isn't being checked anymore since 356c0bf751a55878c448461d8ef1d17f43911acd.

I wonder though if we could also break on an existing `~/.gitconfig`.