### PR TITLE
gtk3, gnome-terminal modules: fix case when hm is used as nixos module

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -90,7 +90,14 @@ in
 
   options = {
     gtk = {
-      enable = mkEnableOption "GTK 2/3 configuration";
+      enable = mkEnableOption ''GTK 2/3 configuration
+        </para><para>
+        Note, on NixOS the following line must be in the
+        system configuration:
+        <programlisting>
+        services.dbus.packages = [ pkgs.gnome3.dconf ];
+        </programlisting>
+      '';
 
       font = mkOption {
         type = types.nullOr fontType;
@@ -153,21 +160,6 @@ in
                 <filename>~/.config/gtk-3.0/gtk.css</filename>.
               '';
             };
-
-            waylandSupport = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Support GSettings provider (dconf) in addition to
-                GtkSettings (INI file). This is needed for Wayland.
-                </para><para>
-                Note, on NixOS the following line must be in the
-                system configuration:
-                <programlisting>
-                services.dbus.packages = [ pkgs.gnome3.dconf ];
-                </programlisting>
-              '';
-            };
           };
         };
       };
@@ -216,22 +208,20 @@ in
 
         xdg.configFile."gtk-3.0/gtk.css".text = cfg3.extraCss;
 
-        home.activation = mkIf cfg3.waylandSupport {
-          gtk3 = dag.entryAfter ["installPackages"] (
-            let
-              iniText = toDconfIni { "/" = dconfIni; };
-              iniFile = pkgs.writeText "gtk3.ini" iniText;
-              dconfPath = "/org/gnome/desktop/interface/";
-            in
-              ''
-                if [[ -v DRY_RUN ]]; then
-                  echo ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
-                else
-                  ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
-                fi
-              ''
-          );
-        };
+        home.activation.gtk3 = dag.entryAfter ["installPackages"] (
+          let
+            iniText = toDconfIni { "/" = dconfIni; };
+            iniFile = pkgs.writeText "gtk3.ini" iniText;
+            dconfPath = "/org/gnome/desktop/interface/";
+          in
+            ''
+              if [[ -v DRY_RUN ]]; then
+                echo ${pkgs.dbus}/bin/dbus-run-session ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
+              else
+                ${pkgs.dbus}/bin/dbus-run-session ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
+              fi
+            ''
+        );
       }
     );
 }

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -162,7 +162,14 @@ in
 
   options = {
     programs.gnome-terminal = {
-      enable = mkEnableOption "Gnome Terminal";
+      enable = mkEnableOption ''Gnome Terminal
+        </para><para>
+        Note, on NixOS the following line must be in the
+        system configuration:
+        <programlisting>
+        services.dbus.packages = [ pkgs.gnome3.dconf ];
+        </programlisting>
+      '';
 
       showMenubar = mkOption {
         default = true;
@@ -190,9 +197,9 @@ in
       in
         ''
           if [[ -v DRY_RUN ]]; then
-            echo ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
+            echo ${pkgs.dbus}/bin/dbus-run-session ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} "<" ${iniFile}
           else
-            ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
+            ${pkgs.dbus}/bin/dbus-run-session ${pkgs.gnome3.dconf}/bin/dconf load ${dconfPath} < ${iniFile}
           fi
         ''
     );


### PR DESCRIPTION
Replaces https://github.com/rycee/home-manager/pull/436
Strange that I've not tried `dbus-run-session` before. It works in both cases (when HM is used as nixos module or as a standalone program). It just brings new dbus-daemon and sets session for dconf. It terminates that dbus-daemon process after dconf is finished:
`The dbus-daemon will run for as long as the program does, after which it will terminate`
https://dbus.freedesktop.org/doc/dbus-run-session.1.html