### PR TITLE
emacs: add `overrides` option

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -6,8 +6,13 @@ let
 
   cfg = config.programs.emacs;
 
-  # Copied from all-packages.nix.
-  emacsPackages = pkgs.emacsPackagesNgGen cfg.package;
+  # Copied from all-packages.nix, with modifications to support
+  # overrides.
+  emacsPackages =
+    let
+      epkgs = pkgs.emacsPackagesNgGen cfg.package;
+    in
+      epkgs.overrideScope' cfg.overrides;
   emacsWithPackages = emacsPackages.emacsWithPackages;
 
 in
@@ -32,6 +37,20 @@ in
         defaultText = "epkgs: []";
         example = literalExample "epkgs: [ epkgs.emms epkgs.magit ]";
         description = "Extra packages available to Emacs.";
+      };
+
+      overrides = mkOption {
+        default = self: super: {};
+        defaultText = "self: super: {}";
+        example = literalExample ''
+          self: super: rec {
+            haskell-mode = self.melpaPackages.haskell-mode;
+            # ...
+          };
+        '';
+        description = ''
+          Allows overriding packages within the Emacs package set.
+        '';
       };
 
       finalPackage = mkOption {


### PR DESCRIPTION
This option enables overriding packages within the generated Emacs package set.

Fixes #486