### PR TITLE
emacs: fix extraPackages defined multiple places

### DIFF
--- a/modules/lib/types.nix
+++ b/modules/lib/types.nix
@@ -1,0 +1,24 @@
+{ lib }:
+
+with lib;
+{
+  selectorFunction = mkOptionType {
+    name = "selectorFunction";
+    description =
+      "Function that takes an attribute set and returns a list "
+      + "containing a selection of the values of the input set";
+    check = isFunction;
+    merge = _loc: defs:
+      as: concatMap (select: select as) (getValues defs);
+  };
+
+  overlayFunction = mkOptionType {
+    name = "overlayFunction";
+    description =
+      "An overlay function, takes self and super and returns"
+      + "an attribute set overriding the desired attributes.";
+    check = isFunction;
+    merge = _loc: defs:
+      self: super: foldl' (res: def: mergeAttrs res (def.value self super)) {} defs;
+  };
+}

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+  types = lib.types // import ../lib/types.nix { inherit lib; };
 
   cfg = config.programs.emacs;
 
@@ -34,6 +35,7 @@ in
 
       extraPackages = mkOption {
         default = self: [];
+        type = types.selectorFunction;
         defaultText = "epkgs: []";
         example = literalExample "epkgs: [ epkgs.emms epkgs.magit ]";
         description = "Extra packages available to Emacs.";
@@ -41,6 +43,7 @@ in
 
       overrides = mkOption {
         default = self: super: {};
+        type = types.overlayFunction;
         defaultText = "self: super: {}";
         example = literalExample ''
           self: super: rec {


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/44601
Had issues with setting up multiple modules that all added to `programs.emacs.extraPackages`.
This fixes it, we could argue waiting for the type to be merged into Nixpkgs. But I think that especially the `selectorFunction` type is something we need.