### PR TITLE
Add /run/wrappers/bin to polybar service PATH

### DIFF
--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -129,7 +129,7 @@ in
 
       Service = {
         Type = "forking";
-        Environment = "PATH=${cfg.package}/bin";
+        Environment = "PATH=${cfg.package}/bin:/run/wrappers/bin";
         ExecStart = ''${pkgs.writeScriptBin "polybar-start" script}/bin/polybar-start'';
       };
 


### PR DESCRIPTION
It's somewhat ugly, but without it network module (with non-zero `ping-interval`) is unable to test connectivity as it invokes 'ping' command directly: https://github.com/jaagr/polybar/blob/master/src/adapters/net.cpp#L128.

kbfs does the same thing: https://github.com/rycee/home-manager/blob/6aa44d62ad6526177a8c1f1babe1646c06738614/modules/services/kbfs.nix#L51