### PR TITLE
emacs: make finalPackage option more accessible

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -55,9 +55,11 @@ in
 
       finalPackage = mkOption {
         type = types.package;
-        internal = true;
+        visible = false;
         readOnly = true;
-        description = "The Emacs package including any extra packages.";
+        description = ''
+          The Emacs package including any overrides and extra packages.
+        '';
       };
     };
   };


### PR DESCRIPTION
Instead of "internal" mark it as "invisible".