### PR TITLE
programs.autorandr: add support for xrandr transformation

### DIFF
--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -79,6 +79,34 @@ let
         default = null;
         example = "left";
       };
+
+      transform = with types;
+        let
+          transformType = let
+            list3 = elemType: addCheck (listOf elemType) (l: length l == 3);
+          in
+            uniq (list3 (list3 float))
+            // { description = "3×3 matrix of floating point numbers"; };
+        in
+        mkOption {
+          type = nullOr transformType;
+          description  = ''
+            Refer to
+            <citerefentry>
+              <refentrytitle>xrandr</refentrytitle>
+              <manvolnum>1</manvolnum>
+            </citerefentry>
+            for the documentation of the transform matrix.
+          '';
+          default = null;
+          example = literalExample ''
+            [
+              [ 0.6 0.0 0.0 ]
+              [ 0.0 0.6 0.0 ]
+              [ 0.0 0.0 1.0 ]
+            ]
+          '';
+        };
     };
   };
 
@@ -150,6 +178,9 @@ let
     ${optionalString (config.mode != "") "mode ${config.mode}"}
     ${optionalString (config.rate != "") "rate ${config.rate}"}
     ${optionalString (config.rotate != null) "rotate ${config.rotate}"}
+    ${optionalString (config.transform != null)
+      (concatMapStringsSep "," toString (flatten config.transform)
+    )}
   '' else ''
     output ${name}
     off


### PR DESCRIPTION
From `man xrandr` (xrandr >= 1.3):

```
       --transform a,b,c,d,e,f,g,h,i
              Specifies a transformation matrix to apply on the output. Automatically a bilinear filter is selected.  The mathematical form corresponds to:
                     a b c
                     d e f
                     g h i
              The transformation is based on homogeneous coordinates. The matrix multiplied by the coordinate vector of a pixel of  the  output  gives  the  transformed coordinate vector of a pixel in the graphic buffer.  More precisely, the vector (x y) of the output pixel is extended to 3 values (x y w), with 1 as the w coordinate and multiplied against the matrix. The final device coordinates of the pixel are then calculated with the so-called homogenic division  by  the transformed w coordinate.  In other words, the device coordinates (x' y') of the transformed pixel are:
                     x' = (ax + by + c) / w'   and
                     y' = (dx + ey + f) / w'   ,
                     with  w' = (gx + hy + i)  .
              Typically,  a and e corresponds to the scaling on the X and Y axes, c and f corresponds to the translation on those axes, and g, h, and i are respectively 0, 0 and 1. The matrix can also be used to express more complex transformations such as keystone correction, or rotation.  For a rotation of an  angle  T, this formula can be used:
                     cos T  -sin T   0
                     sin T   cos T   0
                      0       0      1
              As a special argument, instead of passing a matrix, one can pass the string none, in which case the default values are used (a unit matrix without filter).
```