### PR TITLE
matplotlib: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -929,6 +929,13 @@ in
           A new module is available: 'programs.opam'.
         '';
       }
+
+      {
+        time = "2019-01-11T15:21:30+00:00";
+        message = ''
+          A new module is available: 'programs.matplotlib'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -60,6 +60,7 @@ let
     (loadModule ./programs/jq.nix { })
     (loadModule ./programs/lesspipe.nix { })
     (loadModule ./programs/man.nix { })
+    (loadModule ./programs/matplotlib.nix { })
     (loadModule ./programs/mbsync.nix { })
     (loadModule ./programs/mercurial.nix { })
     (loadModule ./programs/msmtp.nix { })

--- a/modules/programs/matplotlib.nix
+++ b/modules/programs/matplotlib.nix
@@ -29,7 +29,15 @@ in
         type = with types; attrsOf (either attrs (either str (either bool int)));
         description = ''
           Add terms to the matplotlibrc file, control the default matplotlib dehavior'';
-        example = { backend = "Qt5Agg"; axes.grid = true;};
+        example = {
+          backend = "Qt5Agg";
+          axes = {
+            grid = true;
+            facecolor = "black";
+            edgecolor = "FF9900";
+          };
+          grid.color = "FF9900";
+        };
       };
 
       extraConfig = mkOption {

--- a/modules/programs/matplotlib.nix
+++ b/modules/programs/matplotlib.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ...}:
+
+with lib;
+
+let
+
+  cfg = config.programs.matplotlib;
+
+  formatLine = n: v:
+    let
+      formatValue = v:
+        if isBool v then (if v then "True" else "False")
+        else toString v;
+    in
+      "${n}: ${formatValue v}";
+in
+
+{
+    meta.maintainers = [ maintainers.rprospero];
+
+    options.programs.matplotlib = {
+      enable = mkEnableOption ''
+        matplotlib, a plotting library for python'';
+
+      rc = mkOption {
+        default = {};
+        type = with types; attrsOf (either str (either bool int));
+        description = ''
+          Add terms to the matplotlibrc file, control the default matplotlib dehavior'';
+        example = { backend = "Qt5Agg"; axes.grid = true;};
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Additional commands for matplotlib that will be added to the
+          <filename>matplotlibrc</filename> file.
+        '';
+      };
+    };
+    config = mkIf cfg.enable {
+      xdg.configFile."matplotlib/matplotlibrc".text =
+      concatStringsSep "\n" ([]
+        ++ mapAttrsToList formatLine cfg.rc
+        ++ optional (cfg.extraConfig != "") cfg.extraConfig
+      ) + "\n";
+  };
+}


### PR DESCRIPTION
This adds support for configuring the matplotlib python plotting library through home-manager.  I've added this as part of my growing quest to control the colors of all of my programs from one single source, though it does provide full control of matplotlib.

The most contraversial decision that I believe that I've made in this module is that it, while it does configure the rc file, it does _**NOT**_ actually install matplotlib.  I made this choice because I imagine that all users who are using matplotlib are creating a custom python to handle their desired packages anyway and that installing a library that wasn't even visible to the language wouldn't be of help to anyone.  I'm fully amenable to changing this decision.