### PR TITLE
dunst: kill daemon on configuration change

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -155,7 +155,17 @@ in
       }
 
       (mkIf (cfg.settings != {}) {
-        xdg.configFile."dunst/dunstrc".text = toDunstIni cfg.settings;
+        xdg.configFile."dunst/dunstrc" = {
+          text = toDunstIni cfg.settings;
+          onChange = ''
+            pkillVerbose=""
+            if [[ -v VERBOSE ]]; then
+              pkillVerbose="-e"
+            fi
+            $DRY_RUN_CMD ${pkgs.procps}/bin/pkill -u $USER $pkillVerbose dunst
+            unset pkillVerbose
+          '';
+        };
       })
     ]
   );


### PR DESCRIPTION
Since Dunst is DBus activated it is OK to simply kill it since DBus will restart it when necessary.