### PR TITLE
i3: reallow using null to disable a keybinding

### DIFF
--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -411,7 +411,7 @@ let
       };
 
       keybindings = mkOption {
-        type = types.attrsOf types.str;
+        type = types.attrsOf (types.nullOr types.str);
         default = mapAttrs (n: mkOptionDefault) {
           "${cfg.config.modifier}+Return" = "exec i3-sensible-terminal";
           "${cfg.config.modifier}+Shift+q" = "kill";
@@ -486,7 +486,7 @@ let
       };
 
       keycodebindings = mkOption {
-        type = types.attrsOf types.str;
+        type = types.attrsOf (types.nullOr types.str);
         default = {};
         description = ''
           An attribute set that assigns keypress to an action using key code.


### PR DESCRIPTION
The effects of PR https://github.com/rycee/home-manager/pull/291 were disabled by accident in commit https://github.com/rycee/home-manager/commit/c108eaba425cccf7512e02f173043ee2fb536f85. This PR reenables the possibility to use `null` to disable default keybindings.