### PR TITLE
Work around https://github.com/rycee/home-manager/issues/538

### DIFF
--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -49,9 +49,6 @@ let
       '';
 
   genAccountConfig = account: with account;
-    if (imap == null || maildir == null)
-    then ""
-    else
       genSection "IMAPAccount ${name}" (
         {
           Host = imap.host;


### PR DESCRIPTION
Works around https://github.com/rycee/home-manager/issues/538 by converting the assertion into an exception. Since the original assertion was only meant to get a nicer error message than the nix one, I find that this solution still does the job even though it's slightly uglier.