### PR TITLE
Add proxyJump option for SSH config

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -125,6 +125,12 @@ let
         description = "The command to use to connect to the server.";
       };
 
+      proxyJump = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "The proxy host to use to connect to the server.";
+      };
+
       certificateFile = mkOption {
         type = types.nullOr types.path;
         default = null;
@@ -169,6 +175,7 @@ let
     ++ optional (cf.compression != null)     "  Compression ${yn cf.compression}"
     ++ optional (!cf.checkHostIP)            "  CheckHostIP no"
     ++ optional (cf.proxyCommand != null)    "  ProxyCommand ${cf.proxyCommand}"
+    ++ optional (cf.proxyJump != null)       "  ProxyJump ${cf.proxyJump}"
     ++ mapAttrsToList (n: v: "  ${n} ${v}") cf.extraOptions
   );
 


### PR DESCRIPTION
See https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Proxies_and_Jump_Hosts for more info.

TL;DR, this:

```
             proxyCommand = "${pkgs.openssh}/bin/ssh -q vulcan "
                          + "/run/current-system/sw/bin/socat - TCP:%h:%p";
```

can be replaced by:

```
             proxyJump = "vulcan";
```