### PR TITLE
git: generate identities from mail accounts

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -79,15 +79,6 @@ in
         description = "Default user email to use.";
       };
 
-      sendemail.identity = mkOption {
-        type = types.nullOr types.str;
-        default = let
-            primary = filter (a: a.primary) (attrValues config.accounts.email.accounts);
-          in if primary == [] then null else head primary;
-
-        description = "<command>git send-mail</command> default identity.";
-      };
-
       aliases = mkOption {
         type = types.attrs;
         default = {};
@@ -174,10 +165,7 @@ in
                 smtpServerPort = smtp.port;
                 from = address;
               });
-        in (mapAttrs' genIdentity config.accounts.email.accounts)
-        // optionalAttrs (cfg.sendemail.identity  != null) {
-          sendemail.identity = cfg.sendemail.identity;
-        };
+        in (mapAttrs' genIdentity config.accounts.email.accounts);
       }
 
 


### PR DESCRIPTION
Ideally we could use it to generate a default gpg config.

As for the default identity, I wonder if we should use the primaryAccount or let a mailAccount ("defaultIdentity") option to override it