### PR TITLE
fish: use global for abbr

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -7,7 +7,7 @@ let
   cfg = config.programs.fish;
 
   abbrsStr = concatStringsSep "\n" (
-    mapAttrsToList (k: v: "abbr --add ${k} '${v}'") cfg.shellAbbrs
+    mapAttrsToList (k: v: "abbr --add --global ${k} '${v}'") cfg.shellAbbrs
   );
 
   aliasesStr = concatStringsSep "\n" (


### PR DESCRIPTION
Makes fish use global scope for abbreviations.
This makes it so that they don't stick across config changes.
Before, an abbreviation would still exist even if removed from the config.