### PR TITLE
Problem: installation fails on non-x86

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -144,7 +144,7 @@ in
   config = {
     _module.args = {
       pkgs = _pkgs;
-      pkgs_i686 = if _pkgs.stdenv.isLinux then _pkgs.pkgsi686Linux else {};
+      pkgs_i686 = if (_pkgs.stdenv.isLinux && _pkgs.stdenv.isi686) then _pkgs.pkgsi686Linux else {};
     };
   };
 }


### PR DESCRIPTION
On non-x86 architectures (for example, aarch64) the installation
of home-manager fails indicating that it is attempting to select
i686 packages for Linux and those aren't available.

Solution: make the condition for choosing these packages stricter