### PR TITLE
Allow contents in git.includes

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -34,7 +34,7 @@ let
     };
   };
 
-  includeModule = types.submodule {
+  includeModule = types.submodule ({ config, ... }: {
     options = {
       condition = mkOption {
         type = types.nullOr types.str;
@@ -53,8 +53,18 @@ let
         type = types.str;
         description = "Path of the configuration file to include.";
       };
+
+      contents = mkOption {
+        type = types.attrs;
+        default = {};
+        description = "Configuration to include.";
+      };
     };
-  };
+
+    config.path = mkIf (config.contents != {}) (
+      mkDefault (toString (pkgs.writeText "contents" (generators.toINI {} config.contents)))
+    );
+  });
 
 in
 

--- a/tests/modules/programs/git-expected.conf
+++ b/tests/modules/programs/git-expected.conf
@@ -29,3 +29,6 @@ path = ~/path/to/config.inc
 
 [includeIf "gitdir:~/src/dir"]
 path = ~/path/to/conditional.inc
+
+[includeIf "gitdir:~/src/dir"]
+path = @git_include_path@

--- a/tests/modules/programs/git.nix
+++ b/tests/modules/programs/git.nix
@@ -1,6 +1,22 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
+
+let
+  gitInclude = {
+    user = {
+      name = "John Doe";
+      email = "user@example.org";
+    };
+  };
+
+  substituteExpected = path: pkgs.substituteAll {
+    src = path;
+
+    git_include_path = pkgs.writeText "contents" (generators.toINI {} gitInclude);
+  };
+
+in
 
 {
   config = {
@@ -23,6 +39,10 @@ with lib;
             path = "~/path/to/conditional.inc";
             condition = "gitdir:~/src/dir";
           }
+          {
+            condition = "gitdir:~/src/dir";
+            contents = gitInclude;
+          }
         ];
         signing = {
           gpgPath = "path-to-gpg";
@@ -43,7 +63,7 @@ with lib;
 
     nmt.script = ''
       assertFileExists home-files/.config/git/config
-      assertFileContent home-files/.config/git/config ${./git-expected.conf}
+      assertFileContent home-files/.config/git/config ${substituteExpected ./git-expected.conf}
     '';
   };
 }


### PR DESCRIPTION
scenario: I'd like to specify the contents of the included path:
```nix
      includes = [
        { condition = "gitdir:~/work/";
          contents = {
            user = {
              name = "John Doe";
              email = "user@example.org";
            };
          };
        }
      ];
```