### PR TITLE
git: quote sendemail section header

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -151,7 +151,7 @@ in
             hasSmtp = name: account: account.smtp != null;
 
             genIdentity = name: account: with account;
-              nameValuePair "sendemail.${name}" ({
+              nameValuePair "sendemail \"${name}\"" ({
                 smtpEncryption = if smtp.tls.enable then "tls" else "";
                 smtpServer = smtp.host;
                 smtpUser = userName;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -20,6 +20,7 @@ import nmt {
     files-hidden-source = ./modules/files/hidden-source.nix;
     files-source-with-spaces = ./modules/files/source-with-spaces.nix;
     files-text = ./modules/files/text.nix;
+    git-with-email = ./modules/programs/git-with-email.nix;
     git-with-most-options = ./modules/programs/git.nix;
     git-with-str-extra-config = ./modules/programs/git-with-str-extra-config.nix;
     texlive-minimal = ./modules/programs/texlive-minimal.nix;

--- a/tests/modules/accounts/email-test-accounts.nix
+++ b/tests/modules/accounts/email-test-accounts.nix
@@ -1,0 +1,27 @@
+{ ... }:
+
+{
+  accounts.email = {
+    maildirBasePath = "Mail";
+
+    accounts = {
+      "hm@example.com" = {
+        address = "hm@example.com";
+        userName = "home.manager";
+        realName = "H. M. Test";
+        passwordCommand = "password-command";
+        imap.host = "imap.example.com";
+        smtp.host = "smtp.example.com";
+      };
+
+      hm-account = {
+        address = "hm@example.org";
+        userName = "home.manager.jr";
+        realName = "H. M. Test Jr.";
+        passwordCommand = "password-command 2";
+        imap.host = "imap.example.org";
+        smtp.host = "smtp.example.org";
+      };
+    };
+  };
+}

--- a/tests/modules/programs/git-with-email-expected.conf
+++ b/tests/modules/programs/git-with-email-expected.conf
@@ -1,0 +1,15 @@
+[sendemail "hm-account"]
+from=hm@example.org
+smtpEncryption=tls
+smtpServer=smtp.example.org
+smtpUser=home.manager.jr
+
+[sendemail "hm@example.com"]
+from=hm@example.com
+smtpEncryption=tls
+smtpServer=smtp.example.com
+smtpUser=home.manager
+
+[user]
+email=hm@example.com
+name=H. M. Test

--- a/tests/modules/programs/git-with-email.nix
+++ b/tests/modules/programs/git-with-email.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../accounts/email-test-accounts.nix ];
+
+  config = {
+    programs.git = {
+      enable = true;
+      userEmail = "hm@example.com";
+      userName = "H. M. Test";
+    };
+
+    nmt.script = ''
+      function assertGitConfig() {
+        local value
+        value=$(${pkgs.git}/bin/git config \
+          --file $TESTED/home-files/.config/git/config \
+          --get $1)
+        if [[ $value != $2 ]]; then
+          fail "Expected option '$1' to have value '$2' but it was '$value'"
+        fi
+      }
+
+      assertFileExists home-files/.config/git/config
+      assertFileContent home-files/.config/git/config ${./git-with-email-expected.conf}
+
+      assertGitConfig "sendemail.hm@example.com.from" "hm@example.com"
+      assertGitConfig "sendemail.hm-account.from" "hm@example.org"
+    '';
+  };
+}


### PR DESCRIPTION
This will allow, e.g., the character `@` in the email identity.

Also adds a test case.

Fixes #557