### PR TITLE
git: use `attrsOf` instead of `attrs`

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -6,6 +6,12 @@ let
 
   cfg = config.programs.git;
 
+  gitIniType = with types;
+    let
+      primitiveType = either bool (either int str);
+    in
+      attrsOf (attrsOf primitiveType);
+
   signModule = types.submodule {
     options = {
       key = mkOption {
@@ -80,8 +86,9 @@ in
       };
 
       aliases = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.str;
         default = {};
+        example = { co = "checkout"; };
         description = "Git aliases to define.";
       };
 
@@ -92,13 +99,16 @@ in
       };
 
       extraConfig = mkOption {
-        type = types.either types.attrs types.lines;
+        type = types.either types.lines gitIniType;
         default = {};
+        example = {
+          core = { whitespace = "trailing-space,space-before-tab"; };
+        };
         description = "Additional configuration to add.";
       };
 
       iniContent = mkOption {
-        type = types.attrsOf types.attrs;
+        type = gitIniType;
         internal = true;
       };
 

--- a/tests/modules/programs/git-expected.conf
+++ b/tests/modules/programs/git-expected.conf
@@ -1,11 +1,13 @@
 [alias]
 a1=foo
-a2=bar
+a2=baz
 
 [commit]
 gpgSign=true
 
 [extra]
+boolean=true
+integer=38
 name=value
 
 [gpg]

--- a/tests/modules/programs/git.nix
+++ b/tests/modules/programs/git.nix
@@ -4,33 +4,41 @@ with lib;
 
 {
   config = {
-    programs.git = {
-      enable = true;
-      aliases = {
-        a1 = "foo";
-        a2 = "bar";
-      };
-      extraConfig = {
-        extra = {
-          name = "value";
+    programs.git = mkMerge [
+      {
+        enable = true;
+        aliases = {
+          a1 = "foo";
+          a2 = "bar";
         };
-      };
-      ignores = [ "*~" "*.swp" ];
-      includes = [
-        { path = "~/path/to/config.inc"; }
-        {
-          path = "~/path/to/conditional.inc";
-          condition = "gitdir:~/src/dir";
-        }
-      ];
-      signing = {
-        gpgPath = "path-to-gpg";
-        key = "00112233445566778899AABBCCDDEEFF";
-        signByDefault = true;
-      };
-      userEmail = "user@example.org";
-      userName = "John Doe";
-    };
+        extraConfig = {
+          extra = {
+            name = "value";
+          };
+        };
+        ignores = [ "*~" "*.swp" ];
+        includes = [
+          { path = "~/path/to/config.inc"; }
+          {
+            path = "~/path/to/conditional.inc";
+            condition = "gitdir:~/src/dir";
+          }
+        ];
+        signing = {
+          gpgPath = "path-to-gpg";
+          key = "00112233445566778899AABBCCDDEEFF";
+          signByDefault = true;
+        };
+        userEmail = "user@example.org";
+        userName = "John Doe";
+      }
+
+      {
+        aliases.a2 = mkForce "baz";
+        extraConfig.extra.boolean = true;
+        extraConfig.extra.integer = 38;
+      }
+    ];
 
     nmt.script = ''
       assertFileExists home-files/.config/git/config


### PR DESCRIPTION
This makes sure that values added to

    programs.git.aliases

or

    programs.git.extraConfig

are merged as expected.

Also add a few option examples.