### PR TITLE
neovim: Allow to override package

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -104,6 +104,14 @@ in
         '';
       };
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.neovim-unwrapped;
+        defaultText = "pkgs.neovim-unwrapped";
+        example = literalExample "pkgs.neovim-unwrapped";
+        description = "The package to use for the neovim binary.";
+      };
+
       configure = mkOption {
         type = types.attrs;
         default = {};
@@ -130,7 +138,7 @@ in
 
   config = mkIf cfg.enable {
     home.packages = [
-      (pkgs.neovim.override {
+      (pkgs.wrapNeovim cfg.package {
         inherit (cfg)
           extraPython3Packages withPython3
           extraPythonPackages withPython


### PR DESCRIPTION
If you wanna run a development version for instance (my motivation), it is easier to set neovim.package
rather than work around the wrapping mechanism etc.