### PR TITLE
alot: support contact completion

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -379,7 +379,7 @@ in
     accounts = mkOption {
       type = types.attrsOf (types.submodule [
         mailAccountOpts
-        (import ../programs/alot-accounts.nix)
+        (import ../programs/alot-accounts.nix pkgs)
         (import ../programs/astroid-accounts.nix)
         (import ../programs/mbsync-accounts.nix)
         (import ../programs/msmtp-accounts.nix)

--- a/modules/programs/alot-accounts.nix
+++ b/modules/programs/alot-accounts.nix
@@ -2,6 +2,24 @@
 
 with lib;
 
+let
+  contactCompletionStr = let
+    in
+    contactCompletion:
+    (if contactCompletion == "notmuch address" then {
+
+      type = "shellcommand";
+      command = "'notmuch  address --format=json --output=recipients  date:1Y..'";
+      regexp = '''\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?''\''';
+      shellcommand_external_filtering = "False";
+    }
+    else if contactCompletion == "notmuch address simple" then {
+      command = "notmuch address --format=json date:1Y..";
+    }
+    else if contactCompletion == "abook" then {
+      type = "abook";
+    } else {});
+in
 {
   options.alot = {
     sendMailCommand = mkOption {
@@ -10,6 +28,19 @@ with lib;
         Command to send a mail. If msmtp is enabled for the account,
         then this is set to
         <command>msmtpq --read-envelope-from --read-recipients</command>.
+      '';
+    };
+
+    contactCompletion = mkOption {
+      type = types.enum [ "notmuch address simple" "notmuch address" ];
+      default = "notmuch address";
+      apply = v:
+        contactCompletionStr v;
+
+      description = ''
+       Contact completion command.
+       See <link xlink:href="http://alot.readthedocs.io/en/latest/configuration/contacts_completion.html">alot's wiki</link> for
+       some more explanation.
       '';
     };
 

--- a/modules/programs/alot-accounts.nix
+++ b/modules/programs/alot-accounts.nix
@@ -1,25 +1,7 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
-let
-  contactCompletionStr = let
-    in
-    contactCompletion:
-    (if contactCompletion == "notmuch address" then {
-
-      type = "shellcommand";
-      command = "'notmuch  address --format=json --output=recipients  date:1Y..'";
-      regexp = '''\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?''\''';
-      shellcommand_external_filtering = "False";
-    }
-    else if contactCompletion == "notmuch address simple" then {
-      command = "notmuch address --format=json date:1Y..";
-    }
-    else if contactCompletion == "abook" then {
-      type = "abook";
-    } else {});
-in
 {
   options.alot = {
     sendMailCommand = mkOption {
@@ -32,15 +14,25 @@ in
     };
 
     contactCompletion = mkOption {
-      type = types.enum [ "notmuch address simple" "notmuch address" ];
-      default = "notmuch address";
-      apply = v:
-        contactCompletionStr v;
-
+      type = types.attrsOf types.str;
+      default = {
+        type = "shellcommand";
+        command = "'${pkgs.notmuch}/bin/notmuch address --format=json --output=recipients  date:6M..'";
+        regexp = '''\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?''\''';
+        shellcommand_external_filtering = "False";
+      };
+      example = literalExample ''
+        {
+          type = "shellcommand";
+          command = "abook --mutt-query";
+          regexp = "'^(?P<email>[^@]+@[^\t]+)\t+(?P<name>[^\t]+)'";
+          ignorecase = "True";
+        }
+      '';
       description = ''
-       Contact completion command.
+       Contact completion configuration as expected per alot.
        See <link xlink:href="http://alot.readthedocs.io/en/latest/configuration/contacts_completion.html">alot's wiki</link> for
-       some more explanation.
+       explanation about possible values.
       '';
     };
 

--- a/modules/programs/alot-accounts.nix
+++ b/modules/programs/alot-accounts.nix
@@ -1,4 +1,5 @@
-{ config, lib, pkgs, ... }:
+pkgs:
+{ config, lib, ... }:
 
 with lib;
 
@@ -21,6 +22,12 @@ with lib;
         regexp = '''\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?''\''';
         shellcommand_external_filtering = "False";
       };
+      defaultText = literalExample ''{
+        type = "shellcommand";
+        command = "'notmuch address --format=json --output=recipients  date:6M..'";
+        regexp = ''\'''\''\[?{"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"}[,\]]?''\'''\'''\';
+        shellcommand_external_filtering = "False";
+      }'';
       example = literalExample ''
         {
           type = "shellcommand";

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -33,6 +33,12 @@ let
             boolStr (signature.showSignature == "attach");
         }
       )
+      ++ optionals (alot.contactCompletion != null) (
+       [ "[[[abook]]]" ]
+      ++ mapAttrsToList (n: v: n + "=" + v) (
+        alot.contactCompletion
+        )
+       )
     )
     + "\n"
     + alot.extraConfig;

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -33,12 +33,10 @@ let
             boolStr (signature.showSignature == "attach");
         }
       )
-      ++ optionals (alot.contactCompletion != null) (
-       [ "[[[abook]]]" ]
+      ++ [ "[[[abook]]]" ]
       ++ mapAttrsToList (n: v: n + "=" + v) (
         alot.contactCompletion
         )
-       )
     )
     + "\n"
     + alot.extraConfig;


### PR DESCRIPTION
I would like to make contact completion easier, or at least have a valid configuration out of the box.

I am unsure about the interface, ideally the user should be able to pass anything. Should I provide a submodule or freeform attributes with a reasonable default ? 
In alot-accounts.nix, I also wanted to refer to `pkgs.notmuch`, not sure how to cleanly achieve that though, callPackage seems to bring in a HM specific package.