### PR TITLE
Use `pkgs.nix` from store

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -24,6 +24,7 @@ pkgs.stdenv.mkDerivation {
       --subst-var-by findutils "${pkgs.findutils}" \
       --subst-var-by gnused "${pkgs.gnused}" \
       --subst-var-by less "${pkgs.less}" \
+      --subst-var-by nix "${pkgs.nix}" \
       --subst-var-by HOME_MANAGER_PATH '${pathStr}'
   '';
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -1,7 +1,7 @@
 #!@bash@/bin/bash
 
 # Prepare to use tools from Nixpkgs.
-PATH=@coreutils@/bin:@findutils@/bin:@gnused@/bin:@less@/bin${PATH:+:}$PATH
+PATH=@coreutils@/bin:@findutils@/bin:@gnused@/bin:@less@/bin:@nix@/bin${PATH:+:}$PATH
 
 set -euo pipefail
 

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -335,6 +335,7 @@ in
           pkgs.gnugrep
           pkgs.gnused
           pkgs.ncurses          # For `tput`.
+          pkgs.nix
         ]
         + optionalString (!cfg.emptyActivationPath) "\${PATH:+:}$PATH";
 


### PR DESCRIPTION
This allows running home-manager from any environment, since things like `nix-env` and `nix-build` are now well-defined in the generation scripts.

For me this solved the problem calling `home-manager switch` from a userActivationScript (in a very basic experiment). 