### PR TITLE
emacs: move service to 'services' directory

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -87,7 +87,7 @@ let
     (loadModule ./services/blueman-applet.nix { })
     (loadModule ./services/compton.nix { })
     (loadModule ./services/dunst.nix { })
-    (loadModule ./services/emacs.nix { })
+    (loadModule ./services/emacs.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/flameshot.nix { })
     (loadModule ./services/gnome-keyring.nix { })
     (loadModule ./services/gpg-agent.nix { })

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -87,6 +87,7 @@ let
     (loadModule ./services/blueman-applet.nix { })
     (loadModule ./services/compton.nix { })
     (loadModule ./services/dunst.nix { })
+    (loadModule ./services/emacs.nix { })
     (loadModule ./services/flameshot.nix { })
     (loadModule ./services/gnome-keyring.nix { })
     (loadModule ./services/gpg-agent.nix { })

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -70,25 +70,5 @@ in
       home.packages = [ cfg.finalPackage ];
       programs.emacs.finalPackage = emacsWithPackages cfg.extraPackages;
     }
-
-    (mkIf cfg.service {
-      systemd.user.services.emacs = {
-        Unit = {
-          Description = "Emacs: the extensible, self-documenting text editor";
-          Documentation = "info:emacs man:emacs(1) https://gnu.org/software/emacs/";
-        };
-
-        Service = {
-          Type = "simple";
-          ExecStart = "${pkgs.stdenv.shell} -l -c 'exec ${cfg.finalPackage}/bin/emacs --fg-daemon'";
-          ExecStop = "${cfg.finalPackage}/bin/emacsclient --eval '(kill-emacs)'";
-          Restart = "on-failure";
-        };
-
-        Install = {
-          WantedBy = [ "default.target" ];
-        };
-      };
-    })
   ]);
 }

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -64,10 +64,8 @@ in
     };
   };
 
-  config = mkIf cfg.enable (mkMerge [
-    {
-      home.packages = [ cfg.finalPackage ];
-      programs.emacs.finalPackage = emacsWithPackages cfg.extraPackages;
-    }
-  ]);
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.finalPackage ];
+    programs.emacs.finalPackage = emacsWithPackages cfg.extraPackages;
+  };
 }

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -23,7 +23,6 @@ in
   options = {
     programs.emacs = {
       enable = mkEnableOption "Emacs";
-      service = mkEnableOption "Emacs daemon systemd service";
 
       package = mkOption {
         type = types.package;

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -23,6 +23,7 @@ in
   options = {
     programs.emacs = {
       enable = mkEnableOption "Emacs";
+      service = mkEnableOption "Emacs daemon systemd service";
 
       package = mkOption {
         type = types.package;
@@ -64,9 +65,30 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    home.packages = [ cfg.finalPackage ];
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = [ cfg.finalPackage ];
+      programs.emacs.finalPackage = emacsWithPackages cfg.extraPackages;
+    }
 
-    programs.emacs.finalPackage = emacsWithPackages cfg.extraPackages;
-  };
+    (mkIf cfg.service {
+      systemd.user.services.emacs = {
+        Unit = {
+          Description = "Emacs: the extensible, self-documenting text editor";
+          Documentation = "info:emacs man:emacs(1) https://gnu.org/software/emacs/";
+        };
+
+        Service = {
+          Type = "simple";
+          ExecStart = "${pkgs.stdenv.shell} -l -c 'exec ${cfg.finalPackage}/bin/emacs --fg-daemon'";
+          ExecStop = "${cfg.finalPackage}/bin/emacsclient --eval '(kill-emacs)'";
+          Restart = "on-failure";
+        };
+
+        Install = {
+          WantedBy = [ "default.target" ];
+        };
+      };
+    })
+  ]);
 }

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.emacs;
+  emacs = config.programs.emacs;
+in
+{
+  options.services.emacs = {
+    enable = mkEnableOption "Emacs daemon systemd service";
+  };
+  config = mkIf cfg.enable {
+    systemd.user.services.emacs = {
+      Unit = {
+        Description = "Emacs: the extensible, self-documenting text editor";
+        Documentation = "info:emacs man:emacs(1) https://gnu.org/software/emacs/";
+        };
+
+      Service = {
+        Type = "simple";
+        ExecStart = "${pkgs.stdenv.shell} -l -c 'exec ${emacs.finalPackage}/bin/emacs --fg-daemon'";
+        ExecStop = "${emacs.finalPackage}/bin/emacsclient --eval '(kill-emacs)'";
+        Restart = "on-failure";
+      };
+
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -3,19 +3,22 @@
 with lib;
 
 let
+
   cfg = config.services.emacs;
   emacs = config.programs.emacs;
+
 in
 {
   options.services.emacs = {
     enable = mkEnableOption "Emacs daemon systemd service";
   };
+
   config = mkIf cfg.enable {
     systemd.user.services.emacs = {
       Unit = {
         Description = "Emacs: the extensible, self-documenting text editor";
         Documentation = "info:emacs man:emacs(1) https://gnu.org/software/emacs/";
-        };
+      };
 
       Service = {
         Type = "simple";

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -10,7 +10,7 @@ let
 in
 {
   options.services.emacs = {
-    enable = mkEnableOption "Emacs daemon systemd service";
+    enable = mkEnableOption "the Emacs daemon";
   };
 
   config = mkIf cfg.enable {

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -21,7 +21,6 @@ in
       };
 
       Service = {
-        Type = "simple";
         ExecStart = "${pkgs.stdenv.shell} -l -c 'exec ${emacs.finalPackage}/bin/emacs --fg-daemon'";
         ExecStop = "${emacs.finalPackage}/bin/emacsclient --eval '(kill-emacs)'";
         Restart = "on-failure";


### PR DESCRIPTION
Building off of @Jomik's work in https://github.com/rycee/home-manager/pull/517, this PR moves the service declaration code to `/modules/services/emacs.nix` as [suggested by @teto](https://github.com/rycee/home-manager/pull/517#discussion_r251287220).

To see that it's confirmed working, see a log of emacs service being activated on my machine here: http://ix.io/1ArD

---

Closes https://github.com/rycee/home-manager/issues/299