### PR TITLE
i3: make tray_output optional

### DIFF
--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -239,7 +239,10 @@ let
 
       trayOutput = mkOption {
         type = types.nullOr types.str;
-        default = null;
+        default =
+          if versionAtLeast config.home.stateVersion "19.03"
+          then null
+          else "primary";
         example = "primary";
         description = "Where to output tray.";
       };

--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -238,8 +238,9 @@ let
       };
 
       trayOutput = mkOption {
-        type = types.str;
-        default = "primary";
+        type = types.nullOr types.str;
+        default = null;
+        example = "primary";
         description = "Where to output tray.";
       };
     };
@@ -705,7 +706,7 @@ let
       i3bar_command ${command}
       workspace_buttons ${if workspaceButtons then "yes" else "no"}
       strip_workspace_numbers ${if !workspaceNumbers then "yes" else "no"}
-      tray_output ${trayOutput}
+      ${optionalString (trayOutput != null) "tray_output ${trayOutput}"}
       colors {
         background ${colors.background}
         statusline ${colors.statusline}


### PR DESCRIPTION
This option is not required to have tray working. And it also breaks tray on `sway-beta` (as it uses output names instead and doesn't support `primary` identifier). So make it disabled by default.