### PR TITLE
Clean up support code for Home Manager as a submodule

### DIFF
--- a/modules/misc/submodule-support.nix
+++ b/modules/misc/submodule-support.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.rycee ];
+
+  options.submoduleSupport = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      internal = true;
+      description = ''
+        Whether the Home Manager module system is used as a submodule
+        in, for example, NixOS or nix-darwin.
+      '';
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -3,9 +3,6 @@
 
   # Whether to enable module type checking.
 , check ? true
-
-  # Whether these modules are inside a NixOS submodule.
-, nixosSubmodule ? false
 }:
 
 with lib;
@@ -33,6 +30,7 @@ let
     (loadModule ./misc/nixpkgs.nix { })
     (loadModule ./misc/pam.nix { })
     (loadModule ./misc/qt.nix { })
+    (loadModule ./misc/submodule-support.nix { })
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/xdg.nix { })
     (loadModule ./programs/afew.nix { })
@@ -129,17 +127,10 @@ let
   modules = map (getAttr "file") (filter (getAttr "condition") allModules);
 
   pkgsModule = {
-    options.nixosSubmodule = mkOption {
-      type = types.bool;
-      internal = true;
-      readOnly = true;
-    };
-
     config._module.args.baseModules = modules;
     config._module.args.pkgs = lib.mkDefault pkgs;
     config._module.check = check;
     config.lib = import ./lib { inherit lib; };
-    config.nixosSubmodule = nixosSubmodule;
     config.nixpkgs.system = mkDefault pkgs.system;
   };
 

--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -32,7 +32,7 @@ in
     };
   };
 
-  config = mkIf (cfg.enable && !config.nixosSubmodule) {
+  config = mkIf (cfg.enable && !config.submoduleSupport.enable) {
     home.packages = [
       (import ../../home-manager {
         inherit pkgs;

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -7,12 +7,10 @@ let
   cfg = config.home-manager;
 
   hmModule = types.submodule ({name, ...}: {
-    imports = import ../modules/modules.nix {
-      inherit lib pkgs;
-      nixosSubmodule = true;
-    };
+    imports = import ../modules/modules.nix { inherit lib pkgs; };
 
     config = {
+      submoduleSupport.enable = true;
       home.username = config.users.users.${name}.name;
       home.homeDirectory = config.users.users.${name}.home;
     };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -7,12 +7,10 @@ let
   cfg = config.home-manager;
 
   hmModule = types.submodule ({name, ...}: {
-    imports = import ../modules/modules.nix {
-      inherit lib pkgs;
-      nixosSubmodule = true;
-    };
+    imports = import ../modules/modules.nix { inherit lib pkgs; };
 
     config = {
+      submoduleSupport.enable = true;
       home.username = config.users.users.${name}.name;
       home.homeDirectory = config.users.users.${name}.home;
     };


### PR DESCRIPTION
This removes the `nixosSubmodule` option in favor of a new option `submoduleSupport.enable`. This name better indicates that the submodule mode applies to both NixOS and nix-darwin.