### PR TITLE
autorandr: add support for xrandr scale and dpi

### DIFF
--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -114,6 +114,20 @@ let
           for the documentation of the transform matrix.
         '';
       };
+
+      dpi = mkOption {
+        type = types.nullOr types.int;
+        description = "Output DPI configuration.";
+        default = null;
+        example = 96;
+      };
+
+      scale = mkOption {
+        type = types.str;
+        description = "Output scale configuration.";
+        default = "";
+        example = "1.25x1.25";
+      };
     };
   };
 
@@ -181,10 +195,12 @@ let
     output ${name}
     ${optionalString (config.position != "") "pos ${config.position}"}
     ${optionalString config.primary "primary"}
+    ${optionalString (config.dpi != null) "dpi ${toString config.dpi}"}
     ${optionalString (config.gamma != "") "gamma ${config.gamma}"}
     ${optionalString (config.mode != "") "mode ${config.mode}"}
     ${optionalString (config.rate != "") "rate ${config.rate}"}
     ${optionalString (config.rotate != null) "rotate ${config.rotate}"}
+    ${optionalString (config.scale != "") "scale ${config.scale}"}
     ${optionalString (config.transform != null) (
       "transform " + concatMapStringsSep "," toString (flatten config.transform)
     )}

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -123,10 +123,24 @@ let
       };
 
       scale = mkOption {
-        type = types.str;
+        type = types.nullOr (types.submodule {
+          options = {
+            x = mkOption {
+              type = types.float;
+              description = "Horizontal scaling factor.";
+            };
+            y = mkOption {
+              type = types.float;
+              description = "Vertical scaling factor.";
+            };
+          };
+        });
         description = "Output scale configuration.";
-        default = "";
-        example = "1.25x1.25";
+        default = null;
+        example = {
+          x = 1.25;
+          y = 1.25;
+        };
       };
     };
   };
@@ -200,7 +214,7 @@ let
     ${optionalString (config.mode != "") "mode ${config.mode}"}
     ${optionalString (config.rate != "") "rate ${config.rate}"}
     ${optionalString (config.rotate != null) "rotate ${config.rotate}"}
-    ${optionalString (config.scale != "") "scale ${config.scale}"}
+    ${optionalString (config.scale != null) "scale ${toString config.scale.x}x${toString config.scale.y}"}
     ${optionalString (config.transform != null) (
       "transform " + concatMapStringsSep "," toString (flatten config.transform)
     )}

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -125,13 +125,20 @@ let
       scale = mkOption {
         type = types.nullOr (types.submodule {
           options = {
+            method = mkOption {
+              type = types.enum ["factor" "pixel" ];
+              description = "Output scaling method.";
+              default = "factor";
+              example = "pixel";
+            };
+
             x = mkOption {
-              type = types.float;
-              description = "Horizontal scaling factor.";
+              type = types.either types.float types.int;
+              description = "Horizontal scaling factor/pixels.";
             };
             y = mkOption {
-              type = types.float;
-              description = "Vertical scaling factor.";
+              type = types.either types.float types.int;
+              description = "Vertical scaling factor/pixels.";
             };
           };
         });
@@ -214,7 +221,10 @@ let
     ${optionalString (config.mode != "") "mode ${config.mode}"}
     ${optionalString (config.rate != "") "rate ${config.rate}"}
     ${optionalString (config.rotate != null) "rotate ${config.rotate}"}
-    ${optionalString (config.scale != null) "scale ${toString config.scale.x}x${toString config.scale.y}"}
+    ${optionalString (config.scale != null) (
+      (if config.scale.method == "factor" then "scale" else "scale-from") +
+      " ${toString config.scale.x}x${toString config.scale.y}"
+    )}
     ${optionalString (config.transform != null) (
       "transform " + concatMapStringsSep "," toString (flatten config.transform)
     )}

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -157,7 +157,7 @@ let
           will be used.
           </para><para>
           This option is a shortcut version of the transform option and they are mutually
-          exclusive. If you have configured transform this configuration will be ignored.
+          exclusive.
         '';
         default = null;
         example = {

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -326,7 +326,7 @@ in
           assertion = opts.scale == null || opts.transform == null;
           message = ''
             Cannot use the profile output options 'scale' and 'transform' simultaneously.
-            Check configuration for profile ${profile} and output ${output}.
+            Check configuration for: programs.autorandr.profiles.${profile}.config.${output}
           '';
         })
         config

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -142,7 +142,20 @@ let
             };
           };
         });
-        description = "Output scale configuration.";
+        description = ''
+          Output scale configuration.
+
+          Either configure by pixels or a scaling factor. When using pixel method the
+          <citerefentry>
+            <refentrytitle>xrandr</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>
+          option --scale-from will be used; when using factor method the option --scale
+          will be used.
+
+          This option is a shortcut version of the transform option and they are mutually
+          exclusive. If you have configured transform this configuration will be ignored.
+        '';
         default = null;
         example = {
           x = 1.25;
@@ -221,7 +234,7 @@ let
     ${optionalString (config.mode != "") "mode ${config.mode}"}
     ${optionalString (config.rate != "") "rate ${config.rate}"}
     ${optionalString (config.rotate != null) "rotate ${config.rotate}"}
-    ${optionalString (config.scale != null) (
+    ${optionalString (config.transform == null && config.scale != null) (
       (if config.scale.method == "factor" then "scale" else "scale-from") +
       " ${toString config.scale.x}x${toString config.scale.y}"
     )}


### PR DESCRIPTION
I found out that these options were missing and I would like to configure them with autorandr. I initially discovered that it was supported from this ticket: https://github.com/wertarbyte/autorandr/issues/42

I see that the nixpkgs is using the fork from phillipberndt.

I have tried this with both the scale and DPI option and it works as expected. Only thing to note is that if you set a DPI option for one screen setup, it didn't seem to change the DPI setting for another one if that one didn't have a DPI setting. Although I am not 100% sure this is the case. That is however autorandr/xrandr and not part of home-manager.