### PR TITLE
Revert "fish: use global for abbr"

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -7,7 +7,7 @@ let
   cfg = config.programs.fish;
 
   abbrsStr = concatStringsSep "\n" (
-    mapAttrsToList (k: v: "abbr --add --global ${k} '${v}'") cfg.shellAbbrs
+    mapAttrsToList (k: v: "abbr --add ${k} '${v}'") cfg.shellAbbrs
   );
 
   aliasesStr = concatStringsSep "\n" (


### PR DESCRIPTION
This reverts commit 601619660de5a86ae6eb95936b7bffc03227dbc2, because it makes the module [incompatible] with fish < 3.

Fish 2.7.1 is packaged with the current stable NixOS release, 18.09.

[incompatible]: https://github.com/fish-shell/fish-shell/blob/2.7.1/doc_src/abbr.txt