### PR TITLE
Sanitize derivation name of systemd units, allowing @ etc

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -27,11 +27,15 @@ let
   buildService = style: name: serviceCfg:
     let
       filename = "${name}.${style}";
+      pathSafeName = lib.replaceChars ["@" ":" "\\" "[" "]"] ["-" "-" "-" "" ""] filename;
 
       # Needed because systemd derives unit names from the ultimate
       # link target.
-      source = pkgs.writeTextDir filename (toSystemdIni serviceCfg)
-        + "/" + filename;
+      source = pkgs.writeTextFile {
+        name = pathSafeName;
+        text = toSystemdIni serviceCfg;
+        destination = "/${filename}";
+      } + "/${filename}";
 
       wantedBy = target:
         {


### PR DESCRIPTION
This is taken from https://github.com/NixOS/nixpkgs/blob/c414e5bd080836376d3a0305535644423dc2cbbb/nixos/modules/system/boot/systemd-lib.nix#L14