### PR TITLE
nix-darwin: activate home-manager through postActivation

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -30,8 +30,8 @@ in
   };
 
   config = mkIf (cfg.users != {}) {
-    system.activationScripts.extraActivation.text =
-      lib.concatStringsSep "\n" (lib.mapAttrsToList (username: usercfg: ''
+    system.activationScripts.postActivation.text =
+      concatStringsSep "\n" (mapAttrsToList (username: usercfg: ''
         echo Activating home-manager configuration for ${username}
         sudo -u ${username} ${usercfg.home.activationPackage}/activate
       '') cfg.users);


### PR DESCRIPTION
I ran into an issue where home-manager was getting activated before the user was created. @rycee [pointed out](https://github.com/kalbasit/shabka/pull/172#discussion_r257829361) that HM is getting activated [too early](https://github.com/LnL7/nix-darwin/blob/166560ca767e98b6f2f3b23a2f4dadb9f849a532/modules/system/activation-scripts.nix#L55-L57).

@ElvishJerricco I have not tested this change yet (still working on the issues I've been having) so please test it out and let us know if it works for you.