### PR TITLE
nix-darwin module: support Nix-Darwin user packages install

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -11,7 +11,7 @@ let
 
     config = {
       submoduleSupport.enable = true;
-      submoduleSupport.externalPackageInstall = true;
+      submoduleSupport.externalPackageInstall = cfg.useUserPackages;
 
       home.username = config.users.users.${name}.name;
       home.homeDirectory = config.users.users.${name}.home;
@@ -22,12 +22,19 @@ in
 
 {
   options = {
-    home-manager.users = mkOption {
-      type = types.attrsOf hmModule;
-      default = {};
-      description = ''
-        Per-user Home Manager configuration.
+    home-manager = {
+      useUserPackages = mkEnableOption ''
+        installation of user packages through the
+        <option>users.users.&lt;name?&gt;.packages</option> option.
       '';
+
+      users = mkOption {
+        type = types.attrsOf hmModule;
+        default = {};
+        description = ''
+          Per-user Home Manager configuration.
+        '';
+      };
     };
   };
 

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -11,6 +11,8 @@ let
 
     config = {
       submoduleSupport.enable = true;
+      submoduleSupport.externalPackageInstall = true;
+
       home.username = config.users.users.${name}.name;
       home.homeDirectory = config.users.users.${name}.home;
     };


### PR DESCRIPTION
When using the Nix-Darwin module we cannot guarantee that the Nix store
will be writable during startup. Installing the user packages through
`nix-env -i` will fail in these cases.

This commit adds a Nix-Darwin option `home-manager.useUserPackages` that,
when enabled, installs user packages through the Nix-Darwin

    users.users.<name?>.packages

option.

Note, when submodule support and external package install is enabled
then the installed packages are not available in `~/.nix-profile`. We, therefore, set `home.profileDirectory` directly to the HM profile
packages.


depends on https://github.com/LnL7/nix-darwin/pull/127