### PR TITLE
nix-darwin: login as the user when activating

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -33,7 +33,7 @@ in
     system.activationScripts.extraActivation.text =
       lib.concatStringsSep "\n" (lib.mapAttrsToList (username: usercfg: ''
         echo Activating home-manager configuration for ${username}
-        sudo -u ${username} ${usercfg.home.activationPackage}/activate
+        sudo -u ${username} -i ${usercfg.home.activationPackage}/activate
       '') cfg.users);
   };
 }


### PR DESCRIPTION
Log in as the user when activating a home-manager configuration on Nix-Darwin. Otherwise, the `$HOME` is not set correctly and might inadvertently setup the HOME for the current user invoking the switch, although that might also fail with a permission denied error.

This pr depends on https://github.com/LnL7/nix-darwin/pull/128

cc @ElvishJerricco