### PR TITLE
tests: remove tests attribute from root default.nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
 
 script:
   - nix-shell . -A install
-  - nix-shell . -A tests.run.all
+  - nix-shell tests -A run.all

--- a/default.nix
+++ b/default.nix
@@ -11,8 +11,4 @@ rec {
   };
 
   nixos = import ./nixos;
-
-  tests = import ./tests {
-    inherit pkgs;
-  };
 }


### PR DESCRIPTION
Having it there prevented, e.g., `nix-env -qaP` from working in some cases.