### PR TITLE
gnome-terminal: add support for light/dark theme variants

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -141,6 +141,12 @@ in
         description = "Whether to show the menubar by default";
       };
 
+      themeVariant = mkOption {
+        default = "default";
+        type = types.enum [ "default" "light" "dark" ];
+        description = "The theme variation to request";
+      };
+
       profile = mkOption {
         default = {};
         type = types.attrsOf profileSubModule;
@@ -159,6 +165,7 @@ in
         {
           "${dconfPath}" = {
             default-show-menubar = cfg.showMenubar;
+            theme-variant = cfg.themeVariant;
             schema-version = 3;
           };
 


### PR DESCRIPTION
Gnome Terminal allows you to select the theme variant in its general settings. This adds support for that to home-manager.

Though "theme variant" seems like a more general feature than simply "dark" or "light", it appears Gnome Terminal only supports "dark" or "light". Anything else gets ignored as default. So I decided to encode it that way as an enum.