### PR TITLE
nixos/home-manager: evaluate assertions from home-manager modules

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -44,6 +44,12 @@ in
   };
 
   config = mkIf (cfg.users != {}) {
+    assertions = flatten
+      (flip mapAttrsToList cfg.users
+        (user: config: flip map config.assertions
+          (assertion:
+            { inherit (assertion) assertion; message = "${user} profile: ${assertion.message}"; })));
+
     users.users = mkIf cfg.useUserPackages (
       mapAttrs (username: usercfg: {
         packages = usercfg.home.packages;


### PR DESCRIPTION
Until now all assertions defined by home-manager modules were ignored as they were evaluated in `modules/default.nix` which isn't used for the module.

This gathers all assertions from all profile's config, so invalid home-manager configuration actually breaks nixos-rebuild if the `home-manager` module is used.