### PR TITLE
alacritty: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -34,6 +34,7 @@ let
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/xdg.nix { })
     (loadModule ./programs/afew.nix { })
+    (loadModule ./programs/alacritty.nix { })
     (loadModule ./programs/alot.nix { })
     (loadModule ./programs/astroid.nix { })
     (loadModule ./programs/autorandr.nix { })

--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.alacritty;
+
+in
+
+{
+  options = {
+    programs.alacritty = {
+      enable = mkEnableOption "Alacritty";
+
+      settings = mkOption {
+        type = types.attrs;
+        default = {};
+        example = literalExample ''
+          {
+            window.dimensions = {
+              lines = 3;
+              columns = 200;
+            };
+            key_bindings = [
+              {
+                key = "K";
+                mods = "Control";
+                chars = "\\x0c";
+              }
+            ];
+          }
+        '';
+        description = ''
+          Configuration written to <filename>~/.config/alacritty/alacritty.yml</filename>.
+          See <link xlink:href="https://github.com/jwilm/alacritty/blob/master/alacritty.yml">the default config file</link> for possible values.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.alacritty ];
+
+    xdg.configFile."alacritty/alacritty.yml".text = replaceStrings ["\\\\"] ["\\"] (builtins.toJSON cfg.settings);
+  };
+}


### PR DESCRIPTION
supersedes #500.

We point to the good documentation in the example config file provided by alacritty.

This depends on alacritty 0.2.6.