### PR TITLE
git: optional userName/userEmail

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -88,12 +88,14 @@ in
       };
 
       userName = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
+        default = null;
         description = "Default user name to use.";
       };
 
       userEmail = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
+        default = null;
         description = "Default user email to use.";
       };
 
@@ -168,8 +170,8 @@ in
         home.packages = [ cfg.package ];
 
         programs.git.iniContent.user = {
-          name = cfg.userName;
-          email = cfg.userEmail;
+          name = mkIf (cfg.userName != null) cfg.userName;
+          email = mkIf (cfg.userEmail != null) cfg.userEmail;
         };
 
         xdg.configFile = {


### PR DESCRIPTION
There are other ways to provide these variables to git, so it really shouldn't be required.

In particular, the use of `programs.git.extraConfig.user.useConfigOnly=true` - this option could be added to `programs.git` and enforce `user*` when default/false, though it's not clear to me whether that's the correct approach or if this is the only scenario where one would want to have these unset set in .gitconfig.