### PR TITLE
git: support nested sections and multiple values

### DIFF
--- a/tests/modules/programs/git-expected.conf
+++ b/tests/modules/programs/git-expected.conf
@@ -8,6 +8,8 @@ gpgSign=true
 [extra]
 boolean=true
 integer=38
+multiple=1
+multiple=2
 name=value
 
 [filter "lfs"]

--- a/tests/modules/programs/git-expected.conf
+++ b/tests/modules/programs/git-expected.conf
@@ -12,6 +12,12 @@ multiple=1
 multiple=2
 name=value
 
+[extra "backcompat.with.dots"]
+previously=worked
+
+[extra "subsection"]
+value=test
+
 [filter "lfs"]
 clean=git-lfs clean -- %f
 process=git-lfs filter-process
@@ -27,10 +33,10 @@ name=John Doe
 signingKey=00112233445566778899AABBCCDDEEFF
 
 [include]
-path = ~/path/to/config.inc
+path=~/path/to/config.inc
 
 [includeIf "gitdir:~/src/dir"]
-path = ~/path/to/conditional.inc
+path=~/path/to/conditional.inc
 
 [includeIf "gitdir:~/src/dir"]
-path = @git_include_path@
+path=@git_include_path@

--- a/tests/modules/programs/git.nix
+++ b/tests/modules/programs/git.nix
@@ -58,9 +58,11 @@ in
 
       {
         aliases.a2 = mkForce "baz";
+        extraConfig."extra \"backcompat.with.dots\"".previously = "worked";
         extraConfig.extra.boolean = true;
         extraConfig.extra.integer = 38;
         extraConfig.extra.multiple = [2];
+        extraConfig.extra.subsection.value = "test";
       }
     ];
 

--- a/tests/modules/programs/git.nix
+++ b/tests/modules/programs/git.nix
@@ -31,6 +31,7 @@ in
         extraConfig = {
           extra = {
             name = "value";
+            multiple = [1];
           };
         };
         ignores = [ "*~" "*.swp" ];
@@ -59,6 +60,7 @@ in
         aliases.a2 = mkForce "baz";
         extraConfig.extra.boolean = true;
         extraConfig.extra.integer = 38;
+        extraConfig.extra.multiple = [2];
       }
     ];
 


### PR DESCRIPTION
A few improvements to git configs here to be more in line with how the `git-config` CLI presents and parses option names:

- Options that should appear multiple times can now be specified using lists:
    `programs.git.extraConfig.key = [value1 value2]`
- Options with subsections can now be specified with `programs.git.extraConfig.filter.etc.stuff` instead of `programs.git.extraConfig."filter \"etc\"".stuff`