### PR TITLE
Remove some use of `mkDerivation`

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -12,11 +12,20 @@ let
 
 in
 
-pkgs.stdenv.mkDerivation {
-  name = "home-manager";
-
-  buildCommand = ''
-    install -v -D -m755 ${./home-manager} $out/bin/home-manager
+pkgs.runCommand
+  "home-manager"
+  {
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+    meta = with pkgs.stdenv.lib; {
+      description = "A user environment configurator";
+      maintainers = [ maintainers.rycee ];
+      platforms = platforms.unix;
+      license = licenses.mit;
+    };
+  }
+  ''
+    install -v -D -m755  ${./home-manager} $out/bin/home-manager
 
     substituteInPlace $out/bin/home-manager \
       --subst-var-by bash "${pkgs.bash}" \
@@ -25,12 +34,4 @@ pkgs.stdenv.mkDerivation {
       --subst-var-by gnused "${pkgs.gnused}" \
       --subst-var-by less "${pkgs.less}" \
       --subst-var-by HOME_MANAGER_PATH '${pathStr}'
-  '';
-
-  meta = with pkgs.stdenv.lib; {
-    description = "A user environment configurator";
-    maintainers = [ maintainers.rycee ];
-    platforms = platforms.unix;
-    license = licenses.mit;
-  };
-}
+  ''

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -210,17 +210,16 @@ in
       '') (filter (v: v.onChange != "") (attrValues cfg))
     );
 
-    home-files = pkgs.stdenv.mkDerivation {
-      name = "home-manager-files";
-
-      nativeBuildInputs = [ pkgs.xlibs.lndir ];
-
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-
-      # Symlink directories and files that have the right execute bit.
-      # Copy files that need their execute bit changed.
-      buildCommand = ''
+    # Symlink directories and files that have the right execute bit.
+    # Copy files that need their execute bit changed.
+    home-files = pkgs.runCommand
+      "home-manager-files"
+      {
+        nativeBuildInputs = [ pkgs.xlibs.lndir ];
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+      }
+      (''
         mkdir -p $out
 
         function insertFile() {
@@ -279,7 +278,6 @@ in
                         else builtins.toString v.executable}" \
                      "${builtins.toString v.recursive}"
         '') cfg
-      );
-    };
+      ));
   };
 }

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -383,13 +383,13 @@ in
           ${activationCmds}
         '';
       in
-        pkgs.stdenv.mkDerivation {
-          name = "home-manager-generation";
-
-          preferLocalBuild = true;
-          allowSubstitutes = false;
-
-          buildCommand = ''
+        pkgs.runCommand
+          "home-manager-generation"
+          {
+            preferLocalBuild = true;
+            allowSubstitutes = false;
+          }
+          ''
             mkdir -p $out
 
             cp ${activationScript} $out/activate
@@ -402,7 +402,6 @@ in
 
             ${cfg.extraBuilderCommands}
           '';
-        };
 
     home.path = pkgs.buildEnv {
       name = "home-manager-path";


### PR DESCRIPTION
Instead use `runCommand`, which by default uses `stdenvNoCC` resulting in a reduced dependency footprint.

Fixes #612