### PR TITLE
Add vscode keybindings

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -28,6 +28,23 @@ in
         '';
       };
 
+      userKeybindings = mkOption {
+        type = types.listOf types.attrs;
+        default = [];
+        example = literalExample ''
+          [
+            {
+              "key": "ctrl+h",
+              "command": "workbench.action.navigateLeft"
+            }
+          ]
+        '';
+        description = ''
+          Configuration written to
+          <filename>~/.config/Code/User/keybindings.json</filename>.
+        '';
+      };
+
       extensions = mkOption {
         type = types.listOf types.package;
         default = [];
@@ -48,5 +65,8 @@ in
 
     xdg.configFile."Code/User/settings.json".text =
       builtins.toJSON cfg.userSettings;
+
+    xdg.configFile."Code/User/keybindings.json".text =
+      builtins.toJSON cfg.userKeybindings;
   };
 }

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -34,8 +34,12 @@ in
         example = literalExample ''
           [
             {
-              "key": "ctrl+h",
-              "command": "workbench.action.navigateLeft"
+              "key" = "ctrl+h";
+              "command" = "workbench.action.navigateLeft";
+            }
+            {
+              "key" = "ctrl+l";
+              "command" = "workbench.action.navigateRight";
             }
           ]
         '';


### PR DESCRIPTION
This PR adds a `userKeybindings` option that allows a user to create custom keybindings in the nix configuration. This option was mostly copied from the existing `userSettings` option.