### PR TITLE
Use attrsOf instead of attrs

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -146,7 +146,7 @@ in
 
     home.sessionVariables = mkOption {
       default = {};
-      type = types.attrs;
+      type = with types; attrsOf (either int str);
       example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
       description = ''
         Environment variables to always set at login.

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -120,7 +120,7 @@ in
 
       gtk3 = {
         extraConfig = mkOption {
-          type = types.attrs;
+          type = with types; attrsOf (either bool (either int str));
           default = {};
           example = { gtk-cursor-blink = false; gtk-recent-files-limit = 20; };
           description = ''

--- a/modules/misc/pam.nix
+++ b/modules/misc/pam.nix
@@ -14,7 +14,7 @@ in
   options = {
     pam.sessionVariables = mkOption {
       default = {};
-      type = types.attrs;
+      type = with types; attrsOf (either int str);
       example = { EDITOR = "vim"; };
       description = ''
         Environment variables that will be set for the PAM session.

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -72,7 +72,7 @@ in
 
       sessionVariables = mkOption {
         default = {};
-        type = types.attrs;
+        type = with types; attrsOf (either int str);
         example = { MAILCHECK = 30; };
         description = ''
           Environment variables that will be set for the Bash session.
@@ -81,12 +81,12 @@ in
 
       shellAliases = mkOption {
         default = {};
+        type = types.attrsOf types.str;
         example = { ll = "ls -l"; ".." = "cd .."; };
         description = ''
           An attribute set that maps aliases (the top level attribute names in
           this option) to command strings or directly to build outputs.
         '';
-        type = types.attrs;
       };
 
       enableAutojump = mkOption {

--- a/modules/programs/feh.nix
+++ b/modules/programs/feh.nix
@@ -17,7 +17,7 @@ in
 
     keybindings = mkOption {
       default = {};
-      type = types.attrs;
+      type = types.attrsOf types.str;
       example = { zoom_in = "plus"; zoom_out = "minus"; };
       description = ''
         Set keybindings.

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -167,7 +167,7 @@ in
           An attribute set that maps aliases (the top level attribute names in
           this option) to command strings or directly to build outputs.
         '';
-        type = types.attrs;
+        type = types.attrsOf types.str;
       };
 
       enableCompletion = mkOption {
@@ -202,7 +202,7 @@ in
 
       sessionVariables = mkOption {
         default = {};
-        type = types.attrs;
+        type = with types; attrsOf (either int str);
         example = { MAILCHECK = 30; };
         description = "Environment variables that will be set for zsh session.";
       };


### PR DESCRIPTION
Replaces some unnecessary use of `types.attrs`.