### PR TITLE
Overlay fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,12 @@
 { pkgs ? import <nixpkgs> {} }:
 
 rec {
-  home-manager = import ./home-manager {
-    inherit pkgs;
+  home-manager = pkgs.callPackage ./home-manager {
     path = toString ./.;
   };
 
-  install = import ./home-manager/install.nix {
-    inherit home-manager pkgs;
+  install = pkgs.callPackage ./home-manager/install.nix {
+    inherit home-manager;
   };
 
   nixos = import ./nixos;

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,4 +1,4 @@
-{ pkgs
+{ runCommand, lib, bash, coreutils, findutils, gnused, less
 
   # Extra path to Home Manager. If set then this path will be tried
   # before `$HOME/.config/nixpkgs/home-manager` and
@@ -12,12 +12,12 @@ let
 
 in
 
-pkgs.runCommand
+runCommand
   "home-manager"
   {
     preferLocalBuild = true;
     allowSubstitutes = false;
-    meta = with pkgs.stdenv.lib; {
+    meta = with lib; {
       description = "A user environment configurator";
       maintainers = [ maintainers.rycee ];
       platforms = platforms.unix;
@@ -28,10 +28,10 @@ pkgs.runCommand
     install -v -D -m755  ${./home-manager} $out/bin/home-manager
 
     substituteInPlace $out/bin/home-manager \
-      --subst-var-by bash "${pkgs.bash}" \
-      --subst-var-by coreutils "${pkgs.coreutils}" \
-      --subst-var-by findutils "${pkgs.findutils}" \
-      --subst-var-by gnused "${pkgs.gnused}" \
-      --subst-var-by less "${pkgs.less}" \
+      --subst-var-by bash "${bash}" \
+      --subst-var-by coreutils "${coreutils}" \
+      --subst-var-by findutils "${findutils}" \
+      --subst-var-by gnused "${gnused}" \
+      --subst-var-by less "${less}" \
       --subst-var-by HOME_MANAGER_PATH '${pathStr}'
   ''

--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -1,6 +1,6 @@
-{ home-manager, pkgs }:
+{ home-manager, runCommand }:
 
-pkgs.runCommand
+runCommand
   "home-manager-install"
   {
     propagatedBuildInputs = [ home-manager ];

--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -34,8 +34,7 @@ in
 
   config = mkIf (cfg.enable && !config.submoduleSupport.enable) {
     home.packages = [
-      (import ../../home-manager {
-        inherit pkgs;
+      (pkgs.callPackage ../../home-manager {
         inherit (cfg) path;
       })
     ];

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,6 @@
 self: super: {
-  home-manager = import ./home-manager { pkgs = super; };
+  home-manager = import ./home-manager {
+    pkgs = self;
+    path = toString ./.;
+  };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,5 @@
 self: super: {
-  home-manager = import ./home-manager {
-    pkgs = self;
+  home-manager = super.callPackage ./home-manager {
     path = toString ./.;
   };
 }


### PR DESCRIPTION
The overlay using `super` for package dependencies means it was getting them from some earlier stage in nixpkgs' bootstrap and caused a rebuild of all dependencies (bash/find/etc). Using `self` instead properly allows installing it with the usual versions of these from the nix cache.

Using callPackage really doesn't matter much but it seemed appropriate so I figured I'd include it.