### PR TITLE
modules: inform module system about the base modules path

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,6 +23,9 @@ let
     modules =
       [ configuration ]
       ++ (import ./modules.nix { inherit check lib pkgs; });
+    specialArgs = {
+      modulesPath = builtins.toString ./.;
+    };
   };
 
   module = showWarnings (


### PR DESCRIPTION
This is needed, for example, to support relative paths when disabling modules.

Related to #602.