### PR TITLE
add facility for email aliases

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -207,6 +207,13 @@ let
         description = "The email address of this account.";
       };
 
+      aliases = mkOption {
+        type = types.listOf (types.strMatching ".*@.*");
+        default = [];
+        example = [ "webmaster@example.org" "admin@example.org" ];
+        description = "Alternative email addresses of this account.";
+      };
+
       realName = mkOption {
         type = types.str;
         example = "Jane Doe";

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -22,6 +22,9 @@ let
           sendmail_command =
             optionalString (alot.sendMailCommand != null) alot.sendMailCommand;
         }
+        // optionalAttrs (aliases != []) {
+          aliases = concatStringsSep "," aliases;
+        }
         // optionalAttrs (gpg != null) {
           gpg_key = gpg.key;
           encrypt_by_default = if gpg.encryptByDefault then "all" else "none";

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -42,7 +42,9 @@ let
           in {
             name = catAttrs "realName" primary;
             primary_email = catAttrs "address" primary;
-            other_email = catAttrs "address" secondaries;
+            other_email = catAttrs "aliases" primary
+              ++ catAttrs "address" secondaries
+              ++ catAttrs "aliases" secondaries;
           };
 
         search = {


### PR DESCRIPTION
This adds a new option `aliases` and corresponding configuration for notmuch and
alot which make use of this. An email alias can be thought of as an alternative
email address which shares the same mailbox, which is distinct from managing two
separate accounts.