### PR TITLE
fix alot address book completion regex

### DIFF
--- a/modules/programs/alot-accounts.nix
+++ b/modules/programs/alot-accounts.nix
@@ -20,11 +20,11 @@ with lib;
         type = "shellcommand";
         command = "'${pkgs.notmuch}/bin/notmuch address --format=json --output=recipients  date:6M..'";
         regexp =
-          "'\[?{"
+          "'\\[?{"
           + ''"name": "(?P<name>.*)", ''
           + ''"address": "(?P<email>.+)", ''
           + ''"name-addr": ".*"''
-          + "}[,\]]?'";
+          + "}[,\\]]?'";
         shellcommand_external_filtering = "False";
       };
       example = literalExample ''


### PR DESCRIPTION
The brackets `[` and `]` weren't escaped properly in the nix string, so every
time you tried to use it it gave

```python
Traceback (most recent call last):
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/bin/.alot-wrapped", line 11, in <module>
    sys.exit(main())
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/__main__.py", line 137, in main
    UI(dbman, cmdstring)
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/ui.py", line 141, in __init__
    self.mainloop.run()
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/main_loop.py", line 278, in run
    self._run()
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/main_loop.py", line 376, in _run
    self.event_loop.run()
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/main_loop.py", line 1186, in run
    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/main_loop.py", line 1200, in wrapper
    rval = f(*args,**kargs)
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/raw_display.py", line 393, in <lambda>
    event_loop, callback, self.get_available_raw_input())
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/raw_display.py", line 493, in parse_input
    callback(processed, processed_codes)
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/main_loop.py", line 403, in _update
    self.process_input(keys)
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/main_loop.py", line 503, in process_input
    k = self._topmost_widget.keypress(self.screen_size, k)
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/container.py", line 592, in keypress
    *self.calculate_padding_filler(size, True)), key)
  File "/nix/store/7c7ykw5jr2574d5xcr4v35zzygg7i88g-python3.7-urwid-1.3.1/lib/python3.7/site-packages/urwid/container.py", line 2269, in keypress
    key = w.keypress((mc,) + size[1:], key)
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/widgets/globals.py", line 145, in keypress
    self.edit_pos)
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/completion.py", line 118, in complete
      for c, _ in self._completer.complete(mypart, mypos):
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/completion.py", line 243, in complete
    res = res + abook.lookup(prefix)
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/addressbook/external.py", line 49, in lookup
    return AddressBook.lookup(self, prefix)
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/addressbook/__init__.py", line 36, in lookup
    for name, email in self.get_contacts():
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/addressbook/external.py", line 43, in get_contacts
    return self._call_and_parse(self.commandline)
  File "/nix/store/xg6m9cr8qvbsgp9zhkqhfwqd0qa8g6zi-python3.7-alot-0.8/lib/python3.7/site-packages/alot/addressbook/external.py", line 66, in _call_and_parse
    m = re.match(self.regex, l, self.reflags)
  File "/nix/store/gbwx5sc4w0i0ipnmsa0nsk88svs983vl-python3-3.7.2/lib/python3.7/re.py", line 173, in match
    return _compile(pattern, flags).match(string)
  File "/nix/store/gbwx5sc4w0i0ipnmsa0nsk88svs983vl-python3-3.7.2/lib/python3.7/re.py", line 286, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/nix/store/gbwx5sc4w0i0ipnmsa0nsk88svs983vl-python3-3.7.2/lib/python3.7/sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "/nix/store/gbwx5sc4w0i0ipnmsa0nsk88svs983vl-python3-3.7.2/lib/python3.7/sre_parse.py", line 930, in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
  File "/nix/store/gbwx5sc4w0i0ipnmsa0nsk88svs983vl-python3-3.7.2/lib/python3.7/sre_parse.py", line 426, in _parse_sub
    not nested and not items))
  File "/nix/store/gbwx5sc4w0i0ipnmsa0nsk88svs983vl-python3-3.7.2/lib/python3.7/sre_parse.py", line 580, in _parse
    raise source.error(msg, len(this) + 1 + len(that))
re.error: bad character range e-a at position 59
```

This escapes the regex properly.