### PR TITLE
home-environment: make `home.keyboard` optional

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -139,9 +139,12 @@ in
     };
 
     home.keyboard = mkOption {
-      type = keyboardSubModule;
+      type = types.nullOr keyboardSubModule;
       default = {};
-      description = "Keyboard configuration.";
+      description = ''
+        Keyboard configuration. Set to <literal>null</literal> to
+        disable Home Manager keyboard management.
+      '';
     };
 
     home.sessionVariables = mkOption {


### PR DESCRIPTION
When set to `null` then the `xsession` module will not attempt to manage the keyboard settings.