### PR TITLE
manual: add option manual.json.enable

### DIFF
--- a/modules/manual.nix
+++ b/modules/manual.nix
@@ -84,7 +84,7 @@ in
       '';
     };
     
-    manual.optionList.enable = mkOption {
+    manual.json.enable = mkOption {
       type = types.bool;
       default = false;
       example = true;

--- a/modules/manual.nix
+++ b/modules/manual.nix
@@ -83,13 +83,25 @@ in
         Thanks!
       '';
     };
+    
+    manual.optionList.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to install a list of all Home Manager options (as JSON).
+        This can be located at <filename>$HOME/.nix-profile/share/doc/home-manager/options.json</filename>,
+        and may be used for navigating definitions, autocompleting, and other miscellaneous tasks.
+      '';
+    };
+    
   };
 
   config = {
     home.packages = mkMerge [
       (mkIf cfg.html.enable [ helpScript homeManagerManual.manual  ])
-
       (mkIf cfg.manpages.enable [ homeManagerManual.manpages ])
+      (mkIf cfg.optionList.enable [ homeManagerManual.optionsJSON ])
     ];
   };
 


### PR DESCRIPTION
This useful JSON list was previously inaccessible as a package or a module; at least as far as I could tell.
I suspect it was being used internally. It is incredibly useful for building auto-completion lists in various IDEs, as a navigation tool (combined with `jq`), and surely for other scripting tasks. I personally am using it to build a `home-manager-options` mimicking the existing `nixos-options` utility.