### PR TITLE
browserpass: change firefox path for v3

### DIFF
--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -58,8 +58,8 @@ in {
           target = (if isDarwin
             then "Library/Application Support/Mozilla/NativeMessagingHosts"
             else ".mozilla/native-messaging-hosts")
-            + "/com.dannyvankooten.browserpass.json";
-          source = "${pkgs.browserpass}/lib/mozilla/native-messaging-hosts/com.dannyvankooten.browserpass.json";
+            + "/com.github.browserpass.native.json";
+          source = "${pkgs.browserpass}/lib/mozilla/native-messaging-hosts/com.github.browserpass.native.json";
         } ]
       else if x == "vivaldi" then
         let dir = if isDarwin


### PR DESCRIPTION
After browserpass extension update it stopped working and this is what I had to change for it to work.

@dermetfan, could you please revisit and update this wonderful module of yours?
