### PR TITLE
dconf: Allow values to be floats

### DIFF
--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -19,7 +19,7 @@ let
     in
       "${key}=${tweakVal value}";
 
-  primitive = with types; either bool (either int str);
+  primitive = with types; either bool (either int (either float str));
 
 in
 


### PR DESCRIPTION
Technically dconf calls these "double" but nix floats ought to work.