### PR TITLE
config.home: backup file collisions

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -357,6 +357,7 @@ function doHelp() {
     echo "  -A ATTRIBUTE Optional attribute that selects a configuration"
     echo "               expression in the configuration file."
     echo "  -I PATH      Add a path to the Nix expression search path."
+    echo "  -b EXT       Move existing files to new path rather than fail."
     echo "  -v           Verbose output"
     echo "  -n           Do a dry run, only prints what actions would be taken"
     echo "  -h           Print this help"
@@ -399,7 +400,7 @@ for arg in "$@"; do
     fi
 done
 
-while getopts 2f:I:A:vnh opt; do
+while getopts 2f:I:A:b:vnh opt; do
     case $opt in
         2)
             USE_NIX2_COMMAND=1
@@ -412,6 +413,9 @@ while getopts 2f:I:A:vnh opt; do
             ;;
         A)
             HOME_MANAGER_CONFIG_ATTRIBUTE="$OPTARG"
+            ;;
+        b)
+            export HOME_MANAGER_BACKUP_EXT="$OPTARG"
             ;;
         v)
             export VERBOSE=1

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -59,17 +59,22 @@ in
             targetPath="$HOME/$relativePath"
             if [[ -e "$targetPath" \
                 && ! "$(readlink "$targetPath")" == ${homeFilePattern} ]] ; then
-              backup="''${targetPath}.hm-bak"
-              warnEcho "Existing file '$targetPath' is in the way - moving to $backup"
-              if ! mv "$targetPath" "$backup"; then
-                errorEcho "Moving '$targetPath' failed!"
+              if [[ -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+                backup="''${targetPath}''${HOME_MANAGER_BACKUP_EXT}"
+                warnEcho "Existing file '$targetPath' is in the way - moving to $backup"
+                if ! mv "$targetPath" "$backup"; then
+                  errorEcho "Moving '$targetPath' failed!"
+                  collision=1
+                fi
+              else
+                errorEcho "Existing file '$targetPath' is in the way"
                 collision=1
               fi
             fi
           done
 
           if [[ -v collision ]] ; then
-            errorEcho "Please move the above files and try again"
+            errorEcho "Please move the above files and try again or use -b to move automatically."
             exit 1
           fi
         '';

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -62,10 +62,6 @@ in
               if [[ -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
                 backup="''${targetPath}''${HOME_MANAGER_BACKUP_EXT}"
                 warnEcho "Existing file '$targetPath' is in the way - moving to $backup"
-                if ! mv "$targetPath" "$backup"; then
-                  errorEcho "Moving '$targetPath' failed!"
-                  collision=1
-                fi
               else
                 errorEcho "Existing file '$targetPath' is in the way"
                 collision=1
@@ -120,6 +116,10 @@ in
           for sourcePath in "$@" ; do
             relativePath="''${sourcePath#$newGenFiles/}"
             targetPath="$HOME/$relativePath"
+            if [[ -e "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+              backup="''${targetPath}''${HOME_MANAGER_BACKUP_EXT}"
+              $DRY_RUN_CMD mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
+            fi
             $DRY_RUN_CMD mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
             $DRY_RUN_CMD ln -nsf $VERBOSE_ARG "$sourcePath" "$targetPath"
           done

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -59,8 +59,12 @@ in
             targetPath="$HOME/$relativePath"
             if [[ -e "$targetPath" \
                 && ! "$(readlink "$targetPath")" == ${homeFilePattern} ]] ; then
-              errorEcho "Existing file '$targetPath' is in the way"
-              collision=1
+              backup="''${targetPath}.hm-bak"
+              warnEcho "Existing file '$targetPath' is in the way - moving to $backup"
+              if ! mv "$targetPath" "$backup"; then
+                errorEcho "Moving '$targetPath' failed!"
+                collision=1
+              fi
             fi
           done
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1062,8 +1062,9 @@ in
       {
         time = "2019-04-17T19:12:34+00:00";
         message = ''
-          Managed file collisions are now handled by moving the target file to
-          a new path instead of failing the switch command.
+          Managed file collisions can now be handled by moving the target file to
+          a new path instead of failing the switch command by passing -b <ext> to
+          home-manager.
         '';
       }
     ];

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1059,7 +1059,7 @@ in
         '';
       }
 
-       {
+      {
         time = "2019-04-22T12:43:20+00:00";
         message = ''
           A new module is available: 'programs.alacritty'.

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1059,19 +1059,21 @@ in
         '';
       }
 
+       {
+        time = "2019-04-22T12:43:20+00:00";
+        message = ''
+          A new module is available: 'programs.alacritty'.
+        '';
+      }
+
       {
+        time = "2019-06-04T21:43:20+00:00";
         message = ''
           Managed file collisions can now be handled by moving the target file to
           a new path instead of failing the switch command by passing -b <ext> to
           home-manager.
         '';
        }
-       
-       {
-        message = ''
-          A new module is available: 'programs.alacritty'.
-        '';
-      }
     ];
   };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1058,6 +1058,14 @@ in
           A new module is available: 'programs.skim'.
         '';
       }
+
+      {
+        time = "2019-04-17T19:12:34+00:00";
+        message = ''
+          Managed file collisions are now handled by moving the target file to
+          a new path instead of failing the switch command.
+        '';
+      }
     ];
   };
 }


### PR DESCRIPTION
When a configuration file would be written to an existing file,
rather than failing switch (and having the user have to move or delete
those files), move the files automatically to a new path.

Closes #585