### PR TITLE
Fix type of various `sessionVariables` options

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -149,7 +149,7 @@ in
 
     home.sessionVariables = mkOption {
       default = {};
-      type = with types; attrsOf (either int str);
+      type = types.attrs;
       example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
       description = ''
         Environment variables to always set at login.
@@ -167,19 +167,19 @@ in
         variable may have a runtime dependency on another session
         variable. In particular code like
         <programlisting language="nix">
-          home.sessionVariables = {
-            FOO = "Hello";
-            BAR = "$FOO World!";
-          };
+        home.sessionVariables = {
+          FOO = "Hello";
+          BAR = "$FOO World!";
+        };
         </programlisting>
         may not work as expected. If you need to reference another
         session variable, then do so inside Nix instead. The above
         example then becomes
         <programlisting language="nix">
-          home.sessionVariables = {
-            FOO = "Hello";
-            BAR = "''${config.home.sessionVariables.FOO} World!";
-          };
+        home.sessionVariables = {
+          FOO = "Hello";
+          BAR = "''${config.home.sessionVariables.FOO} World!";
+        };
         </programlisting>
       '';
     };

--- a/modules/misc/pam.nix
+++ b/modules/misc/pam.nix
@@ -14,7 +14,7 @@ in
   options = {
     pam.sessionVariables = mkOption {
       default = {};
-      type = with types; attrsOf (either int str);
+      type = types.attrs;
       example = { EDITOR = "vim"; };
       description = ''
         Environment variables that will be set for the PAM session.

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -72,7 +72,7 @@ in
 
       sessionVariables = mkOption {
         default = {};
-        type = with types; attrsOf (either int str);
+        type = types.attrs;
         example = { MAILCHECK = 30; };
         description = ''
           Environment variables that will be set for the Bash session.

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -202,7 +202,7 @@ in
 
       sessionVariables = mkOption {
         default = {};
-        type = with types; attrsOf (either int str);
+        type = types.attrs;
         example = { MAILCHECK = 30; };
         description = "Environment variables that will be set for zsh session.";
       };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -31,8 +31,12 @@ import nmt {
     {
       i3-keybindings = ./modules/services/window-managers/i3-keybindings.nix;
     }
+    // import ./modules/misc/pam
     // import ./modules/systemd
   )
+  // import ./modules/home-environment
+  // import ./modules/programs/bash
   // import ./modules/programs/ssh
-  // import ./modules/programs/tmux;
+  // import ./modules/programs/tmux
+  // import ./modules/programs/zsh;
 }

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -1,0 +1,3 @@
+{
+  home-session-variables = ./session-variables.nix;
+}

--- a/tests/modules/home-environment/session-variables-expected.txt
+++ b/tests/modules/home-environment/session-variables-expected.txt
@@ -1,0 +1,6 @@
+# Only source this once.
+if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+export __HM_SESS_VARS_SOURCED=1
+
+export V1="v1"
+export V2="v2-v1"

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    home.sessionVariables = {
+      V1 = "v1";
+      V2 = "v2-${config.home.sessionVariables.V1}";
+    };
+
+    nmt.script = ''
+      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+      assertFileContent \
+        home-path/etc/profile.d/hm-session-vars.sh \
+        ${./session-variables-expected.txt}
+    '';
+  };
+}

--- a/tests/modules/misc/pam/default.nix
+++ b/tests/modules/misc/pam/default.nix
@@ -1,0 +1,3 @@
+{
+  pam-session-variables = ./session-variables.nix;
+}

--- a/tests/modules/misc/pam/session-variables-expected.txt
+++ b/tests/modules/misc/pam/session-variables-expected.txt
@@ -1,0 +1,2 @@
+V1 OVERRIDE="v1"
+V2 OVERRIDE="v2-v1"

--- a/tests/modules/misc/pam/session-variables.nix
+++ b/tests/modules/misc/pam/session-variables.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    pam.sessionVariables = {
+      V1 = "v1";
+      V2 = "v2-${config.pam.sessionVariables.V1}";
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.pam_environment
+      assertFileContent \
+        home-files/.pam_environment \
+        ${./session-variables-expected.txt}
+    '';
+  };
+}

--- a/tests/modules/programs/bash/default.nix
+++ b/tests/modules/programs/bash/default.nix
@@ -1,0 +1,3 @@
+{
+  bash-session-variables = ./session-variables.nix;
+}

--- a/tests/modules/programs/bash/session-variables-expected.txt
+++ b/tests/modules/programs/bash/session-variables-expected.txt
@@ -1,0 +1,8 @@
+# -*- mode: sh -*-
+
+. "@homeDirectory@/.nix-profile/etc/profile.d/hm-session-vars.sh"
+
+export V1="v1"
+export V2="v2-v1"
+
+

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.bash = {
+      enable = true;
+
+      sessionVariables = {
+        V1 = "v1";
+        V2 = "v2-${config.programs.bash.sessionVariables.V1}";
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.profile
+      assertFileContent \
+        home-files/.profile \
+        ${
+          pkgs.substituteAll {
+            src = ./session-variables-expected.txt;
+            inherit (config.home) homeDirectory;
+          }
+        }
+    '';
+  };
+}

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -1,0 +1,3 @@
+{
+  zsh-session-variables = ./session-variables.nix;
+}

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+
+      sessionVariables = {
+        V1 = "v1";
+        V2 = "v2-${config.programs.zsh.sessionVariables.V1}";
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.zshrc
+      assertFileRegex home-files/.zshrc 'export V1="v1"'
+      assertFileRegex home-files/.zshrc 'export V2="v2-v1"'
+    '';
+  };
+}


### PR DESCRIPTION
Unfortunately, using `attrsOf` is not possible since it results in too eager evaluation. In particular, the

    home.sessionVariables = {
      FOO = "Hello";
      BAR = "${config.home.sessionVariables.FOO} World!";
    };

example will cause an infinite recursion.

This commit restores the option type of

- `home.sessionVariables`,
- `pam.sessionVariables`,
- `programs.bash.sessionVariables`, and
- `programs.zsh.sessionVariables`

to `attrs`. It also adds test cases for the above options to avoid regressions.