### PR TITLE
rsibreak: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -116,6 +116,7 @@ let
     (loadModule ./services/stalonetray.nix { })
     (loadModule ./services/status-notifier-watcher.nix { })
     (loadModule ./services/syncthing.nix { })
+    (loadModule ./services/rsibreak.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/taffybar.nix { })
     (loadModule ./services/tahoe-lafs.nix { })
     (loadModule ./services/udiskie.nix { })

--- a/modules/services/rsibreak.nix
+++ b/modules/services/rsibreak.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.rsibreak;
+
+in
+
+{
+  options.services.rsibreak = {
+
+    enable = mkEnableOption "rsibreak";
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.rsibreak = {
+      Unit = {
+        Description = "RSI break timer";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Environment = "PATH=${config.home.profileDirectory}/bin";
+        ExecStart = "${pkgs.rsibreak}/bin/rsibreak";
+      };
+    };
+  };
+}


### PR DESCRIPTION
I've been using the `rsibreak` package for a while now to remind me to take regular breaks. Last week turned this into a systemd user service and thought that maybe more people are interested in this.

PS. I really like home-manager. Thanks for the great work!