### PR TITLE
fix "find" invocation broken in c94eaa0e

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -74,7 +74,7 @@ in
         function checkNewGenCollision() {
           local newGenFiles
           newGenFiles="$(readlink -e "$newGenPath/home-files")"
-          find "$newGenFiles" -type f -or -type l \
+          find "$newGenFiles" \( -type f -or -type l \) \
               -exec bash ${check} "$newGenFiles" {} +
         }
 
@@ -155,7 +155,7 @@ in
 
             local newGenFiles
             newGenFiles="$(readlink -e "$newGenPath/home-files")"
-            find "$newGenFiles" -type f -or -type l \
+            find "$newGenFiles" \( -type f -or -type l \) \
               -exec bash ${link} "$newGenFiles" {} +
           }
 


### PR DESCRIPTION
Add parens to expression so the `-exec` includes
files matching both.

Otherwise (before this change) the `-exec` is
only invoked for links (`-type l`):

file or (link -> doexec)
=>
(file or link) -> doexec