### PR TITLE
fontconfig: fix build error

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -35,6 +35,7 @@ import nmt {
     // import ./modules/systemd
   )
   // import ./modules/home-environment
+  // import ./modules/misc/fontconfig
   // import ./modules/programs/bash
   // import ./modules/programs/ssh
   // import ./modules/programs/tmux

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -5,8 +5,8 @@ let
   nmt = pkgs.fetchFromGitLab {
     owner = "rycee";
     repo = "nmt";
-    rev = "b6ab61e707ec1ca3839fef42f9960a1179d543c4";
-    sha256 = "097fm1hmsyhy8chf73wwrvafcxny37414fna3haxf0q5fvpv4jfb";
+    rev = "89fb12a2aaa8ec671e22a033162c7738be714305";
+    sha256 = "07yc1jkgw8vhskzk937k9hfba401q8rn4sgj9baw3fkjl9zrbcyf";
   };
 
 in

--- a/tests/modules/misc/fontconfig/default.nix
+++ b/tests/modules/misc/fontconfig/default.nix
@@ -1,0 +1,5 @@
+{
+  fontconfig-no-font-package = ./no-font-package.nix;
+  fontconfig-single-font-package = ./single-font-package.nix;
+  fontconfig-multiple-font-packages = ./multiple-font-packages.nix;
+}

--- a/tests/modules/misc/fontconfig/multiple-font-packages.nix
+++ b/tests/modules/misc/fontconfig/multiple-font-packages.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.packages = [ pkgs.comic-relief pkgs.unifont ];
+
+    fonts.fontconfig.enable = true;
+
+    nmt.script = ''
+      assertDirectoryNotEmpty home-path/lib/fontconfig/cache
+    '';
+  };
+}

--- a/tests/modules/misc/fontconfig/no-font-package.nix
+++ b/tests/modules/misc/fontconfig/no-font-package.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.packages = [
+      # Look, no font!
+    ];
+
+    fonts.fontconfig.enable = true;
+
+    nmt.script = ''
+      assertPathNotExists home-path/lib/fontconfig/cache
+    '';
+  };
+}

--- a/tests/modules/misc/fontconfig/single-font-package.nix
+++ b/tests/modules/misc/fontconfig/single-font-package.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.packages = [ pkgs.comic-relief ];
+
+    fonts.fontconfig.enable = true;
+
+    nmt.script = ''
+      assertDirectoryNotEmpty home-path/lib/fontconfig/cache
+    '';
+  };
+}

--- a/tests/modules/programs/tmux/not-enabled.nix
+++ b/tests/modules/programs/tmux/not-enabled.nix
@@ -7,7 +7,7 @@ with lib;
     programs.tmux = { enable = false; };
 
     nmt.script = ''
-      assertFileNotExists home-files/.tmux.conf
+      assertPathNotExists home-files/.tmux.conf
     '';
   };
 }


### PR DESCRIPTION
This fixes a build error occurring when building a configuration having fontconfig enabled and `home.packages` only containing one package installing things to `/lib`.

Also adds a number of test cases to verify the fontconfig cache generation functionality.

Fixes #703