### PR TITLE
zsh: add autocd option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -149,6 +149,14 @@ in
     programs.zsh = {
       enable = mkEnableOption "Z shell (Zsh)";
 
+      autocd = mkOption {
+        default = false;
+        description = ''
+        automatically enter into a directory if typed directly into shell.
+        '';
+        type = types.bool;
+      };
+
       dotDir = mkOption {
         default = null;
         example = ".config/zsh";
@@ -378,6 +386,7 @@ in
         ${if cfg.history.expireDuplicatesFirst then "setopt" else "unsetopt"} HIST_EXPIRE_DUPS_FIRST
         ${if cfg.history.share then "setopt" else "unsetopt"} SHARE_HISTORY
         ${if cfg.history.extended then "setopt" else "unsetopt"} EXTENDED_HISTORY
+        ${if cfg.autocd then "setopt" else "unsetopt"} autocd
 
         ${cfg.initExtra}
 

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -152,7 +152,7 @@ in
       autocd = mkOption {
         default = false;
         description = ''
-        automatically enter into a directory if typed directly into shell.
+          Automatically enter into a directory if typed directly into shell.
         '';
         type = types.bool;
       };

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -150,11 +150,11 @@ in
       enable = mkEnableOption "Z shell (Zsh)";
 
       autocd = mkOption {
-        default = false;
+        default = null;
         description = ''
           Automatically enter into a directory if typed directly into shell.
         '';
-        type = types.bool;
+        type = types.nullOr types.bool;
       };
 
       dotDir = mkOption {
@@ -386,7 +386,7 @@ in
         ${if cfg.history.expireDuplicatesFirst then "setopt" else "unsetopt"} HIST_EXPIRE_DUPS_FIRST
         ${if cfg.history.share then "setopt" else "unsetopt"} SHARE_HISTORY
         ${if cfg.history.extended then "setopt" else "unsetopt"} EXTENDED_HISTORY
-        ${if cfg.autocd then "setopt" else "unsetopt"} autocd
+        ${if cfg.autocd != null then "${if cfg.autocd then "setopt" else "unsetopt"} autocd" else ""}
 
         ${cfg.initExtra}
 


### PR DESCRIPTION
autocd option was missing. It allows one to type a path (relative or non-relative) into their terminal raw and navigate to it. This feature is in the zsh configuration wizard and is why I personally started using ZSH so I hope it can be included c: