### PR TITLE
xsession: generalize lock command

### DIFF
--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -13,6 +13,7 @@ in {
 
     lockCmd = mkOption {
       type = types.str;
+      default = config.xsession.lockCmd;
       description = "Locker command to run.";
       example = "\${pkgs.i3lock}/bin/i3lock -n -c 000000";
     };

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -57,6 +57,13 @@ in
         description = "Extra shell commands to run before session start.";
       };
 
+      lockCmd = mkOption {
+        type = types.str;
+        description = "Command to use to lock the screen";
+        default = "${pkgs.xscreensaver}/bin/xscreensaver";
+        defaultText = "\${pkgs.xscreensaver}/bin/screensaver";
+      };
+
       initExtra = mkOption {
         type = types.lines;
         default = "";


### PR DESCRIPTION
We want to have one option for `lockCmd` regardless which lock is used.