### PR TITLE
nixos: use usercfg.home.username for username

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -60,7 +60,9 @@ in
       }) cfg.users
     );
 
-    systemd.services = mapAttrs' (username: usercfg:
+    systemd.services = mapAttrs' (_: usercfg: let
+      username = usercfg.home.username;
+    in
       nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {
         description = "Home Manager environment for ${username}";
         wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
Use `usercfg.home.username` for username instead of attribute name,
as this way we can change username regardless of the name of the attribute.