### PR TITLE
browserpass: fix host/policy link sources

### DIFF
--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -32,11 +32,11 @@ in {
         in [
           {
             target = "${dir}/com.github.browserpass.native.json";
-            source = "${pkgs.browserpass}/etc/chrome-host.json";
+            source = "${pkgs.browserpass}/lib/browserpass/hosts/chromium/com.github.browserpass.native.json";
           }
           {
             target = "${dir}/../policies/managed/com.github.browserpass.native.json";
-            source = "${pkgs.browserpass}/etc/chrome-policy.json";
+            source = "${pkgs.browserpass}/lib/browserpass/policies/chromium/com.github.browserpass.native.json";
           }
         ]
       else if x == "chromium" then
@@ -46,11 +46,11 @@ in {
         in [
           {
             target = "${dir}/com.github.browserpass.native.json";
-            source = "${pkgs.browserpass}/etc/chrome-host.json";
+            source = "${pkgs.browserpass}/lib/browserpass/hosts/chromium/com.github.browserpass.native.json";
           }
           {
             target = "${dir}/../policies/managed/com.github.browserpass.native.json";
-            source = "${pkgs.browserpass}/etc/chrome-policy.json";
+            source = "${pkgs.browserpass}/lib/browserpass/policies/chromium/com.github.browserpass.native.json";
           }
         ]
       else if x == "firefox" then
@@ -59,7 +59,7 @@ in {
             then "Library/Application Support/Mozilla/NativeMessagingHosts"
             else ".mozilla/native-messaging-hosts")
             + "/com.github.browserpass.native.json";
-          source = "${pkgs.browserpass}/lib/mozilla/native-messaging-hosts/com.github.browserpass.native.json";
+          source = "${pkgs.browserpass}/lib/browserpass/hosts/firefox/com.github.browserpass.native.json";
         } ]
       else if x == "vivaldi" then
         let dir = if isDarwin
@@ -68,11 +68,11 @@ in {
         in [
           {
             target = "${dir}/com.github.browserpass.native.json";
-            source = "${pkgs.browserpass}/etc/chrome-host.json";
+            source = "${pkgs.browserpass}/lib/browserpass/hosts/chromium/com.github.browserpass.native.json";
           }
           {
             target = "${dir}/../policies/managed/com.github.browserpass.native.json";
-            source = "${pkgs.browserpass}/etc/chrome-policy.json";
+            source = "${pkgs.browserpass}/lib/browserpass/policies/chromium/com.github.browserpass.native.json";
           }
         ]
       else throw "unknown browser ${x}") config.programs.browserpass.browsers);

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,6 +16,7 @@ import nmt {
   modules = import ../modules/modules.nix { inherit pkgs; lib = pkgs.lib; };
   testedAttrPath = [ "home" "activationPackage" ];
   tests = {
+    browserpass = ./modules/programs/browserpass.nix;
     files-executable = ./modules/files/executable.nix;
     files-hidden-source = ./modules/files/hidden-source.nix;
     files-source-with-spaces = ./modules/files/source-with-spaces.nix;

--- a/tests/modules/programs/browserpass.nix
+++ b/tests/modules/programs/browserpass.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.browserpass = {
+      enable = true;
+      browsers = [
+        "chrome"
+        "chromium"
+        "firefox"
+        "vivaldi"
+      ];
+    };
+
+    nmt.script = if pkgs.stdenv.hostPlatform.isDarwin then ''
+      for dir in "Google/Chrome" "Chromium" "Mozilla" "Vivaldi"; do
+        assertFileExists "home-files/Library/Application Support/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
+      done
+
+      for dir in "Google/Chrome" "Chromium" "Vivaldi"; do
+        assertFileExists "home-files/Library/Application Support/$dir/policies/managed/com.github.browserpass.native.json"
+      done
+    '' else ''
+      for dir in "google-chrome" "chromium" "vivaldi"; do
+        assertFileExists "home-files/.config/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
+        assertFileExists "home-files/.config/$dir/policies/managed/com.github.browserpass.native.json"
+      done
+
+      assertFileExists "home-files/.mozilla/native-messaging-hosts/com.github.browserpass.native.json"
+    '';
+  };
+}


### PR DESCRIPTION
The `browserpass` package has relocated its host/policy files. This updates those locations and adds tests so we can catch this in the future.