### PR TITLE
screen-locker: don't add trailing backslashes introduced by xautolockExtraOptions

### DIFF
--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -58,13 +58,12 @@ in {
       };
 
       Service = {
-        ExecStart = ''
-          ${pkgs.xautolock}/bin/xautolock \
-          -detectsleep \
-          -time ${toString cfg.inactiveInterval} \
-          -locker '${pkgs.systemd}/bin/loginctl lock-session $XDG_SESSION_ID' \
-          ${concatStringsSep " " cfg.xautolockExtraOptions}
-        '';
+        ExecStart = concatStringsSep " " ([
+          "${pkgs.xautolock}/bin/xautolock"
+          "-detectsleep"
+          "-time ${toString cfg.inactiveInterval}"
+          "-locker '${pkgs.systemd}/bin/loginctl lock-session $XDG_SESSION_ID'"
+        ] ++ cfg.xautolockExtraOptions);
       };
     };
 


### PR DESCRIPTION
systemd's unit file parser seems to have gotten a bit stricter, and the
trailing backslash now causes the next non-empty line to be ignored. In
that case, this was [Section], so all subsequent settings were
mistakenly added to [Service], causing them to be ignored entirely.