### PR TITLE
tmux: Disable confirmation prompt

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -65,6 +65,11 @@ let
       bind C-${cfg.shortcut} last-window
     ''}
 
+    ${optionalString cfg.disableConfirmationPrompt ''
+      bind-key & kill-window
+      bind-key x kill-pane
+    ''}
+
     setw -g aggressive-resize ${boolToStr cfg.aggressiveResize}
     setw -g clock-mode-style  ${if cfg.clock24 then "24" else "12"}
     set  -s escape-time       ${toString cfg.escapeTime}
@@ -106,6 +111,14 @@ in
         description = ''
           Override the hjkl and HJKL bindings for pane navigation and
           resizing in VI mode.
+        '';
+      };
+
+      disableConfirmationPrompt = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Disable confirmation prompt before killing a pane or window
         '';
       };
 

--- a/tests/modules/programs/tmux/default.nix
+++ b/tests/modules/programs/tmux/default.nix
@@ -3,4 +3,5 @@
   tmux-not-enabled = ./not-enabled.nix;
   tmux-vi-all-true = ./vi-all-true.nix;
   tmux-secure-socket-enabled = ./secure-socket-enabled.nix;
+  tmux-disable-confirmation-prompt = ./disable-confirmation-prompt.nix;
 }

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.conf
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.conf
@@ -8,23 +8,23 @@ set  -g default-terminal "screen"
 set  -g base-index      0
 setw -g pane-base-index 0
 
-new-session
-
-bind v split-window -h
-bind s split-window -v
 
 
-set -g status-keys vi
-set -g mode-keys   vi
+
+
+set -g status-keys emacs
+set -g mode-keys   emacs
 
 
 
 
 
+bind-key & kill-window
+bind-key x kill-pane
 
 
-setw -g aggressive-resize on
-setw -g clock-mode-style  24
+setw -g aggressive-resize off
+setw -g clock-mode-style  12
 set  -s escape-time       500
 set  -g history-limit     2000
 

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.nix
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  substituteExpected = path: pkgs.substituteAll {
+    src = path;
+
+    sensible_rtp = pkgs.tmuxPlugins.sensible.rtp;
+  };
+  
+in
+
+{
+  config = {
+    programs.tmux = {
+      enable = true;
+      disableConfirmationPrompt = true;
+    };
+  
+    nmt.script = ''
+      assertFileExists home-files/.tmux.conf
+      assertFileContent home-files/.tmux.conf \
+        ${substituteExpected ./disable-confirmation-prompt.conf}
+    '';
+  };
+}

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -21,6 +21,8 @@ set -g mode-keys   emacs
 
 
 
+
+
 setw -g aggressive-resize on
 setw -g clock-mode-style  24
 set  -s escape-time       500


### PR DESCRIPTION
Add a new option to tmux module in order to be able to disable confirmation prompt before killing a pane or window 