### PR TITLE
xsession: add option `importedVariables`

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -65,8 +65,7 @@ in
       then [ pkgs.qgnomeplatform ]
       else [ pkgs.libsForQt5.qtstyleplugins ];
 
-    xsession.profileExtra =
-      "systemctl --user import-environment QT_QPA_PLATFORMTHEME";
+    xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ];
 
     # Enable GTK+ style for Qt4 in either case.
     # It doesn’t support the platform theme packages.

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -42,5 +42,7 @@ in
         WantedBy = [ "graphical-session.target" ];
       };
     };
+
+    xsession.importedVariables = [ "GDK_PIXBUF_MODULE_FILE" ];
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -33,6 +33,7 @@ import nmt {
       i3-keybindings = ./modules/services/window-managers/i3-keybindings.nix;
     }
     // import ./modules/misc/pam
+    // import ./modules/misc/xsession
     // import ./modules/systemd
   )
   // import ./modules/home-environment

--- a/tests/modules/misc/xsession/basic-xprofile-expected.txt
+++ b/tests/modules/misc/xsession/basic-xprofile-expected.txt
@@ -1,0 +1,16 @@
+. "/test-home/.nix-profile/etc/profile.d/hm-session-vars.sh"
+
+if [[ -e "$HOME/.profile" ]]; then
+  . "$HOME/.profile"
+fi
+
+# If there are any running services from a previous session.
+# Need to run this in xprofile because the NixOS xsession
+# script starts up graphical-session.target.
+systemctl --user stop graphical-session.target graphical-session-pre.target
+
+systemctl --user import-environment DBUS_SESSION_BUS_ADDRESS DISPLAY SSH_AUTH_SOCK XAUTHORITY XDG_DATA_DIRS XDG_RUNTIME_DIR XDG_SESSION_ID EXTRA_IMPORTED_VARIABLE
+
+profile extra commands
+
+export HM_XPROFILE_SOURCED=1

--- a/tests/modules/misc/xsession/basic-xsession-expected.txt
+++ b/tests/modules/misc/xsession/basic-xsession-expected.txt
@@ -1,0 +1,18 @@
+if [[ ! -v HM_XPROFILE_SOURCED ]]; then
+  . ~/.xprofile
+fi
+unset HM_XPROFILE_SOURCED
+
+systemctl --user start hm-graphical-session.target
+
+init extra commands
+
+window manager command
+
+systemctl --user stop graphical-session.target
+systemctl --user stop graphical-session-pre.target
+
+# Wait until the units actually stop.
+while [[ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]]; do
+  sleep 0.5
+done

--- a/tests/modules/misc/xsession/basic.nix
+++ b/tests/modules/misc/xsession/basic.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    home.homeDirectory = "/test-home";
+
+    xsession = {
+      enable = true;
+      windowManager.command = "window manager command";
+      importedVariables = [ "EXTRA_IMPORTED_VARIABLE" ];
+      initExtra = "init extra commands";
+      profileExtra = "profile extra commands";
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.xprofile
+      assertFileContent \
+        home-files/.xprofile \
+        ${./basic-xprofile-expected.txt}
+
+      assertFileExists home-files/.xsession
+      assertFileContent \
+        home-files/.xsession \
+        ${./basic-xsession-expected.txt}
+
+    '';
+  };
+}

--- a/tests/modules/misc/xsession/default.nix
+++ b/tests/modules/misc/xsession/default.nix
@@ -1,0 +1,3 @@
+{
+  xsession-basic = ./basic.nix;
+}


### PR DESCRIPTION
This option lists the environment variables to be imported into the systemd user session.

Also add a basic test of the xsession module.