### PR TITLE
[WIP] Spacemacs module: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -80,6 +80,7 @@ let
     (loadModule ./programs/pidgin.nix { })
     (loadModule ./programs/rofi.nix { })
     (loadModule ./programs/skim.nix { })
+    (loadModule ./programs/spacemacs/spacemacs.nix { })
     (loadModule ./programs/ssh.nix { })
     (loadModule ./programs/taskwarrior.nix { })
     (loadModule ./programs/termite.nix { })

--- a/modules/programs/spacemacs/change-paths.patch
+++ b/modules/programs/spacemacs/change-paths.patch
@@ -1,0 +1,92 @@
+diff --git a/core/core-configuration-layer.el b/core/core-configuration-layer.el
+index 4e373e590..2f592be2a 100644
+--- a/core/core-configuration-layer.el
++++ b/core/core-configuration-layer.el
+@@ -28,7 +28,7 @@
+   "Configuration layer templates directory.")
+ 
+ (defconst configuration-layer-directory
+-  (expand-file-name (concat spacemacs-start-directory "layers/"))
++  (expand-file-name (concat spacemacs-immutable-directory "layers/"))
+   "Spacemacs contribution layers base directory.")
+ 
+ (defconst configuration-layer-private-directory
+diff --git a/core/core-dotspacemacs.el b/core/core-dotspacemacs.el
+index dba0489c1..b67c0f7ac 100644
+--- a/core/core-dotspacemacs.el
++++ b/core/core-dotspacemacs.el
+@@ -36,14 +36,7 @@ SPACEMACSDIR environment variable. If neither of these
+ directories exist, this variable will be nil.")
+ 
+   (defvar dotspacemacs-filepath
+-    (let ((spacemacs-dir-init (when dotspacemacs-directory
+-                                 (concat dotspacemacs-directory
+-                                         "init.el"))))
+-      (cond
+-       (env-init)
+-       ((file-exists-p default-init) default-init)
+-       ((and dotspacemacs-directory (file-exists-p spacemacs-dir-init)) spacemacs-dir-init)
+-       (t default-init)))
++    "@spacemacs@"
+     "Filepath to the installed dotfile. If SPACEMACSDIR is given
+ then SPACEMACSDIR/init.el is used. Otherwise, if ~/.spacemacs
+ exists, then this is used. If ~/.spacemacs does not exist, then
+diff --git a/core/core-load-paths.el b/core/core-load-paths.el
+index 3e17d4ec4..89ec5a6e0 100644
+--- a/core/core-load-paths.el
++++ b/core/core-load-paths.el
+@@ -20,7 +20,7 @@
+   user-emacs-directory
+   "Spacemacs start directory.")
+ (defconst spacemacs-core-directory
+-  (expand-file-name (concat spacemacs-start-directory "core/"))
++  (expand-file-name (concat spacemacs-immutable-directory "core/"))
+   "Spacemacs core directory.")
+ (defconst spacemacs-info-directory
+   (expand-file-name (concat spacemacs-core-directory "info/"))
+@@ -48,16 +48,16 @@
+   (expand-file-name (concat spacemacs-cache-directory "auto-save/"))
+   "Spacemacs auto-save directory")
+ (defconst spacemacs-docs-directory
+-  (expand-file-name (concat spacemacs-start-directory "doc/"))
++  (expand-file-name (concat spacemacs-immutable-directory "doc/"))
+   "Spacemacs documentation directory.")
+ (defconst spacemacs-news-directory
+-  (expand-file-name (concat spacemacs-start-directory "news/"))
++  (expand-file-name (concat spacemacs-immutable-directory "news/"))
+   "Spacemacs News directory.")
+ (defconst spacemacs-assets-directory
+-  (expand-file-name (concat spacemacs-start-directory "assets/"))
++  (expand-file-name (concat spacemacs-immutable-directory "assets/"))
+   "Spacemacs assets directory.")
+ (defconst spacemacs-test-directory
+-  (expand-file-name (concat spacemacs-start-directory "tests/"))
++  (expand-file-name (concat spacemacs-immutable-directory "tests/"))
+   "Spacemacs tests directory.")
+ 
+ (defconst user-home-directory
+@@ -80,4 +80,3 @@
+ ;; themes
+ (add-to-list 'custom-theme-load-path (concat spacemacs-core-directory
+                                              "libs/spacemacs-theme/"))
+-
+diff --git a/init.el b/init.el
+index e2aaff131..154130fb1 100644
+--- a/init.el
++++ b/init.el
+@@ -23,11 +23,13 @@
+     (error (concat "Your version of Emacs (%s) is too old. "
+                    "Spacemacs requires Emacs version %s or above.")
+            emacs-version spacemacs-emacs-min-version)
+-  (load-file (concat (file-name-directory load-file-name)
++  (defvar spacemacs-immutable-directory
++    (file-name-directory load-file-name))
++  (load-file (concat spacemacs-immutable-directory
+                      "core/core-load-paths.el"))
+   (require 'core-spacemacs)
+   (spacemacs/init)
+-  (configuration-layer/sync)
++  (configuration-layer/sync 'no-install)
+   (spacemacs-buffer/display-startup-note)
+   (spacemacs/setup-startup-hook)
+   (require 'server)

--- a/modules/programs/spacemacs/default.nix
+++ b/modules/programs/spacemacs/default.nix
@@ -1,0 +1,63 @@
+{ emacsWithPackages, stdenv, fetchFromGitHub, substituteAll, lib, runCommand, makeWrapper, spacemacs }:
+let
+  pname = "spacemacs";
+  version = "0.200.13";
+
+  src = fetchFromGitHub {
+    owner = "syl20bnr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0m634adqnwqvi8d7qkq7nh8ivfz6cx90idvwd2wiylg4w1hly252";
+  };
+
+  bootstrapEmacs = emacsWithPackages (p: [ p.melpaStablePackages.which-key ]);
+
+  script = substituteAll {
+    src = ./script.el;
+    inherit version;
+  };
+
+  packages = runCommand "spacemacs-packages" {} ''
+    mkdir -p $out
+    cd $out
+    mkdir -p spacemacs-files
+    cp -r ${src}/* ./spacemacs-files
+    chmod -R +w spacemacs-files
+    touch packages.txt
+    cd spacemacs-files
+    ${bootstrapEmacs}/bin/emacs --debug --batch --load ${script}
+    cd ..
+    cat packages.txt
+    rm -r spacemacs-files
+  '';
+
+  packageList = (lib.splitString "\n" (builtins.readFile "${packages}/packages.txt"));
+
+  retrievePackage = p: x: let
+    e = p.elpaPackages;
+    m = p.melpaStablePackages;
+  in if builtins.hasAttr x e then builtins.getAttr x e else if builtins.hasAttr x m then builtins.getAttr x m else null;
+
+  retrievedPackageList = p: builtins.filter (x: x != null) (map (retrievePackage p) packageList);
+
+  emacspkgs = emacsWithPackages (builtins.deepSeq packageList (builtins.trace packageList (retrievedPackageList)));
+in
+stdenv.mkDerivation rec {
+  inherit src pname version;
+
+  patches = [ (substituteAll {
+    src = ./change-paths.patch;
+    inherit spacemacs;
+  }) ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out
+    mkdir -p $out/.emacs.d
+    mkdir -p $out/bin
+    cp -r * $out/.emacs.d
+    makeWrapper "${emacspkgs}/bin/emacs" $out/bin/spacemacs \
+      --add-flags "-q -l $out/.emacs.d/init.el"
+  '';
+}

--- a/modules/programs/spacemacs/script.el
+++ b/modules/programs/spacemacs/script.el
@@ -1,0 +1,17 @@
+(require 'which-key)
+(defconst spacemacs-version "@version@" "Spacemacs version.")
+(setq user-emacs-directory "./")
+(load-file "./core/core-load-paths.el")
+(require 'core-spacemacs)
+(require 'core-configuration-layer)
+(configuration-layer/initialize)
+(defun configuration-layer//configure-packages (x) t)
+(configuration-layer/sync 'no-install)
+
+(defun printInfo (x)
+  (format "%s" x ))
+
+(defun printList (x)
+  (if (cdr x) (concat (printInfo (car x)) "\n" (printList (cdr x))) (printInfo (car x))))
+
+(write-region (printList configuration-layer--used-packages) nil "../packages.txt")

--- a/modules/programs/spacemacs/spacemacs.nix
+++ b/modules/programs/spacemacs/spacemacs.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  homeDirectory = config.home.homeDirectory;
+
+  fileType = (import ../../lib/file-type.nix {
+    inherit homeDirectory lib pkgs;
+  }).fileType;
+
+  cfg = config.programs.spacemacs;
+in
+{
+  meta.maintainers = [ ]; #TODO
+
+  options = {
+    programs.spacemacs = {
+      enable = mkEnableOption "Spacemacs";
+
+      configFile = mkOption {
+        type = types.nullOr types.str;
+        default = "${homeDirectory}/spacemacs";
+        defaultText = "${homeDirectory}/spacemacs";
+        example = "${homeDirectory}/dotfiles/spacemacs";
+        description = "The spacemacs dotfile to use";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ (pkgs.callPackage ./. { spacemacs = cfg.configFile; }) ];
+  };
+}


### PR DESCRIPTION
This is very wip and I am not sure it is even suitable for being merged into home-manager. However I have seen interest in packaging spacemacs in various places and thought I would post my attempt in case anyone else was interested. This does the following:

- fetches the spacemacs git repository
- uses emacs to run an elisp script that calls enough spacemacs functions to get a list of packages that spacemacs wants
- Builds emacsWithPackages with these packages (currently obtained by getting them from where ever they can be found)
- patches spacemacs so that it doesn't install packages itself
- makes a wrapper around the emacsWithPackages so that it uses the init.el from the patched spacemacs

My limited testing suggests that this might work though I haven't used it for very long
Problems with this at the moment:
- Some emacs packages used by spacemacs are marked broken (in particular evil-indent-highlight-persist)
- The spacemacs is patched in the main derivation and so the patched version isn't used to get the packages list. I think this means private layers can't be used.
- Not really sure what will happen if it tries to update itself as this hasn't happened yet
- Should really use nix options to configure instead of just passing a config file.

The only advantage seems to be the determinism. Perhaps compiling packages in nix instead of on first opening spacemacs could be viewed as an advantage.

I would be interested in what other approaches have been made for packaging this.