### PR TITLE
taskwarrior-sync: add service module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -124,6 +124,7 @@ let
     (loadModule ./services/syncthing.nix { })
     (loadModule ./services/taffybar.nix { })
     (loadModule ./services/tahoe-lafs.nix { })
+    (loadModule ./services/taskwarrior-sync.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/udiskie.nix { })
     (loadModule ./services/unclutter.nix { })
     (loadModule ./services/window-managers/awesome.nix { })

--- a/modules/services/taskwarrior-sync.nix
+++ b/modules/services/taskwarrior-sync.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.taskwarrior-sync;
+in {
+  meta.maintainers = with maintainers; [ minijackson pacien ];
+
+  options.services.taskwarrior-sync = {
+    enable = mkEnableOption "Taskwarrior periodic sync";
+
+    frequency = mkOption {
+      type = types.str;
+      default = "*:0/5";
+      description = ''
+        How often to run <literal>taskwarrior sync</literal>.
+        This value is passed to the systemd timer configuration as the onCalendar option.
+        See
+        <citerefentry>
+          <refentrytitle>systemd.time</refentrytitle>
+          <manvolnum>7</manvolnum>
+        </citerefentry>
+        for more information about the format.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.taskwarrior-sync = {
+      Unit = {
+        Description = "Taskwarrior sync";
+        PartOf = [ "network-online.target" ];
+      };
+      Service = {
+        CPUSchedulingPolicy = "idle";
+        IOSchedulingClass = "idle";
+        ExecStart = "${pkgs.taskwarrior}/bin/task synchronize";
+      };
+    };
+
+    systemd.user.timers.taskwarrior-sync = {
+      Unit = {
+        Description = "Taskwarrior periodic sync";
+      };
+      Timer = {
+        Unit = "taskwarrior-sync.service";
+        OnCalendar = cfg.frequency;
+      };
+      Install = {
+        WantedBy = [ "timers.target" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
This PR adds a service module for Taskwarrior periodic sync.

CC: @minijackson 