### PR TITLE
skim: correctly name default options

### DIFF
--- a/modules/programs/skim.nix
+++ b/modules/programs/skim.nix
@@ -107,7 +107,7 @@ in
           SKIM_CTRL_T_COMMAND = cfg.fileWidgetCommand;
           SKIM_CTRL_T_OPTS = cfg.fileWidgetOptions;
           SKIM_DEFAULT_COMMAND = cfg.defaultCommand;
-          SKIM_DEFAULT_OPTS = cfg.defaultOptions;
+          SKIM_DEFAULT_OPTIONS = cfg.defaultOptions;
         }
       );
 


### PR DESCRIPTION
skim uses the [SKIM_DEFAULT_OPTIONS](https://github.com/lotabout/skim/blob/master/src/main.rs#L79) environment variable rather than `SKIM_DEFAULT_OPTS`.

The other (`_OPTS`) environment variables are [still correct](https://github.com/lotabout/skim/blob/master/shell/key-bindings.zsh#L14) however as they seem to have a different naming convention.