### PR TITLE
zsh: add initExtraBeforeCompInit config option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -215,6 +215,12 @@ in
         description = "Environment variables that will be set for zsh session.";
       };
 
+      initExtraBeforeCompInit = mkOption {
+        default = "";
+        type = types.lines;
+        description = "Extra commands that should be added to <filename>.zshrc</filename> before compinit.";
+      };
+
       initExtra = mkOption {
         default = "";
         type = types.lines;
@@ -340,6 +346,8 @@ in
         ''}
 
         ${localVarsStr}
+
+        ${cfg.initExtraBeforeCompInit}
 
         ${concatStrings (map (plugin: ''
           path+="$HOME/${pluginsDir}/${plugin.name}"


### PR DESCRIPTION
I added a new config option for zsh:
The new initExtraBeforeCompInit option enables the user to inject commands in zshrc before compinit is executed.

I need this option because I want to set the fpath and other options manually before compinit is executed