### PR TITLE
zsh: add envExtra option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -221,6 +221,12 @@ in
         description = "Extra commands that should be added to <filename>.zshrc</filename>.";
       };
 
+      envExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = "Extra commands that should be added to <filename>.zshenv</filename>.";
+      };
+
       profileExtra = mkOption {
         default = "";
         type = types.lines;
@@ -287,6 +293,10 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.envExtra != "") {
+      home.file."${relToDotDir ".zshenv"}".text = cfg.envExtra;
+    })
+
     (mkIf (cfg.profileExtra != "") {
       home.file."${relToDotDir ".zprofile"}".text = cfg.profileExtra;
     })


### PR DESCRIPTION
Add envExtra option in zsh to inject commands into .zshenv