### PR TITLE
xdg: create cache directory using keep file

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -92,10 +92,13 @@ in
     })
 
     {
-      home.file = mkMerge [ cfg.configFile cfg.dataFile ];
-      home.activation.xdgCreateCache = dag.entryAfter [ "writeBoundary" ] ''
-        $DRY_RUN_CMD mkdir $VERBOSE_ARG -m0700 -p "${config.xdg.cacheHome}"
-      '';
+      home.file = mkMerge [
+        cfg.configFile
+        cfg.dataFile
+        {
+          "${config.xdg.cacheHome}/.keep".text = "";
+        }
+      ];
     }
   ];
 }


### PR DESCRIPTION
We can avoid the activation block by instead creating a hidden file in the directory.