### PR TITLE
xsession: add numlock module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -33,6 +33,7 @@ let
     (loadModule ./misc/submodule-support.nix { })
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/xdg.nix { })
+    (loadModule ./numlock.nix { })
     (loadModule ./programs/afew.nix { })
     (loadModule ./programs/alacritty.nix { })
     (loadModule ./programs/alot.nix { })

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -33,7 +33,7 @@ let
     (loadModule ./misc/submodule-support.nix { })
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/xdg.nix { })
-    (loadModule ./numlock.nix { })
+    (loadModule ./numlock.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/afew.nix { })
     (loadModule ./programs/alacritty.nix { })
     (loadModule ./programs/alot.nix { })

--- a/modules/numlock.nix
+++ b/modules/numlock.nix
@@ -10,7 +10,7 @@ in
       xsession.numlock.enable = mkEnableOption "Num Lock";
     };
 
-    config = mkIf (cfg.enable) {
+    config = mkIf cfg.enable {
 
       xsession.profileExtra = ''
         ${pkgs.numlockx}/bin/numlockx

--- a/modules/numlock.nix
+++ b/modules/numlock.nix
@@ -10,7 +10,7 @@ in
       xsession.numlock.enable = mkEnableOption "Numlock";
     };
 
-    config = mkIf (cfg != null) {
+    config = mkIf (cfg.enable) {
 
       xsession.profileExtra = ''
         ${pkgs.numlockx}/bin/numlockx

--- a/modules/numlock.nix
+++ b/modules/numlock.nix
@@ -7,7 +7,7 @@ let
 in
   {
     options = {
-      xsession.numlock.enable = mkEnableOption "Numlock";
+      xsession.numlock.enable = mkEnableOption "Num Lock";
     };
 
     config = mkIf (cfg.enable) {

--- a/modules/numlock.nix
+++ b/modules/numlock.nix
@@ -12,8 +12,21 @@ in
 
     config = mkIf cfg.enable {
 
-      xsession.profileExtra = ''
-        ${pkgs.numlockx}/bin/numlockx
-      '';
+      systemd.user.services.numlockx = {
+        Unit = {
+          Description = "NumLockX";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.numlockx}/bin/numlockx";
+        };
+
+        Install = {
+          WantedBy = [ "graphical-session.target" ];
+        };
+      };
     };
   }

--- a/modules/numlock.nix
+++ b/modules/numlock.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.xsession.numlock;
+in
+  {
+    options = {
+      xsession.numlock.enable = mkEnableOption "Numlock";
+    };
+
+    config = mkIf (cfg != null) {
+
+      xsession.profileExtra = ''
+        ${pkgs.numlockx}/bin/numlockx
+      '';
+    };
+  }


### PR DESCRIPTION
Resolves #651 

Not sure how to support Darwin for this, if that's an issue.

The only other concern I have is how well it might play with [other DEs or WMs](https://wiki.archlinux.org/index.php/Activating_Numlock_on_Bootup#startx), aside from what I'm currently using (verified working on xmonad + gdm).

Please let me know if there's anything else I'm missing.
