### PR TITLE
Add hound service

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1152,6 +1152,14 @@ in
           A new module is available: 'programs.kakoune'.
         '';
       }
+
+      {
+        time = "2019-08-02T09:07:43+00:00";
+        message = ''
+          A new module is available: 'services.hound'.
+        '';
+      }
+
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -101,6 +101,7 @@ let
     (loadModule ./services/flameshot.nix { })
     (loadModule ./services/gnome-keyring.nix { })
     (loadModule ./services/gpg-agent.nix { })
+    (loadModule ./services/hound.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/imapnotify.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/getmail.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/kbfs.nix { })

--- a/modules/services/hound.nix
+++ b/modules/services/hound.nix
@@ -1,0 +1,85 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.hound;
+
+  configFile = pkgs.writeText "hound-config.json" (
+    builtins.toJSON {
+      max-concurrent-indexers = cfg.maxConcurrentIndexers;
+      dbpath = cfg.databasePath;
+      repos = cfg.repositories;
+      health-check-url = "/healthz";
+    });
+
+  houndOptions = [
+    "--addr ${cfg.listenAddress}"
+    "--conf ${configFile}"
+  ];
+
+in
+
+{
+  meta.maintainers = [ maintainers.adisbladis ];
+
+  options.services.hound = {
+    enable = mkEnableOption "hound";
+
+    maxConcurrentIndexers = mkOption {
+      type = types.ints.positive;
+      default = 2;
+      description = "Limit the amount of concurrent indexers.";
+    };
+
+    databasePath = mkOption {
+      type = types.path;
+      default = "${config.xdg.dataHome}/hound";
+      defaultText = "\$XDG_DATA_HOME/hound";
+      description = "The Hound database path.";
+    };
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "localhost:6080";
+      description = "Listen address of the Hound daemon.";
+    };
+
+
+    repositories = mkOption {
+      type = types.attrsOf (types.uniq types.attrs);
+      default = {};
+      example = literalExample ''
+        {
+          SomeGitRepo = {
+            url = "https://www.github.com/YourOrganization/RepoOne.git";
+            ms-between-poll = 10000;
+            exclude-dot-files = true;
+          };
+        }
+      '';
+      description = "The repository configuration.";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.hound ];
+
+    systemd.user.services.hound = {
+      Unit = {
+        Description = "Hound source code search engine";
+      };
+
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+
+      Service = {
+        Environment = "PATH=${makeBinPath [ pkgs.mercurial pkgs.git ]}";
+        ExecStart = "${pkgs.hound}/bin/houndd ${concatStringsSep " " houndOptions}";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Hound is a pretty cool code search tool :)

I use it with the following config to automatically index all my local checkouts:
```
let 
  findGitRecursive = root: let
    files = builtins.readDir root;
    dirs = lib.filterAttrs (k: v: v == "directory") files;
    repoSet = lib.mapAttrs (k: v: builtins.pathExists (root + "/${k}/.git")) dirs;
    repos = builtins.map (v: builtins.toString (root + "/${v}")) (lib.attrNames (lib.filterAttrs (k: v: v) repoSet));
    notRepos = lib.attrNames (lib.filterAttrs (k: v: !v) repoSet);
    nestedRepos = builtins.foldl' (a: v: a ++ findGitRecursive (root + "/${v}")) [] notRepos;
  in repos ++ nestedRepos;

in {

  services.hound = {
    enable = true;
    repos = let
      repos = findGitRecursive /home/adisbladis/sauce;
    in lib.listToAttrs (builtins.map (v: {
      name = builtins.baseNameOf v;
      value = { url = "file://" + v; };
    }) repos);
  };

}
```