### PR TITLE
nix-channels: add module

### DIFF
--- a/modules/misc/nix-channels.nix
+++ b/modules/misc/nix-channels.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.nix-channels;
+in
+
+{
+  meta.maintainers = [ maintainers.gerschtli ];
+
+  options = {
+    nix-channels = mkOption {
+      type = types.attrsOf types.str;
+      default = {};
+      example = literalExample ''
+        {
+          nixos = "https://nixos.org/channels/nixos-19.03";
+        };
+      '';
+      description = ''
+        List of channels to be added to <filename>~/.nix-channels</filename>.
+
+        </para><para>
+
+        Note: As part of nix' shell init script, <filename>~/.nix-channels</filename>
+        will always be created if it does not exists.  This means for the first time
+        enabling this module, you have to run <command>home-manager</command> with the
+        <command>-b</command> flag to backup the automatically generated
+        <filename>~/.nix-channels</filename>.
+      '';
+    };
+  };
+
+  config = mkIf (cfg != {}) {
+    home = {
+      file.".nix-channels".text =
+        (concatStringsSep "\n" (mapAttrsToList (name: url: "${url} ${name}") cfg)) + "\n";
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -27,6 +27,7 @@ let
     (loadModule ./misc/gtk.nix { })
     (loadModule ./misc/lib.nix { })
     (loadModule ./misc/news.nix { })
+    (loadModule ./misc/nix-channels.nix { })
     (loadModule ./misc/nixpkgs.nix { })
     (loadModule ./misc/pam.nix { })
     (loadModule ./misc/qt.nix { })

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -33,6 +33,7 @@ import nmt {
       getmail = ./modules/programs/getmail.nix;
       i3-keybindings = ./modules/services/window-managers/i3-keybindings.nix;
     }
+    // import ./modules/misc/nix-channels
     // import ./modules/misc/pam
     // import ./modules/misc/xsession
     // import ./modules/systemd

--- a/tests/modules/misc/nix-channels/default.nix
+++ b/tests/modules/misc/nix-channels/default.nix
@@ -1,0 +1,3 @@
+{
+  nix-channels = ./nix-channels.nix;
+}

--- a/tests/modules/misc/nix-channels/nix-channels-expected.txt
+++ b/tests/modules/misc/nix-channels/nix-channels-expected.txt
@@ -1,0 +1,2 @@
+https://nixos.org/channels/nixos-19.03 nixos
+https://nixos.org/channels/nixos-unstable unstable

--- a/tests/modules/misc/nix-channels/nix-channels.nix
+++ b/tests/modules/misc/nix-channels/nix-channels.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    nix-channels = {
+      nixos = "https://nixos.org/channels/nixos-19.03";
+      unstable = "https://nixos.org/channels/nixos-unstable";
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.nix-channels
+      assertFileContent \
+        home-files/.nix-channels \
+        ${./nix-channels-expected.txt}
+    '';
+  };
+}


### PR DESCRIPTION
Hey, I have added an option to manage `~/.nix-channels` with home-manager.

It was a bit tricky because `~/.nix-channels` is created in https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/shell.nix#L31. I added a note in the description of the option.