### PR TITLE
mbsync: fixed certificatesFile

### DIFF
--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -20,7 +20,7 @@ let
     }
     //
     optionalAttrs (tls.enable && tls.certificatesFile != null) {
-      CertificateFile = tls.certificatesFile;
+      CertificateFile = toString tls.certificatesFile;
     };
 
   masterSlaveMapping = {


### PR DESCRIPTION
tls.certificatesFile returns a path, Certificate file should be a string