### PR TITLE
msmtp: added optional argument fingerprint

### DIFF
--- a/modules/programs/msmtp-accounts.nix
+++ b/modules/programs/msmtp-accounts.nix
@@ -22,6 +22,17 @@ with lib;
       '';
     };
 
+    tls.fingerprint = mkOption {
+      type = types.nullOr (types.strMatching "([[:alnum:]]{2}\:)+[[:alnum:]]{2}");
+      default = null;
+      example = "my:SH:a2:56:ha:sh";
+      description = ''
+        Fingerprint of a trusted TLS certificate.
+        The fingerprint can be obtained by executing
+        <command>msmtp --serverinfo --tls --tls-certcheck=off</command>.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.attrsOf types.str;
       default = { };

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -24,6 +24,9 @@ let
           tls_starttls = onOff smtp.tls.useStartTls;
           tls_trust_file = smtp.tls.certificatesFile;
         }
+        // optionalAttrs (msmtp.tls.fingerprint != null) {
+          tls_fingerprint = msmtp.tls.fingerprint;
+        }
         // optionalAttrs (smtp.port != null) {
           port = toString smtp.port;
         }


### PR DESCRIPTION
The TLS fingerprint can be obtained by executing:
`msmtp --serverinfo --tls --tls-certcheck=off`