### PR TITLE
systemd-activate.rb: add start/stop/restart sockets

### DIFF
--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -76,7 +76,7 @@ def get_services(dir)
 end
 
 def get_service_files(dir)
-  Dir.chdir(dir) { Dir['*.service'] }
+  Dir.chdir(dir) { Dir['*.{service,socket}'] }
 end
 
 def get_changed_services(dir_a, dir_b, services)


### PR DESCRIPTION
Hey, this little commit enables `home-manager` to automatically handle systemd sockets during activation.

Resolves https://github.com/rycee/home-manager/issues/708