### PR TITLE
alot: added send/draf_box to configuration file

### DIFF
--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -21,6 +21,8 @@ let
           realname = realName;
           sendmail_command =
             optionalString (alot.sendMailCommand != null) alot.sendMailCommand;
+          sent_box = "maildir" + "://" + maildir.absPath + "/" + folders.sent;
+          draft_box = "maildir" + "://"+ maildir.absPath + "/" + folders.drafts;
         }
         // optionalAttrs (aliases != []) {
           aliases = concatStringsSep "," aliases;


### PR DESCRIPTION
By adding these settings we'll be able to access drafted/sent messages.