### PR TITLE
zsh: fix completion when oh-my-zsh is enabled

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -346,7 +346,13 @@ in
           fpath+="$HOME/${pluginsDir}/${plugin.name}"
         '') cfg.plugins)}
 
-        ${optionalString cfg.enableCompletion "autoload -U compinit && compinit"}
+        # Oh-My-Zsh calls compinit during initialization,
+        # calling it twice causes sight start up slowdown
+        # as all $fpath entries will be traversed again.
+        ${optionalString (cfg.enableCompletion && !cfg.oh-my-zsh.enable)
+          "autoload -U compinit && compinit"
+        }
+
         ${optionalString cfg.enableAutosuggestions
           "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
         }
@@ -396,11 +402,6 @@ in
     }
 
     (mkIf cfg.oh-my-zsh.enable {
-      # Oh-My-Zsh calls compinit during initialization,
-      # calling it twice causes sight start up slowdown
-      # as all $fpath entries will be traversed again.
-      programs.zsh.enableCompletion = mkForce false;
-
       # Make sure we create a cache directory since some plugins expect it to exist
       # See: https://github.com/rycee/home-manager/issues/761
       home.file."${config.xdg.cacheHome}/oh-my-zsh/.keep".text = "";


### PR DESCRIPTION
enableCompletion option not only calls compinit but also adds
nix-zsh-completions package to home.packages which should still happen
even if oh-my-zsh is enabled.

The double compinit call will still be eliminated by moving guarding condition
down to the compinit call itself.

Fixes #771.