### PR TITLE
vim: allow packages to be passed as plugins

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1176,6 +1176,15 @@ in
           A new module is available: 'services.dwm-status'.
         '';
       }
+
+      {
+        time = "2019-08-18T14:35:39+00:00";
+        condition = config.programs.vim.enable;
+        message = ''
+          The 'programs.vim.plugins' option now accepts packages. Specifying them as
+          strings is deprecated.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.programs.vim;
-  defaultPlugins = [ "sensible" ];
+  defaultPlugins = [ pkgs.vimPlugins.sensible ];
 
   knownSettings = {
     background = types.enum [ "dark" "light" ];
@@ -55,6 +55,16 @@ let
     in
       optionalString (value != null) ("set " + v);
 
+  plugins =
+    let
+      vpkgs = pkgs.vimPlugins;
+      getPkg = p:
+        if isDerivation p
+        then [ p ]
+        else optional (isString p && hasAttr p vpkgs) vpkgs.${p};
+    in
+      concatMap getPkg cfg.plugins;
+
 in
 
 {
@@ -63,12 +73,16 @@ in
       enable = mkEnableOption "Vim";
 
       plugins = mkOption {
-        type = types.listOf types.str;
+        type = with types; listOf (either str package);
         default = defaultPlugins;
-        example = [ "YankRing" ];
+        example = literalExample ''[ pkgs.vimPlugins.YankRing ]'';
         description = ''
           List of vim plugins to install. To get a list of supported plugins run:
           <command>nix-env -f '&lt;nixpkgs&gt;' -qaP -A vimPlugins</command>.
+
+          </para><para>
+
+          Note: String values are deprecated, please use actual packages.
         '';
       };
 
@@ -135,16 +149,40 @@ in
 
       vim = pkgs.vim_configurable.customize {
         name = "vim";
-        vimrcConfig.customRC = customRC;
-        vimrcConfig.vam.knownPlugins = pkgs.vimPlugins;
-        vimrcConfig.vam.pluginDictionaries = [
-          { names = defaultPlugins ++ cfg.plugins; }
-        ];
-      };
+        vimrcConfig = {
+          inherit customRC;
 
-    in mkIf cfg.enable {
-      programs.vim.package = vim;
-      home.packages = [ cfg.package ];
-    }
+          packages.home-manager.start = plugins;
+        };
+      };
+    in
+      mkIf cfg.enable {
+        assertions =
+          let
+            packagesNotFound = filter (p: isString p && (!hasAttr p pkgs.vimPlugins)) cfg.plugins;
+          in
+            [
+              {
+                assertion = packagesNotFound == [];
+                message = "Following VIM plugin not found in pkgs.vimPlugins: ${
+                  concatMapStringsSep ", " (p: ''"${p}"'') packagesNotFound
+                }";
+              }
+            ];
+
+        warnings =
+          let
+            stringPlugins = filter isString cfg.plugins;
+          in
+            optional (stringPlugins != []) ''
+              Specifying VIM plugins using strings is deprecated, found ${
+                concatMapStringsSep ", " (p: ''"${p}"'') stringPlugins
+              } as strings.
+            '';
+
+        home.packages = [ cfg.package ];
+
+        programs.vim.package = vim;
+      }
   );
 }


### PR DESCRIPTION
This change allows to pass custom packages into vim.plugins option.

Additionally I added a deprecation warning via trace and an error
message using throw if a vim plugin is not present. This is an
improvement because the user gets instant feedback, when a plugin is not
found.