### PR TITLE
dwm-status: add as user service

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -98,6 +98,7 @@ let
     (loadModule ./services/blueman-applet.nix { })
     (loadModule ./services/compton.nix { })
     (loadModule ./services/dunst.nix { })
+    (loadModule ./services/dwm-status.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/emacs.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/flameshot.nix { })
     (loadModule ./services/getmail.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/dwm-status.nix
+++ b/modules/services/dwm-status.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dwm-status;
+
+  features = [ "audio" "backlight" "battery" "cpu_load" "network" "time" ];
+
+  configText = builtins.toJSON ({ inherit (cfg) order; } // cfg.extraConfig);
+
+  configFile = pkgs.writeText "dwm-status.json" configText;
+in
+
+{
+  options = {
+    services.dwm-status = {
+      enable = mkEnableOption "dwm-status user service";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.dwm-status;
+        defaultText = "pkgs.dwm-status";
+        example = "pkgs.dwm-status.override { enableAlsaUtils = false; }";
+        description = "Which dwm-status package to use.";
+      };
+
+      order = mkOption {
+        type = types.listOf (types.enum features);
+        description = "List of enabled features in order.";
+      };
+
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = {};
+        example = literalExample ''
+          {
+            separator = "#";
+
+            battery = {
+              notifier_levels = [ 2 5 10 15 20 ];
+            };
+
+            time = {
+              format = "%H:%M";
+            };
+          }
+        '';
+        description = "Extra config of dwm-status.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.dwm-status = {
+      Unit = {
+        Description = "DWM status service";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/dwm-status ${configFile}";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Hey, I have added a service module for my own package called [`dwm-status`](https://github.com/Gerschtli/dwm-status). It is already present in nixpkgs for a long time now.