### PR TITLE
Add remain after exit options

### DIFF
--- a/modules/misc/numlock.nix
+++ b/modules/misc/numlock.nix
@@ -23,6 +23,7 @@ in
 
       Service = {
         Type = "oneshot";
+        RemainAfterExit = true;
         ExecStart = "${pkgs.numlockx}/bin/numlockx";
       };
 

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -102,6 +102,7 @@ in
 
           Service = {
             Type = "oneshot";
+            RemainAfterExit = true;
             ExecStart =
               let
                 args = concatStringsSep " " (


### PR DESCRIPTION
Added `RemainAfterExit` option for `numlock` and `setxkbmap` services. As result of this change they are not restarted on every activation because systemd marks them still as running.