### PR TITLE
Improve non NixOS support

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -351,6 +351,10 @@ in
             if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
             export __HM_SESS_VARS_SOURCED=1
 
+            ${optionalString config.targets.genericLinux.enable ''
+              . "${pkgs.nix}/etc/profile.d/nix.sh"
+            ''}
+
             ${config.lib.shell.exportAll cfg.sessionVariables}
           '';
         }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1443,6 +1443,16 @@ in
           'services.picom' as soon as possible.
         '';
       }
+
+      {
+        time = "2020-04-05T21:16:44+01:00";
+        message = ''
+          A new option is available: 'targets.genericLinux.enable'.
+
+          Enable this option to make Home Manager work better on
+          GNU/Linux distributions other than NixOS.
+        '';
+      }
     ];
   };
 }

--- a/modules/misc/targets.nix
+++ b/modules/misc/targets.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  profileDirectory = config.home.profileDirectory;
+in
+
+{
+  options.targets.genericLinux.enable = mkEnableOption "" // {
+    description = ''
+      Whether to enable settings that make Home Manager work better on
+      GNU/Linux distributions other than NixOS.
+    '';
+  };
+
+  config = mkIf config.targets.genericLinux.enable {
+    home.sessionVariables =
+      let
+        profiles = [ "/nix/var/nix/profiles/default" profileDirectory ];
+        dataDirs = concatStringsSep ":" (map (profile: "${profile}/share") profiles);
+      in
+        {
+          XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS";
+        };
+
+    # We need to source both nix.sh and hm-session-vars.sh as noted in
+    # https://github.com/rycee/home-manager/pull/797#issuecomment-544783247
+    programs.bash.initExtra = ''
+      . "${pkgs.nix}/etc/profile.d/nix.sh"
+      . "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
+    '';
+
+    systemd.user.sessionVariables = {
+      NIX_PATH = "$HOME/.nix-defexpr/channels\${NIX_PATH:+:}$NIX_PATH";
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -36,6 +36,7 @@ let
     (loadModule ./misc/pam.nix { })
     (loadModule ./misc/qt.nix { })
     (loadModule ./misc/submodule-support.nix { })
+    (loadModule ./misc/targets.nix { })
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/xdg-mime.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime-apps.nix { condition = hostPlatform.isLinux; })

--- a/tests/modules/home-environment/session-variables-generic-linux-expected.txt
+++ b/tests/modules/home-environment/session-variables-generic-linux-expected.txt
@@ -2,6 +2,7 @@
 if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
 export __HM_SESS_VARS_SOURCED=1
 
+. "@nix@/etc/profile.d/nix.sh"
 
 
 export V1="v1"

--- a/tests/modules/home-environment/session-variables-generic-linux.nix
+++ b/tests/modules/home-environment/session-variables-generic-linux.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    home.sessionVariables = {
+      V1 = "v1";
+      V2 = "v2-${config.home.sessionVariables.V1}";
+    };
+
+    targets.genericLinux.enable = true;
+
+    nmt.script = ''
+      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+      assertFileContent \
+        home-path/etc/profile.d/hm-session-vars.sh \
+        ${./session-variables-generic-linux-expected.txt}
+    '';
+  };
+}

--- a/tests/modules/programs/tmux/hm-session-vars.sh
+++ b/tests/modules/programs/tmux/hm-session-vars.sh
@@ -2,4 +2,6 @@
 if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
 export __HM_SESS_VARS_SOURCED=1
 
+
+
 export TMUX_TMPDIR="${XDG_RUNTIME_DIR:-"/run/user/\$(id -u)"}"


### PR DESCRIPTION
Hello,

I have added sourcing of nix.sh on startup and setting `NIX_PATH`, `NIX_PROFILES` and `XDG_DATA_DIRS` for non NixOS systems. I would like to hear your opinion to this implementation.

The `isNixOS` function feels very impure, but I did not come up with a better implementation.

Resolves https://github.com/rycee/home-manager/issues/688