### PR TITLE
lorri: add service

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -109,6 +109,7 @@ let
     (loadModule ./services/kdeconnect.nix { })
     (loadModule ./services/keepassx.nix { })
     (loadModule ./services/keybase.nix { })
+    (loadModule ./services/lorri.nix { })
     (loadModule ./services/mbsync.nix { })
     (loadModule ./services/mpd.nix { })
     (loadModule ./services/mpdris2.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.lorri;
+
+  lorri = import (fetchTarball {
+    url = "https://github.com/target/lorri/archive/rolling-release.tar.gz";
+  }) { };
+in
+
+{
+  meta.maintainers = [ maintainers.gerschtli ];
+
+  options = {
+    services.lorri = {
+	  enable = mkEnableOption "lorri setup";
+
+      package = mkOption {
+        type = types.package;
+        default = lorri;
+        defaultText = ''
+          import (fetchTarball {
+            url = "https://github.com/target/lorri/archive/rolling-release.tar.gz";
+          }) { }
+        '';
+        description = ''
+          Lorri package to install.
+
+          </para><para>
+
+          Note: Because lorri is still under development, they provide only a
+          rolling-release branch instead of a package in nixpkgs.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ lorri ];
+
+    systemd.user = {
+      services.lorri = {
+        Unit = {
+          Description = "Lorri build daemon";
+          Documentation = "https://github.com/target/lorri";
+          ConditionUser = "!@system";
+          Requires = "lorri.socket";
+          After = "lorri.socket";
+          RefuseManualStart = true;
+        };
+
+        Service = {
+          ExecStart = "${lorri}/bin/lorri daemon";
+          PrivateTmp = true;
+          ProtectSystem = "strict";
+          WorkingDirectory = "%h";
+          Restart = "on-failure";
+          Environment =
+            let
+              path = with pkgs; makeSearchPath "bin" [ nix gnutar git mercurial ];
+            in
+              concatStringsSep " " [
+                "PATH=${path}"
+                "RUST_BACKTRACE=1"
+              ];
+        };
+      };
+
+      sockets.lorri = {
+        Unit = {
+          Description = "Socket for lorri build daemon";
+        };
+
+        Socket = {
+          ListenStream = "%t/lorri/daemon.socket";
+        };
+
+        Install = {
+          WantedBy = [ "sockets.target" ];
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Hey, this PR adds a systemd user service for [lorri](https://github.com/target/lorri) and installs it as package.

Service definition originates from https://github.com/target/lorri/issues/96#issuecomment-506890388.

To fully support non NixOS systems, https://github.com/rycee/home-manager/pull/797 (especially https://github.com/rycee/home-manager/pull/797/commits/96e1e7fb2b4703d31b8556802526186ed8e3c53d) needs to merged.

Relates to https://github.com/target/lorri/issues/96.