### PR TITLE
alot: fix account extraConfig section

### DIFF
--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -38,11 +38,10 @@ let
             boolStr (signature.showSignature == "attach");
         }
       )
+      ++ [ alot.extraConfig ]
       ++ [ "[[[abook]]]" ]
       ++ mapAttrsToList (n: v: n + "=" + v) alot.contactCompletion
-    )
-    + "\n"
-    + alot.extraConfig;
+    );
 
   configFile =
     let


### PR DESCRIPTION
Anything in `accounts.email.accounts.*.alot.extraConfig` was incorrectly set under the `[[[abook]]]` configuration sub-section. This PR fixes that.

CC: @teto 