### PR TITLE
kdeconnect: Change incorrect kdeconnectd location

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -42,7 +42,7 @@ in
 
         Service = {
           Environment = "PATH=${config.home.profileDirectory}/bin";
-          ExecStart = "${package}/lib/libexec/kdeconnectd";
+          ExecStart = "${package}/libexec/kdeconnectd";
           Restart = "on-abort";
         };
       };


### PR DESCRIPTION
The location of the `kdeconnectd` binary must have changed sometime ago, this branch fixes the location and allows the service to run again.