### PR TITLE
Use `types.port` where applicable

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -95,7 +95,7 @@ let
       };
 
       port = mkOption {
-        type = types.nullOr types.ints.positive;
+        type = types.nullOr types.port;
         default = null;
         example = 993;
         description = ''
@@ -125,7 +125,7 @@ let
       };
 
       port = mkOption {
-        type = types.nullOr types.ints.positive;
+        type = types.nullOr types.port;
         default = null;
         example = 465;
         description = ''

--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -101,7 +101,7 @@ let
         };
 
         port = mkOption {
-          type = types.int;
+          type = types.port;
           default = 6667;
           description = "Port of the chat server.";
         };

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -21,7 +21,7 @@ let
       };
 
       port = mkOption {
-        type = types.nullOr types.int;
+        type = types.nullOr types.port;
         default = null;
         description = "Specifies port number to connect on remote host.";
       };

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -98,7 +98,7 @@ in {
         };
 
         port = mkOption {
-          type = types.ints.positive;
+          type = types.port;
           default = 6600;
           description = ''
             The TCP port on which the the daemon will listen.

--- a/modules/services/mpdris2.nix
+++ b/modules/services/mpdris2.nix
@@ -56,7 +56,7 @@ in
       };
 
       port = mkOption {
-        type = types.ints.positive;
+        type = types.port;
         default = config.services.mpd.network.port;
         defaultText = "config.services.mpd.network.port";
         description = ''


### PR DESCRIPTION
This changes the type of all options that specify ports to `types.port`. This type restricts values to between 0 and 65535.