### PR TITLE
add services.random-background.noXinerama option

### DIFF
--- a/modules/services/random-background.nix
+++ b/modules/services/random-background.nix
@@ -6,6 +6,9 @@ let
 
   cfg = config.services.random-background;
 
+  flags = lib.concatStringsSep " " ([ "--randomize" "--bg-${cfg.display}" ]
+    ++ (lib.optional (!cfg.enableXinerama) "--no-xinerama"));
+
 in
 
 {
@@ -41,6 +44,15 @@ in
           as a duration understood by systemd.
         '';
       };
+
+      enableXinerama = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Will place a separate image per screen when enabled,
+          otherwise a single image will be stretched across all screens.
+        '';
+      };
     };
   };
 
@@ -56,7 +68,7 @@ in
 
           Service = {
             Type = "oneshot";
-            ExecStart = "${pkgs.feh}/bin/feh --randomize --bg-${cfg.display} ${cfg.imageDirectory}";
+            ExecStart = "${pkgs.feh}/bin/feh ${flags} ${cfg.imageDirectory}";
             IOSchedulingClass = "idle";
           };
 


### PR DESCRIPTION
This prevents assigning a different background image to each monitor, since I use images that stretch across them.