### PR TITLE
home-manager: support a few extra pass-through options

### DIFF
--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -103,6 +103,22 @@
    </arg>
     
    <arg>
+    --cores <replaceable>number</replaceable>
+   </arg>
+    
+   <arg>
+    --max-jobs <replaceable>number</replaceable>
+   </arg>
+    
+   <arg>
+    --keep-failed
+   </arg>
+    
+   <arg>
+    --keep-going
+   </arg>
+    
+   <arg>
     --show-trace
    </arg>
     
@@ -351,6 +367,54 @@
      <para>
       Perform a dry-run of the given operation, only prints what actions would
       be taken.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--cores <replaceable>number</replaceable></option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix-build</refentrytitle>
+      <manvolnum>1</manvolnum> </citerefentry>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--max-jobs <replaceable>number</replaceable></option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix-build</refentrytitle>
+      <manvolnum>1</manvolnum> </citerefentry>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--keep-failed</option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix-build</refentrytitle>
+      <manvolnum>1</manvolnum> </citerefentry>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--keep-going</option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix-build</refentrytitle>
+      <manvolnum>1</manvolnum> </citerefentry>.
      </para>
     </listitem>
    </varlistentry>

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -423,6 +423,14 @@ function doHelp() {
     echo "  -n           Do a dry run, only prints what actions would be taken"
     echo "  -h           Print this help"
     echo
+    echo "Options passed on to nix-build(1)"
+    echo
+    echo "  --cores NUM"
+    echo "  --keep-failed"
+    echo "  --keep-going"
+    echo "  --max-jobs NUM"
+    echo "  --show-trace"
+    echo
     echo "Commands"
     echo
     echo "  help         Print this help"
@@ -490,7 +498,11 @@ while [[ $# -gt 0 ]]; do
         -n|--dry-run)
             export DRY_RUN=1
             ;;
-        --show-trace)
+        --max-jobs|--cores)
+            PASSTHROUGH_OPTS+=("$opt" "$1")
+            shift
+            ;;
+        --keep-failed|--keep-going|--show-trace)
             PASSTHROUGH_OPTS+=("$opt")
             ;;
         -v|--verbose)

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -485,6 +485,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -h|--help)
             doHelp
+            exit 0
             ;;
         -n|--dry-run)
             export DRY_RUN=1


### PR DESCRIPTION
These options will be passed through to the `nix-build` tool.