### PR TITLE
Fix option `defaultText` when referencing packages

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -21,7 +21,7 @@ let
           inherit visible;
           type = types.package;
           default = defaultPkg;
-          defaultText = "pkgs.${browser}";
+          defaultText = literalExample "pkgs.${browser}";
           description = "The ${name} package to use.";
         };
 

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -29,7 +29,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.emacs;
-        defaultText = "pkgs.emacs";
+        defaultText = literalExample "pkgs.emacs";
         example = literalExample "pkgs.emacs25-nox";
         description = "The Emacs package to use.";
       };

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -49,7 +49,7 @@ in
           if versionAtLeast config.home.stateVersion "19.09"
           then pkgs.firefox
           else pkgs.firefox-unwrapped;
-        defaultText = "pkgs.firefox";
+        defaultText = literalExample "pkgs.firefox";
         description = ''
           The Firefox package to use. If state version ≥ 19.09 then
           this should be a wrapped Firefox package. For earlier state

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -23,7 +23,7 @@ in
 
       package = mkOption {
         default = pkgs.fish;
-        defaultText = "pkgs.fish";
+        defaultText = literalExample "pkgs.fish";
         description = ''
           The fish package to install. May be used to change the version.
         '';

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -122,7 +122,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.git;
-        defaultText = "pkgs.git";
+        defaultText = literalExample "pkgs.git";
         description = ''
           Git package to install. Use <varname>pkgs.gitAndTools.gitFull</varname>
           to gain access to <command>git send-email</command> for instance.

--- a/modules/programs/go.nix
+++ b/modules/programs/go.nix
@@ -18,7 +18,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.go;
-        defaultText = "pkgs.go";
+        defaultText = literalExample "pkgs.go";
         description = "The Go package to use.";
       };
 

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -25,7 +25,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.keychain;
-      defaultText = "pkgs.keychain";
+      defaultText = literalExample "pkgs.keychain";
       description = ''
         Keychain package to install.
       '';

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -112,7 +112,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.isync;
-        defaultText = "pkgs.isync";
+        defaultText = literalExample "pkgs.isync";
         example = literalExample "pkgs.isync";
         description = "The package to use for the mbsync binary.";
       };

--- a/modules/programs/mercurial.nix
+++ b/modules/programs/mercurial.nix
@@ -17,7 +17,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.mercurial;
-        defaultText = "pkgs.mercurial";
+        defaultText = literalExample "pkgs.mercurial";
         description = "Mercurial package to install.";
       };
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -107,7 +107,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.neovim-unwrapped;
-        defaultText = "pkgs.neovim-unwrapped";
+        defaultText = literalExample "pkgs.neovim-unwrapped";
         description = "The package to use for the neovim binary.";
       };
 

--- a/modules/programs/opam.nix
+++ b/modules/programs/opam.nix
@@ -17,7 +17,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.opam;
-      defaultText = "pkgs.opam";
+      defaultText = literalExample "pkgs.opam";
       description = "Opam package to install.";
     };
 

--- a/modules/programs/pidgin.nix
+++ b/modules/programs/pidgin.nix
@@ -18,7 +18,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.pidgin;
-        defaultText = "pkgs.pidgin";
+        defaultText = literalExample "pkgs.pidgin";
         description = "The Pidgin package to use.";
       };
 

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -169,7 +169,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.tmux;
-        defaultText = "pkgs.tmux";
+        defaultText = literalExample "pkgs.tmux";
         example = literalExample "pkgs.tmux";
         description = "The tmux package to install";
       };

--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -15,7 +15,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.rxvt_unicode;
-      defaultText = "pkgs.rxvt_unicode";
+      defaultText = literalExample "pkgs.rxvt_unicode";
       description = "rxvt-unicode package to install.";
     };
 

--- a/modules/services/compton.nix
+++ b/modules/services/compton.nix
@@ -263,7 +263,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.compton;
-      defaultText = "pkgs.compton";
+      defaultText = literalExample "pkgs.compton";
       example = literalExample "pkgs.compton";
       description = ''
         Compton derivation to use.

--- a/modules/services/dwm-status.nix
+++ b/modules/services/dwm-status.nix
@@ -20,7 +20,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.dwm-status;
-        defaultText = "pkgs.dwm-status";
+        defaultText = literalExample "pkgs.dwm-status";
         example = "pkgs.dwm-status.override { enableAlsaUtils = false; }";
         description = "Which dwm-status package to use.";
       };

--- a/modules/services/mbsync.nix
+++ b/modules/services/mbsync.nix
@@ -22,7 +22,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.isync;
-      defaultText = "pkgs.isync";
+      defaultText = literalExample "pkgs.isync";
       example = literalExample "pkgs.isync";
       description = "The package to use for the mbsync binary.";
     };

--- a/modules/services/mpdris2.nix
+++ b/modules/services/mpdris2.nix
@@ -42,7 +42,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.mpdris2;
-      defaultText = "pkgs.mpdris2";
+      defaultText = literalExample "pkgs.mpdris2";
       description = "The mpDris2 package to use.";
     };
 

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -37,7 +37,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.polybar;
-        defaultText = "pkgs.polybar";
+        defaultText = literalExample "pkgs.polybar";
         description = "Polybar package to install.";
         example =  literalExample ''
           pkgs.polybar.override {

--- a/modules/services/redshift.nix
+++ b/modules/services/redshift.nix
@@ -96,7 +96,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.redshift;
-      defaultText = "pkgs.redshift";
+      defaultText = literalExample "pkgs.redshift";
       description = ''
         redshift derivation to use.
       '';

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -15,7 +15,7 @@ in
 
       package = mkOption {
         default = pkgs.stalonetray;
-        defaultText = "pkgs.stalonetray";
+        defaultText = literalExample "pkgs.stalonetray";
         type = types.package;
         example = literalExample "pkgs.stalonetray";
         description = "The package to use for the Stalonetray binary.";

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -17,7 +17,7 @@ in
 
       package = mkOption {
         default = pkgs.haskellPackages.status-notifier-item;
-        defaultText = "pkgs.haskellPackages.status-notifier-item";
+        defaultText = literalExample "pkgs.haskellPackages.status-notifier-item";
         type = types.package;
         example = literalExample "pkgs.haskellPackages.status-notifier-item";
         description = "The package to use for the status notifier watcher binary.";

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -17,7 +17,7 @@ in
 
       package = mkOption {
         default = pkgs.taffybar;
-        defaultText = "pkgs.taffybar";
+        defaultText = literalExample "pkgs.taffybar";
         type = types.package;
         example = literalExample "pkgs.taffybar";
         description = "The package to use for the Taffybar binary.";

--- a/modules/services/unclutter.nix
+++ b/modules/services/unclutter.nix
@@ -13,7 +13,7 @@ in {
       description = "unclutter derivation to use.";
       type = types.package;
       default = pkgs.unclutter-xfixes;
-      defaultText = "pkgs.unclutter-xfixes";
+      defaultText = literalExample "pkgs.unclutter-xfixes";
     };
 
     timeout = mkOption {

--- a/modules/services/window-managers/awesome.nix
+++ b/modules/services/window-managers/awesome.nix
@@ -22,7 +22,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.awesome;
-        defaultText = "pkgs.awesome";
+        defaultText = literalExample "pkgs.awesome";
         description = "Package to use for running the Awesome WM.";
       };
 

--- a/modules/services/window-managers/i3.nix
+++ b/modules/services/window-managers/i3.nix
@@ -781,8 +781,8 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.i3;
-        defaultText = "pkgs.i3";
-        example = "pkgs.i3-gaps";
+        defaultText = literalExample "pkgs.i3";
+        example = literalExample "pkgs.i3-gaps";
         description = ''
           i3 package to use.
           If 'i3.config.gaps' settings are specified, 'pkgs.i3-gaps' will be set as a default package.

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -24,7 +24,7 @@ in
 
       haskellPackages = mkOption {
         default = pkgs.haskellPackages;
-        defaultText = "pkgs.haskellPackages";
+        defaultText = literalExample "pkgs.haskellPackages";
         example = literalExample "pkgs.haskell.packages.ghc784";
         description = ''
           The <varname>haskellPackages</varname> used to build xmonad

--- a/modules/services/xembed-sni-proxy.nix
+++ b/modules/services/xembed-sni-proxy.nix
@@ -18,7 +18,7 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.plasma-workspace;
-        defaultText = "pkgs.plasma-workspace";
+        defaultText = literalExample "pkgs.plasma-workspace";
         description = ''
           Package containing the <command>xembedsniproxy</command>
           program.


### PR DESCRIPTION
By using `literalExample` the documentation will show the option default without surrounding quotes.