### PR TITLE
manual: add nmd as a generation dependency

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -5,6 +5,7 @@ let
   lib = pkgs.lib;
 
   nmdSrc = pkgs.fetchFromGitLab {
+    name = "nmd";
     owner = "rycee";
     repo = "nmd";
     rev = "9751ca5ef6eb2ef27470010208d4c0a20e89443d";
@@ -55,6 +56,7 @@ let
 in
 
 {
+  inherit nmdSrc;
 
   options = {
     json = hmModulesDocs.json.override {
@@ -67,5 +69,4 @@ in
   manual = {
     inherit (docs) html htmlOpenTool;
   };
-
 }

--- a/modules/manual.nix
+++ b/modules/manual.nix
@@ -56,6 +56,13 @@ in
       (mkIf cfg.manpages.enable [ docs.manPages ])
       (mkIf cfg.json.enable [ docs.options.json ])
     ];
+
+    # Whether a dependency on nmd should be introduced.
+    home.extraBuilderCommands =
+      mkIf (cfg.html.enable || cfg.manpages.enable || cfg.json.enable) ''
+        mkdir $out/lib
+        ln -s ${docs.nmdSrc} $out/lib/nmd
+      '';
   };
 
 }


### PR DESCRIPTION
This is to allow network-less rebuilding of a generation after a garbage collection.

Fixes #819