### PR TITLE
vim: always add sensible plugin

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -182,7 +182,10 @@ in
 
         home.packages = [ cfg.package ];
 
-        programs.vim.package = vim;
+        programs.vim = {
+          package = vim;
+          plugins = defaultPlugins;
+        };
       }
   );
 }


### PR DESCRIPTION
Hey, I introduced a bug in https://github.com/rycee/home-manager/pull/792 where the default plugin `sensible` was not added if any plugins were defined. This fixes the issue.

Fixes https://github.com/rycee/home-manager/pull/792#issuecomment-526342006