### PR TITLE
notmuch: allow specifying a custom package

### DIFF
--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -60,6 +60,13 @@ in
     programs.notmuch = {
       enable = mkEnableOption "Notmuch mail indexer";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.notmuch;
+        defaultText = literalExample "pkgs.notmuch";
+        description = "The notmuch package to use.";
+      };
+
       new = mkOption {
         type = types.submodule {
           options = {
@@ -168,7 +175,7 @@ in
       }
     ];
 
-    home.packages = [ pkgs.notmuch ];
+    home.packages = [ cfg.package ];
 
     home.sessionVariables = {
       NOTMUCH_CONFIG = "${config.xdg.configHome}/notmuch/notmuchrc";


### PR DESCRIPTION
This works, but it fails when trying to compile my notmuch package. I'm using the same nix expression as in https://github.com/NixOS/nixpkgs/pull/67813 but it fails saying it can't find gmime. I don't know why. See http://ix.io/1TSm if interested in helping me figure that part out