### PR TITLE
rofi: string -> str

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -270,7 +270,7 @@ in
 
     theme = mkOption {
       default = null;
-      type = with types; nullOr (either string path);
+      type = with types; nullOr (either str path);
       example = "Arc";
       description = ''
         Name of theme or path to theme file in rasi format. Available


### PR DESCRIPTION
Seems to be one missing `types.string` in `modules/programs/rofi.nix`