### PR TITLE
mpd: use systemd journal instead of syslog

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -16,7 +16,6 @@ let
     ''}
     state_file          "${cfg.dataDir}/state"
     sticker_file        "${cfg.dataDir}/sticker.sql"
-    log_file            "syslog"
 
     ${optionalString (cfg.network.listenAddress != "any")
       ''bind_to_address "${cfg.network.listenAddress}"''}


### PR DESCRIPTION
MPD is using syslog for its logging output, while it could directly log to
systemd's journal, as this daemon is primarily used (in home-manager) as a systemd user service.
This change makes MPD log to standard output, which is captured by systemd.

See [NixOS PR #57608](https://github.com/NixOS/nixpkgs/pull/57608), which does the same thing to NixOS's MPD service :

> Yes, logging directly to the journal should be done in the user service from home-manager as well. But since home-manager is a separate repository, this cannot be done atomically. It is better to keep the syslog support and update home-manager in a follow-up step. I initially meant to remove syslog support but I changed my mind on it. syslog support has no extra dependencies so it's there is no cost anyway.