### PR TITLE
gpg: Sane default for throw-keyids option

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -51,7 +51,6 @@ in {
       with-fingerprint = mkDefault true;
       require-cross-certification = mkDefault true;
       no-symkey-cache = mkDefault true;
-      throw-keyids = mkDefault true;
       use-agent = mkDefault true;
     };
 

--- a/tests/modules/programs/gpg/override-defaults.nix
+++ b/tests/modules/programs/gpg/override-defaults.nix
@@ -10,6 +10,7 @@ with lib;
       settings = {
         no-comments = false;
         s2k-cipher-algo = "AES128";
+        throw-keyids = true;
       };
     };
 


### PR DESCRIPTION
The [throw-keyids](https://www.gnupg.org/gph/en/manual/r2110.html) option "hides the receiver of the encrypted data as a countermeasure against traffic analysis." However, it also slows down decryption, and even breaks some applications; see e.g. https://github.com/open-keychain/open-keychain/issues/626

I think the sane default would be to leave it off, just as it is off by default in gpg. The typical user will probably not need this level of security, and will probably prefer a better user experience (faster decryption and compatibility with a wider range of applications).