### PR TITLE
xsession: remove bashisms in start scripts

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -130,7 +130,7 @@ in
     home.file.".xprofile".text = ''
         . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
-        if [[ -e "$HOME/.profile" ]]; then
+        if [ -e "$HOME/.profile" ]; then
           . "$HOME/.profile"
         fi
 
@@ -152,7 +152,7 @@ in
     home.file.${cfg.scriptPath} = {
       executable = true;
       text = ''
-        if [[ ! -v HM_XPROFILE_SOURCED ]]; then
+        if [ -z "$HM_XPROFILE_SOURCED" ]; then
           . ~/.xprofile
         fi
         unset HM_XPROFILE_SOURCED
@@ -167,7 +167,7 @@ in
         systemctl --user stop graphical-session-pre.target
 
         # Wait until the units actually stop.
-        while [[ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]]; do
+        while [ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]; do
           sleep 0.5
         done
       '';

--- a/tests/modules/misc/xsession/basic-xprofile-expected.txt
+++ b/tests/modules/misc/xsession/basic-xprofile-expected.txt
@@ -1,6 +1,6 @@
 . "/test-home/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
-if [[ -e "$HOME/.profile" ]]; then
+if [ -e "$HOME/.profile" ]; then
   . "$HOME/.profile"
 fi
 

--- a/tests/modules/misc/xsession/basic-xsession-expected.txt
+++ b/tests/modules/misc/xsession/basic-xsession-expected.txt
@@ -1,4 +1,4 @@
-if [[ ! -v HM_XPROFILE_SOURCED ]]; then
+if [ -z "$HM_XPROFILE_SOURCED" ]; then
   . ~/.xprofile
 fi
 unset HM_XPROFILE_SOURCED
@@ -13,6 +13,6 @@ systemctl --user stop graphical-session.target
 systemctl --user stop graphical-session-pre.target
 
 # Wait until the units actually stop.
-while [[ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]]; do
+while [ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]; do
   sleep 0.5
 done


### PR DESCRIPTION
Fixes #836