### PR TITLE
sxhkd: add service

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -128,6 +128,7 @@ let
     (loadModule ./services/screen-locker.nix { })
     (loadModule ./services/stalonetray.nix { })
     (loadModule ./services/status-notifier-watcher.nix { })
+    (loadModule ./services/sxhkd.nix { })
     (loadModule ./services/syncthing.nix { })
     (loadModule ./services/taffybar.nix { })
     (loadModule ./services/tahoe-lafs.nix { })

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -128,7 +128,7 @@ let
     (loadModule ./services/screen-locker.nix { })
     (loadModule ./services/stalonetray.nix { })
     (loadModule ./services/status-notifier-watcher.nix { })
-    (loadModule ./services/sxhkd.nix { })
+    (loadModule ./services/sxhkd.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/syncthing.nix { })
     (loadModule ./services/taffybar.nix { })
     (loadModule ./services/tahoe-lafs.nix { })

--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -20,7 +20,7 @@ in
 
 {
   options.services.sxhkd = {
-    enable = mkEnableOption "Simple X hotkey daemon";
+    enable = mkEnableOption "simple X hotkey daemon";
 
     keybindings = mkOption {
       type = types.attrsOf (types.nullOr types.str);

--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -1,0 +1,85 @@
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+
+  cfg = config.services.sxhkd;
+
+  hotkeybindingsStr = concatStringsSep "\n" (
+    mapAttrsToList (hotkey: command:
+      optionalString (command != null) ''
+        ${hotkey}
+          ${command}
+      ''
+    )
+    cfg.hotkeybindings
+  );
+
+in
+
+{
+  options.services.sxhkd = {
+    enable = mkEnableOption "Simple X hotkey daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.sxhkd;
+      defaultText = literalExample "pkgs.sxhkd";
+      description = "sxhkd package to install.";
+      example =  literalExample "pkgs.sxhkd";
+    };
+
+    hotkeybindings = mkOption {
+      type = types.attrsOf (types.nullOr types.str);
+      default = {};
+      description = "An attribute set that assigns a hotkey to a command";
+      example = literalExample ''
+        {
+          "super + shift + {r,c}" = "i3-msg {restart,reload}";
+          "super + {s,w}"         = "i3-msg {stacking,tabbed}";
+        }
+      '';
+    };
+
+    extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      description = "Additional configuration to add";
+      example = literalExample ''
+        super + {_,shift +} {1-9,0}
+          i3-msg {workspace,move container to workspace} {1-10}
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."sxhkd/sxhkdrc".text = concatStringsSep "\n" [
+      hotkeybindingsStr
+      cfg.extraConfig
+    ];
+
+    systemd.user.services.sxhkd = {
+      Unit = {
+        Description = "Simple X hotkey daemon";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Environment = "PATH=" + concatStringsSep ":" [
+          "${config.home.profileDirectory}/bin"
+          "/run/wrappers/bin"
+          "/run/current-system/sw/bin"
+        ];
+        ExecStart = "${cfg.package}/bin/sxhkd";
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}

--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -6,14 +6,14 @@ let
 
   cfg = config.services.sxhkd;
 
-  hotkeybindingsStr = concatStringsSep "\n" (
+  keybindingsStr = concatStringsSep "\n" (
     mapAttrsToList (hotkey: command:
       optionalString (command != null) ''
         ${hotkey}
           ${command}
       ''
     )
-    cfg.hotkeybindings
+    cfg.keybindings
   );
 
 in
@@ -22,18 +22,10 @@ in
   options.services.sxhkd = {
     enable = mkEnableOption "Simple X hotkey daemon";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.sxhkd;
-      defaultText = literalExample "pkgs.sxhkd";
-      description = "sxhkd package to install.";
-      example =  literalExample "pkgs.sxhkd";
-    };
-
-    hotkeybindings = mkOption {
+    keybindings = mkOption {
       type = types.attrsOf (types.nullOr types.str);
       default = {};
-      description = "An attribute set that assigns a hotkey to a command";
+      description = "An attribute set that assigns hotkeys to commands.";
       example = literalExample ''
         {
           "super + shift + {r,c}" = "i3-msg {restart,reload}";
@@ -45,25 +37,32 @@ in
     extraConfig = mkOption {
       default = "";
       type = types.lines;
-      description = "Additional configuration to add";
+      description = "Additional configuration to add.";
       example = literalExample ''
         super + {_,shift +} {1-9,0}
           i3-msg {workspace,move container to workspace} {1-10}
       '';
     };
+
+    extraPath = mkOption {
+      default = "";
+      type = types.envVar;
+      description = "Additional PATH to search for commands.";
+      example = literalExample "/home/some-user/bin:/extra/path/bin";
+    };
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = [ pkgs.sxhkd ];
 
     xdg.configFile."sxhkd/sxhkdrc".text = concatStringsSep "\n" [
-      hotkeybindingsStr
+      keybindingsStr
       cfg.extraConfig
     ];
 
     systemd.user.services.sxhkd = {
       Unit = {
-        Description = "Simple X hotkey daemon";
+        Description = "simple X hotkey daemon";
         After = [ "graphical-session-pre.target" ];
         PartOf = [ "graphical-session.target" ];
       };
@@ -71,10 +70,9 @@ in
       Service = {
         Environment = "PATH=" + concatStringsSep ":" [
           "${config.home.profileDirectory}/bin"
-          "/run/wrappers/bin"
-          "/run/current-system/sw/bin"
+          cfg.extraPath
         ];
-        ExecStart = "${cfg.package}/bin/sxhkd";
+        ExecStart = "${pkgs.sxhkd}/bin/sxhkd";
       };
 
       Install = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -38,6 +38,7 @@ import nmt {
     // import ./modules/misc/xsession
     // import ./modules/programs/firefox
     // import ./modules/programs/rofi
+    // import ./modules/services/sxhkd
     // import ./modules/systemd
   )
   // import ./modules/home-environment

--- a/tests/modules/services/sxhkd/configuration.nix
+++ b/tests/modules/services/sxhkd/configuration.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+{
+  config = {
+    services.sxhkd = {
+      enable = true;
+
+      hotkeybindings = {
+        "super + a" = "run command a";
+        "super + b" = null;
+        "super + Shift + b" = "run command b";
+      };
+
+      extraConfig = ''
+        super + c
+          call command c
+ 
+        # comment
+        super + d
+          call command d
+      '';
+    };
+
+    nmt.script = ''
+      local sxhkdrc=home-files/.config/sxhkd/sxhkdrc
+
+      assertFileExists $sxhkdrc
+
+      assertFileContent $sxhkdrc ${./sxhkdrc}
+    '';
+  };
+}

--- a/tests/modules/services/sxhkd/configuration.nix
+++ b/tests/modules/services/sxhkd/configuration.nix
@@ -4,7 +4,7 @@
     services.sxhkd = {
       enable = true;
 
-      hotkeybindings = {
+      keybindings = {
         "super + a" = "run command a";
         "super + b" = null;
         "super + Shift + b" = "run command b";

--- a/tests/modules/services/sxhkd/default.nix
+++ b/tests/modules/services/sxhkd/default.nix
@@ -1,0 +1,4 @@
+{
+  sxhkd-configuration = ./configuration.nix;
+  sxhkd-service = ./service.nix;
+}

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -1,7 +1,10 @@
 { config, ... }:
 {
   config = {
-    services.sxhkd.enable = true;
+    services.sxhkd = {
+      enable = true;
+      extraPath = "/home/the-user/bin:/extra/path/bin";
+    };
 
     nmt.script = ''
       local serviceFile=home-files/.config/systemd/user/sxhkd.service
@@ -11,7 +14,7 @@
       assertFileRegex $serviceFile 'ExecStart=.*/bin/sxhkd'
 
       assertFileRegex $serviceFile \
-        'Environment=PATH=.*nix-profile/bin:/run/wrappers/bin:/run/current-system/sw/bin'
+        'Environment=PATH=.*\.nix-profile/bin:/home/the-user/bin:/extra/path/bin'
     '';
   };
 }

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -1,0 +1,17 @@
+{ config, ... }:
+{
+  config = {
+    services.sxhkd.enable = true;
+
+    nmt.script = ''
+      local serviceFile=home-files/.config/systemd/user/sxhkd.service
+
+      assertFileExists $serviceFile
+
+      assertFileRegex $serviceFile 'ExecStart=.*/bin/sxhkd'
+
+      assertFileRegex $serviceFile \
+        'Environment=PATH=.*nix-profile/bin:/run/wrappers/bin:/run/current-system/sw/bin'
+    '';
+  };
+}

--- a/tests/modules/services/sxhkd/sxhkdrc
+++ b/tests/modules/services/sxhkd/sxhkdrc
@@ -1,0 +1,13 @@
+super + Shift + b
+  run command b
+
+super + a
+  run command a
+
+
+super + c
+  call command c
+
+# comment
+super + d
+  call command d


### PR DESCRIPTION
This is a new service for sxhkd hotkeys daemon. 

I am using sxhkd with i3 but it is also required for bspwm https://github.com/rycee/home-manager/issues/359

As I understand https://github.com/rycee/home-manager/pull/362 is dropped, I've picked sxhkd configuration from there.