### PR TITLE
mpd: allow path literal values in options

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -45,6 +45,7 @@ in {
         type = types.path;
         default = "${config.home.homeDirectory}/music";
         defaultText = "$HOME/music";
+        apply = toString;       # Prevent copies to Nix store.
         description = ''
           The directory where mpd reads music from.
         '';
@@ -54,6 +55,7 @@ in {
         type = types.path;
         default = "${cfg.dataDir}/playlists";
         defaultText = ''''${dataDir}/playlists'';
+        apply = toString;       # Prevent copies to Nix store.
         description = ''
           The directory where mpd stores playlists.
         '';
@@ -78,6 +80,7 @@ in {
         type = types.path;
         default = "${config.xdg.dataHome}/${name}";
         defaultText = "$XDG_DATA_HOME/mpd";
+        apply = toString;       # Prevent copies to Nix store.
         description = ''
           The directory where MPD stores its state, tag cache,
           playlists etc.


### PR DESCRIPTION
This allows specifying, for example, the music directory using path literals without causing the directory to be copied to the Nix store.

Suggested-by: Silvan Mosberger <infinisil@icloud.com>