### PR TITLE
xdg-mime-apps: save mimeapps.list in .local/share/applications

### DIFF
--- a/modules/misc/xdg-mime-apps.nix
+++ b/modules/misc/xdg-mime-apps.nix
@@ -75,6 +75,10 @@ in
   };
 
   config = mkIf cfg.enable {
+    # Deprecated but still used by some applications.
+    home.file.".local/share/applications/mimeapps.list".source =
+      config.xdg.configFile."mimeapps.list".source;
+
     xdg.configFile."mimeapps.list".text =
       let
         joinValues = mapAttrs (n: concatStringsSep ";");


### PR DESCRIPTION
Although .local/share/applications/mimeapps.list is deprecated, this file is still being read by some applications. 

To ensure compatibility duplicate the file as recommended in https://wiki.archlinux.org/index.php/XDG_MIME_Applications#mimeapps.list