### PR TITLE
termite: use vte-ng at pkgs.termite.vte-ng

### DIFF
--- a/modules/programs/termite.nix
+++ b/modules/programs/termite.nix
@@ -9,7 +9,7 @@ let
   vteInitStr = ''
     # See https://github.com/thestinger/termite#id1
     if [[ $TERM == xterm-termite ]]; then
-      . ${pkgs.gnome3.vte-ng}/etc/profile.d/vte.sh
+      . ${pkgs.termite.vte-ng}/etc/profile.d/vte.sh
     fi
   '';
 


### PR DESCRIPTION
depends on https://github.com/NixOS/nixpkgs/pull/70776
closes #864 