### PR TITLE
tests: reduce number of downloads

### DIFF
--- a/tests/modules/misc/xsession/basic.nix
+++ b/tests/modules/misc/xsession/basic.nix
@@ -14,6 +14,16 @@ with lib;
       profileExtra = "profile extra commands";
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        xorg = super.xorg // {
+          setxkbmap = super.xorg.setxkbmap // {
+            outPath = "@setxkbmap@";
+          };
+        };
+     })
+    ];
+
     nmt.script = ''
       assertFileExists home-files/.xprofile
       assertFileContent \
@@ -28,10 +38,7 @@ with lib;
       assertFileExists home-files/.config/systemd/user/setxkbmap.service
       assertFileContent \
         home-files/.config/systemd/user/setxkbmap.service \
-        ${pkgs.substituteAll {
-          src = ./basic-setxkbmap-expected.service;
-          inherit (pkgs.xorg) setxkbmap;
-        }}
+        ${./basic-setxkbmap-expected.service}
     '';
   };
 }

--- a/tests/modules/misc/xsession/keyboard-without-layout.nix
+++ b/tests/modules/misc/xsession/keyboard-without-layout.nix
@@ -20,14 +20,21 @@ with lib;
       profileExtra = "profile extra commands";
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        xorg = super.xorg // {
+          setxkbmap = super.xorg.setxkbmap // {
+            outPath = "@setxkbmap@";
+          };
+        };
+     })
+    ];
+
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/setxkbmap.service
       assertFileContent \
         home-files/.config/systemd/user/setxkbmap.service \
-        ${pkgs.substituteAll {
-          src = ./keyboard-without-layout-expected.service;
-          inherit (pkgs.xorg) setxkbmap;
-        }}
+        ${./keyboard-without-layout-expected.service}
     '';
   };
 }

--- a/tests/modules/programs/alacritty/empty-settings.nix
+++ b/tests/modules/programs/alacritty/empty-settings.nix
@@ -6,6 +6,12 @@ with lib;
   config = {
     programs.alacritty.enable = true;
 
+    nixpkgs.overlays = [
+      (self: super: {
+        alacritty = pkgs.writeScriptBin "dummy-alacritty" "";
+      })
+    ];
+
     nmt.script = ''
       assertPathNotExists home-files/.config/alacritty
     '';

--- a/tests/modules/programs/alacritty/example-settings.nix
+++ b/tests/modules/programs/alacritty/example-settings.nix
@@ -23,6 +23,12 @@ with lib;
       };
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        alacritty = pkgs.writeScriptBin "dummy-alacritty" "";
+      })
+    ];
+
     nmt.script = ''
       assertFileContent \
         home-files/.config/alacritty/alacritty.yml \

--- a/tests/modules/programs/bash/session-variables-expected.txt
+++ b/tests/modules/programs/bash/session-variables-expected.txt
@@ -1,6 +1,6 @@
 # -*- mode: sh -*-
 
-. "@homeDirectory@/.nix-profile/etc/profile.d/hm-session-vars.sh"
+. "/home/testuser/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
 export V1="v1"
 export V2="v2-v1"

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -13,16 +13,13 @@ with lib;
       };
     };
 
+    home.homeDirectory = "/home/testuser";
+
     nmt.script = ''
       assertFileExists home-files/.profile
       assertFileContent \
         home-files/.profile \
-        ${
-          pkgs.substituteAll {
-            src = ./session-variables-expected.txt;
-            inherit (config.home) homeDirectory;
-          }
-        }
+        ${./session-variables-expected.txt}
     '';
   };
 }

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -11,6 +11,24 @@ with lib;
       };
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        firefox-unwrapped =
+          pkgs.runCommand
+            "firefox-0"
+            {
+              meta.description = "I pretend to be Firefox";
+              preferLocalBuild = true;
+              allowSubstitutes = false;
+            }
+            ''
+              mkdir -p "$out/bin"
+              touch "$out/bin/firefox"
+              chmod 755 "$out/bin/firefox"
+            '';
+      })
+    ];
+
     nmt.script = ''
       assertFileRegex \
         home-path/bin/firefox \

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -8,6 +8,24 @@ with lib;
 
     programs.firefox.enable = true;
 
+    nixpkgs.overlays = [
+      (self: super: {
+        firefox-unwrapped =
+          pkgs.runCommand
+            "firefox-0"
+            {
+              meta.description = "I pretend to be Firefox";
+              preferLocalBuild = true;
+              allowSubstitutes = false;
+            }
+            ''
+              mkdir -p "$out/bin"
+              touch "$out/bin/firefox"
+              chmod 755 "$out/bin/firefox"
+            '';
+      })
+    ];
+
     nmt.script = ''
       assertFileRegex \
         home-path/bin/firefox \

--- a/tests/modules/programs/git-with-email.nix
+++ b/tests/modules/programs/git-with-email.nix
@@ -8,6 +8,7 @@ with lib;
   config = {
     programs.git = {
       enable = true;
+      package = pkgs.gitMinimal;
       userEmail = "hm@example.com";
       userName = "H. M. Test";
     };

--- a/tests/modules/programs/git-with-str-extra-config.nix
+++ b/tests/modules/programs/git-with-str-extra-config.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -6,6 +6,7 @@ with lib;
   config = {
     programs.git = {
       enable = true;
+      package = pkgs.gitMinimal;
       extraConfig = ''
         This can be anything.
       '';

--- a/tests/modules/programs/git.nix
+++ b/tests/modules/programs/git.nix
@@ -24,6 +24,7 @@ in
     programs.git = mkMerge [
       {
         enable = true;
+        package = pkgs.gitMinimal;
         aliases = {
           a1 = "foo";
           a2 = "bar";

--- a/tests/modules/programs/gpg/override-defaults.nix
+++ b/tests/modules/programs/gpg/override-defaults.nix
@@ -14,6 +14,12 @@ with lib;
       };
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        gnupg = pkgs.writeScriptBin "dummy-gnupg" "";
+      })
+    ];
+
     nmt.script = ''
       assertFileExists home-files/.gnupg/gpg.conf
       assertFileContent home-files/.gnupg/gpg.conf ${./override-defaults-expected.conf}

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.nix
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.nix
@@ -2,27 +2,27 @@
 
 with lib;
 
-let
-
-  substituteExpected = path: pkgs.substituteAll {
-    src = path;
-
-    sensible_rtp = pkgs.tmuxPlugins.sensible.rtp;
-  };
-  
-in
-
 {
   config = {
     programs.tmux = {
       enable = true;
       disableConfirmationPrompt = true;
     };
-  
+
+    nixpkgs.overlays = [
+      (self: super: {
+        tmuxPlugins = super.tmuxPlugins // {
+          sensible = super.tmuxPlugins.sensible // {
+            rtp = "@sensible_rtp@";
+          };
+        };
+      })
+    ];
+
     nmt.script = ''
       assertFileExists home-files/.tmux.conf
       assertFileContent home-files/.tmux.conf \
-        ${substituteExpected ./disable-confirmation-prompt.conf}
+        ${./disable-confirmation-prompt.conf}
     '';
   };
 }

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -37,18 +37,18 @@ set  -g history-limit     2000
 # tmuxplugin-logging
 # ---------------------
 
-run-shell @tmuxplugin_logging@/share/tmux-plugins/logging/logging.tmux
+run-shell @tmuxplugin_logging_rtp@
 
 
 # tmuxplugin-prefix-highlight
 # ---------------------
 
-run-shell @tmuxplugin_prefix_highlight@/share/tmux-plugins/prefix-highlight/prefix_highlight.tmux
+run-shell @tmuxplugin_prefix_highlight_rtp@
 
 
 # tmuxplugin-fzf-tmux-url
 # ---------------------
 
-run-shell @tmuxplugin_fzf_tmux_url@/share/tmux-plugins/fzf-tmux-url/fzf-url.tmux
+run-shell @tmuxplugin_fzf_tmux_url_rtp@
 
 # ============================================= #

--- a/tests/modules/programs/tmux/emacs-with-plugins.nix
+++ b/tests/modules/programs/tmux/emacs-with-plugins.nix
@@ -2,19 +2,6 @@
 
 with lib;
 
-let
-
-  substituteExpected = path: pkgs.substituteAll {
-    src = path;
-
-    tmuxplugin_fzf_tmux_url = pkgs.tmuxPlugins.fzf-tmux-url;
-    tmuxplugin_logging = pkgs.tmuxPlugins.logging;
-    tmuxplugin_prefix_highlight = pkgs.tmuxPlugins.prefix-highlight;
-    tmuxplugin_sensible_rtp = pkgs.tmuxPlugins.sensible.rtp;
-  };
-
-in
-
 {
   config = {
     programs.tmux = {
@@ -32,10 +19,31 @@ in
       ];
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        tmuxPlugins = super.tmuxPlugins // {
+          fzf-tmux-url = super.tmuxPlugins.fzf-tmux-url // {
+            rtp = "@tmuxplugin_fzf_tmux_url_rtp@";
+          };
+
+          logging = super.tmuxPlugins.logging // {
+            rtp = "@tmuxplugin_logging_rtp@";
+          };
+
+          prefix-highlight = super.tmuxPlugins.prefix-highlight // {
+            rtp = "@tmuxplugin_prefix_highlight_rtp@";
+          };
+
+          sensible = super.tmuxPlugins.sensible // {
+            rtp = "@tmuxplugin_sensible_rtp@";
+          };
+        };
+      })
+    ];
+
     nmt.script = ''
       assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf \
-        ${substituteExpected ./emacs-with-plugins.conf}
+      assertFileContent home-files/.tmux.conf ${./emacs-with-plugins.conf}
     '';
   };
 }

--- a/tests/modules/programs/tmux/vi-all-true.nix
+++ b/tests/modules/programs/tmux/vi-all-true.nix
@@ -2,15 +2,7 @@
 
 with lib;
 
-let
-
-  substituteExpected = path: pkgs.substituteAll {
-    src = path;
-
-    sensible_rtp = pkgs.tmuxPlugins.sensible.rtp;
-  };
-
-in {
+{
   config = {
     programs.tmux = {
       aggressiveResize = true;
@@ -21,10 +13,19 @@ in {
       reverseSplit = true;
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        tmuxPlugins = super.tmuxPlugins // {
+          sensible = super.tmuxPlugins.sensible // {
+            rtp = "@sensible_rtp@";
+          };
+        };
+      })
+    ];
+
     nmt.script = ''
       assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf \
-        ${substituteExpected ./vi-all-true.conf}
+      assertFileContent home-files/.tmux.conf ${./vi-all-true.conf}
     '';
   };
 }

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -12,6 +12,12 @@ with lib;
         V2 = "v2-${config.programs.zsh.sessionVariables.V1}";
       };
     };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        zsh = pkgs.writeScriptBin "dummy-zsh" "";
+      })
+    ];
 
     nmt.script = ''
       assertFileExists home-files/.zshrc

--- a/tests/modules/services/window-managers/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3-keybindings-expected.conf
@@ -1,0 +1,100 @@
+font pango:monospace 8
+floating_modifier Mod1
+new_window normal 2
+new_float normal 2
+hide_edge_borders none
+force_focus_wrapping no
+focus_follows_mouse yes
+focus_on_window_activation smart
+mouse_warping output
+workspace_layout default
+
+client.focused #4c7899 #285577 #ffffff #2e9ef4 #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50 #5f676a
+client.unfocused #333333 #222222 #888888 #292d2e #222222
+client.urgent #2f343a #900000 #ffffff #900000 #900000
+client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
+client.background #ffffff
+
+bindsym Mod1+1 workspace 1
+bindsym Mod1+2 workspace 2
+bindsym Mod1+3 workspace 3
+bindsym Mod1+4 workspace 4
+bindsym Mod1+5 workspace 5
+bindsym Mod1+6 workspace 6
+bindsym Mod1+7 workspace 7
+bindsym Mod1+8 workspace 8
+bindsym Mod1+9 workspace 9
+bindsym Mod1+Down focus down
+bindsym Mod1+Invented invented-key-command
+bindsym Mod1+Left overridden-command
+bindsym Mod1+Return exec i3-sensible-terminal
+
+bindsym Mod1+Shift+1 move container to workspace 1
+bindsym Mod1+Shift+2 move container to workspace 2
+bindsym Mod1+Shift+3 move container to workspace 3
+bindsym Mod1+Shift+4 move container to workspace 4
+bindsym Mod1+Shift+5 move container to workspace 5
+bindsym Mod1+Shift+6 move container to workspace 6
+bindsym Mod1+Shift+7 move container to workspace 7
+bindsym Mod1+Shift+8 move container to workspace 8
+bindsym Mod1+Shift+9 move container to workspace 9
+bindsym Mod1+Shift+Down move down
+bindsym Mod1+Shift+Left move left
+bindsym Mod1+Shift+Right move right
+bindsym Mod1+Shift+Up move up
+bindsym Mod1+Shift+c reload
+bindsym Mod1+Shift+e exec i3-nagbar -t warning -m 'Do you want to exit i3?' -b 'Yes' 'i3-msg exit'
+bindsym Mod1+Shift+q kill
+bindsym Mod1+Shift+r restart
+bindsym Mod1+Shift+space floating toggle
+bindsym Mod1+Up focus up
+bindsym Mod1+d exec @dmenu@/bin/dmenu_run
+bindsym Mod1+e layout toggle split
+bindsym Mod1+f fullscreen toggle
+bindsym Mod1+h split h
+bindsym Mod1+r mode resize
+bindsym Mod1+s layout stacking
+bindsym Mod1+space focus mode_toggle
+bindsym Mod1+v split v
+bindsym Mod1+w layout tabbed
+
+mode "resize" {
+bindsym Down resize grow height 10 px or 10 ppt
+bindsym Escape mode default
+bindsym Left resize shrink width 10 px or 10 ppt
+bindsym Return mode default
+bindsym Right resize grow width 10 px or 10 ppt
+bindsym Up resize shrink height 10 px or 10 ppt
+}
+
+
+bar {
+  
+  font pango:monospace 8
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  i3bar_command @i3@/bin/i3bar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output primary
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+  
+}
+
+
+
+
+
+

--- a/tests/modules/services/window-managers/i3-keybindings.nix
+++ b/tests/modules/services/window-managers/i3-keybindings.nix
@@ -18,17 +18,26 @@ with lib;
           };
     };
 
+    nixpkgs.overlays = [
+      (self: super: {
+        dmenu = super.dmenu // {
+          outPath = "@dmenu@";
+        };
+
+        i3 = super.i3 // {
+          outPath = "@i3@";
+        };
+
+        i3status = super.i3status // {
+          outPath = "@i3status@";
+        };
+      })
+    ];
+
     nmt.script = ''
       assertFileExists home-files/.config/i3/config
-
-      assertFileRegex home-files/.config/i3/config \
-        'bindsym Mod1+Left overridden-command'
-
-      assertFileNotRegex home-files/.config/i3/config \
-        'Mod1+Right'
-
-      assertFileRegex home-files/.config/i3/config \
-        'bindsym Mod1+Invented invented-key-command'
+      assertFileContent home-files/.config/i3/config \
+        ${./i3-keybindings-expected.conf}
     '';
   };
 }


### PR DESCRIPTION
This replaces some derivation outputs by simple strings rather than full Nix store paths. This removes the need to download the whole derivation when all we need is a static string.