### PR TITLE
Create spotifyd user service

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -130,6 +130,7 @@ let
     (loadModule ./services/screen-locker.nix { })
     (loadModule ./services/stalonetray.nix { })
     (loadModule ./services/status-notifier-watcher.nix { })
+    (loadModule ./services/spotifyd.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/sxhkd.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/syncthing.nix { })
     (loadModule ./services/taffybar.nix { })

--- a/modules/services/spotifyd.nix
+++ b/modules/services/spotifyd.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.spotifyd;
+
+  configFile = pkgs.writeText "spotifyd.conf" ''
+    ${generators.toINI {} cfg.settings}
+  '';
+in {
+  options.services.spotifyd = {
+    enable = mkEnableOption "SpotifyD connect";
+
+    settings = mkOption {
+      type = types.attrsOf (types.attrsOf types.str);
+      default = {};
+      description = "Configuration for spotifyd";
+      example = literalExample ''
+        {
+          global = {
+            user = "Alex";
+            password = "foo";
+            device_name = "nix";
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.spotifyd ];
+
+    systemd.user.services.spotifyd = {
+      Unit = {
+        Description = "spotify daemon";
+        Documentation = "https://github.com/Spotifyd/spotifyd";
+      };
+
+      Install.WantedBy = [ "default.target" ];
+
+      Service = {
+        ExecStart = "${pkgs.spotifyd}/bin/spotifyd --no-daemon --config ${configFile}";
+        Restart = "always";
+        RestartSec = 12;
+      };
+    };
+  };
+} 


### PR DESCRIPTION
Create a SpotifyD user service.

There is already a spotifyd service in nixpkgs, but this one is a system-wide service, and I wanted to have a user service, so different users can use different accounts.