### PR TITLE
getmail: add port option

### DIFF
--- a/modules/programs/getmail.nix
+++ b/modules/programs/getmail.nix
@@ -31,6 +31,7 @@ let
       [retriever]
       type = ${retrieverType}
       server = ${imap.host}
+      ${optionalString (imap.port != null) "port = ${imap.port}"}
       username = ${userName}
       password_command = (${passCmd})
       mailboxes = ( ${renderedMailboxes} )

--- a/tests/modules/programs/getmail-expected.conf
+++ b/tests/modules/programs/getmail-expected.conf
@@ -2,6 +2,7 @@
 [retriever]
 type = SimpleIMAPSSLRetriever
 server = imap.example.com
+
 username = home.manager
 password_command = ('password-command')
 mailboxes = ( 'INBOX', 'Sent', 'Work' )


### PR DESCRIPTION
Fixed bug where "accounts.email.accounts.\<name\>.imap.port" option was being ignored in getmail.

Note: I'm new to Nix language.