### PR TITLE
getmail: fix port option type mismatch

### DIFF
--- a/modules/programs/getmail.nix
+++ b/modules/programs/getmail.nix
@@ -31,7 +31,7 @@ let
       [retriever]
       type = ${retrieverType}
       server = ${imap.host}
-      ${optionalString (imap.port != null) "port = ${imap.port}"}
+      ${optionalString (imap.port != null) "port = ${toString imap.port}"}
       username = ${userName}
       password_command = (${passCmd})
       mailboxes = ( ${renderedMailboxes} )

--- a/tests/modules/programs/getmail-expected.conf
+++ b/tests/modules/programs/getmail-expected.conf
@@ -2,7 +2,7 @@
 [retriever]
 type = SimpleIMAPSSLRetriever
 server = imap.example.com
-
+port = 993
 username = home.manager
 password_command = ('password-command')
 mailboxes = ( 'INBOX', 'Sent', 'Work' )

--- a/tests/modules/programs/getmail.nix
+++ b/tests/modules/programs/getmail.nix
@@ -10,11 +10,14 @@ with lib;
     home.homeDirectory = "/home/hm-user";
 
     accounts.email.accounts = {
-      "hm@example.com".getmail = {
-        enable = true;
-        mailboxes = ["INBOX" "Sent" "Work"];
-        destinationCommand = "/bin/maildrop";
-        delete = false;
+      "hm@example.com" = {
+        getmail = {
+          enable = true;
+          mailboxes = ["INBOX" "Sent" "Work"];
+          destinationCommand = "/bin/maildrop";
+          delete = false;
+        };
+        imap.port = 993;
       };
     };
 


### PR DESCRIPTION
Fixed type mismatch in commit 410f5732267d48d78ff0a1e6f38f512c4aea4808.
Added test case to ensure it works well.

Sorry for inconvenience caused :cry: