### PR TITLE
zsh: fix history.path issues

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1207,6 +1207,21 @@ in
           A new module is available: 'programs.rtorrent'.
         '';
       }
+
+      {
+        time = "2019-10-28T14:41:48+00:00";
+        condition = config.programs.zsh.enable;
+        message = ''
+          The 'programs.zsh.history.path' option behavior and default
+          value has changed for state version 20.03 and above.
+
+          Specifically, '$HOME' will no longer be prepended to the
+          option value, which allows specifying absolute paths (e.g.
+          using the xdg module). Also, the default value is fixed to
+          '$HOME/.zsh_history' and 'dotDir' path is not prepended to
+          it anymore.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -26,6 +26,8 @@ let
     vicmd = "bindkey -a";
   };
 
+  stateVersion = config.home.stateVersion;
+
   historyModule = types.submodule ({ config, ... }: {
     options = {
       size = mkOption {
@@ -43,8 +45,10 @@ let
 
       path = mkOption {
         type = types.str;
-        default = relToDotDir ".zsh_history";
-        defaultText = ".zsh_history";
+        default = if versionAtLeast stateVersion "20.03"
+          then "$HOME/.zsh_history"
+          else relToDotDir ".zsh_history";
+        example = literalExample ''"''${config.xdg.dataHome}/zsh/zsh_history"'';
         description = "History file location";
       };
 
@@ -402,8 +406,11 @@ in
         # History options should be set in .zshrc and after oh-my-zsh sourcing.
         # See https://github.com/rycee/home-manager/issues/177.
         HISTSIZE="${toString cfg.history.size}"
-        HISTFILE="$HOME/${cfg.history.path}"
         SAVEHIST="${toString cfg.history.save}"
+        ${if versionAtLeast config.home.stateVersion "20.03"
+          then ''HISTFILE="${cfg.history.path}"''
+          else ''HISTFILE="$HOME/${cfg.history.path}"''}
+        mkdir -p "$(dirname "$HISTFILE")"
 
         setopt HIST_FCNTL_LOCK
         ${if cfg.history.ignoreDups then "setopt" else "unsetopt"} HIST_IGNORE_DUPS

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -1,3 +1,7 @@
 {
   zsh-session-variables = ./session-variables.nix;
+  zsh-history-path-new-default = ./history-path-new-default.nix;
+  zsh-history-path-new-custom = ./history-path-new-custom.nix;
+  zsh-history-path-old-default = ./history-path-old-default.nix;
+  zsh-history-path-old-custom = ./history-path-old-custom.nix;
 }

--- a/tests/modules/programs/zsh/history-path-new-custom.nix
+++ b/tests/modules/programs/zsh/history-path-new-custom.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "20.03";
+    programs.zsh = {
+      enable = true;
+      history.path = "$HOME/some/directory/zsh_history";
+    };
+
+    nmt.script = ''
+      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/some/directory/zsh_history"$'
+    '';
+  };
+}

--- a/tests/modules/programs/zsh/history-path-new-default.nix
+++ b/tests/modules/programs/zsh/history-path-new-default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "20.03";
+    programs.zsh.enable = true;
+
+    nmt.script = ''
+      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/.zsh_history"$'
+    '';
+  };
+}

--- a/tests/modules/programs/zsh/history-path-old-custom.nix
+++ b/tests/modules/programs/zsh/history-path-old-custom.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "19.09";
+    programs.zsh = {
+      enable = true;
+      history.path = "some/directory/zsh_history";
+    };
+
+    nmt.script = ''
+      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/some/directory/zsh_history"$'
+    '';
+  };
+}

--- a/tests/modules/programs/zsh/history-path-old-default.nix
+++ b/tests/modules/programs/zsh/history-path-old-default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "19.03";
+    programs.zsh.enable = true;
+
+    nmt.script = ''
+      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/.zsh_history"$'
+    '';
+  };
+}


### PR DESCRIPTION
- Default value is set to static '$HOME/.zsh_history' -- dotDir is not
prepended anymore
- $HOME is not prepended to the option value
- Ensure history path directory exists

Fixes #886, replaces #427.