### PR TITLE
khal, vdirsyncer: add and fix options (lost #775 rebased on top of current branch and extended)

### DIFF
--- a/modules/programs/khal-calendar-accounts.nix
+++ b/modules/programs/khal-calendar-accounts.nix
@@ -20,5 +20,26 @@ with lib;
         type is set to discover.
       '';
     };
+
+    color = mkOption {
+      type = types.nullOr (types.enum [
+        "black" "white" "brown" "yellow" "dark gray" "dark green" "dark blue"
+        "light gray" "light green" "light blue" "dark magenta" "dark cyan"
+        "dark red" "light magenta" "light cyan" "light red"
+      ]);
+      default = null;
+      description = ''
+        Color in which events in this calendar are displayed.
+      '';
+      example = "light green";
+    };
+
+    priority = mkOption {
+      type = types.int;
+      default = 10;
+      description = ''
+        Priority of a calendar used for coloring.
+      '';
+    };
   };
 }

--- a/modules/programs/khal.nix
+++ b/modules/programs/khal.nix
@@ -20,9 +20,10 @@ let
     findSingle (a: a.primary) null null
     (mapAttrsToList (n: v: v // {name= n;}) khalAccounts);
 
-  toKeyValueListIfDefined = attrs:
-    mapAttrsToList (n: v: "${n} = ${toString v}")
-      (filterAttrs (_: v: !isNull v) attrs);
+  definedAttrs = filterAttrs (_: v: !isNull v);
+
+  toKeyValueIfDefined = attrs:
+    generators.toKeyValue {} (definedAttrs attrs);
 
   genCalendarStr = name: value:
     concatStringsSep "\n" (
@@ -31,15 +32,123 @@ let
         "path = ${value.local.path + "/" + (optionalString (value.khal.type == "discover") value.khal.glob)}"
       ]
       ++ optional (value.khal.readOnly) "readonly = True"
-      ++ toKeyValueListIfDefined (getAttrs [ "type" "color" "priority" ] value.khal)
+      ++ [ (toKeyValueIfDefined (getAttrs [ "type" "color" "priority" ] value.khal)) ]
       ++ ["\n"]
     );
+
+  localeFormatOptions = let T = lib.types; in mapAttrs (n: v: v // {
+    description = v.description + ''
+
+      Format strings are for python 'strftime', similarly to man 3 strftime.
+    '';
+  }) {
+    dateformat = {
+      type = T.str;
+      default = "%x";
+      description = ''
+        khal will display and understand all dates in this format.
+      '';
+    };
+
+    timeformat = {
+      type = T.str;
+      default = "%X";
+      description = ''
+        khal will display and understand all times in this format.
+      '';
+    };
+
+    datetimeformat = {
+      type = T.str;
+      default = "%c";
+      description = ''
+        khal will display and understand all datetimes in this format.
+      '';
+    };
+
+    longdateformat = {
+      type = T.str;
+      default = "%x";
+      description = ''
+        khal will display and understand all dates in this format.
+        It should contain a year (e.g. %Y).
+      '';
+    };
+
+    longdatetimeformat = {
+      type = T.str;
+      default = "%c";
+      description = ''
+        khal will display and understand all datetimes in this format.
+        It should contain a year (e.g. %Y).
+      '';
+    };
+  };
+
+
+  localeOptions = let T = lib.types; in localeFormatOptions // {
+    unicode_symbols = {
+      type = T.bool;
+      default = true;
+      description = ''
+        By default khal uses some unicode symbols (as in ‘non-ascii’) as
+        indicators for things like repeating events.
+        If your font, encoding etc. does not support those symbols, set this
+        to false (this will enable ascii based replacements).
+      '';
+    };
+
+    default_timezone = {
+      type = T.nullOr T.str;
+      default = null;
+      description = ''
+        Default for new events or if khal does not understand the timezone
+        in an ical file.
+        If 'null', the timezone of your computer will be used.
+      '';
+    };
+
+    local_timezone = {
+      type = T.nullOr T.str;
+      default = null;
+      description = ''
+        khal will show all times in this timezone.
+        If 'null', the timezone of your computer will be used.
+      '';
+    };
+
+    firstweekday = {
+      type = T.ints.between 0 6;
+      default = 0;
+      description = ''
+        the first day of the week, where Monday is 0 and Sunday is 6
+      '';
+    };
+
+    weeknumbers = {
+      type = T.enum [ "off" "left" "right" ];
+      default = "off";
+      description = ''
+        Enable weeknumbers in calendar and interactive (ikhal) mode.
+        As those are iso weeknumbers, they only work properly if firstweekday
+        is set to 0.
+      '';
+    };
+  };
 
 in
 
 {
   options.programs.khal = {
     enable = mkEnableOption "khal, a CLI calendar application";
+    locale = mkOption {
+      type = lib.types.submodule {
+        options = mapAttrs (n: v: mkOption v) localeOptions;
+      };
+      description = ''
+        khal locale settings. 
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -53,16 +162,10 @@ in
       ++
       [
         (generators.toINI {} {
+          locale = definedAttrs (cfg.locale // { _module = null; });
+
           default = optionalAttrs (!isNull primaryAccount) {
             default_calendar = if isNull primaryAccount.primaryCollection then primaryAccount.name else primaryAccount.primaryCollection;
-          };
-          locale = {
-            timeformat = "%H:%M";
-            dateformat = "%Y-%m-%d";
-            longdateformat = "%Y-%m-%d";
-            datetimeformat = "%Y-%m-%d %H:%M";
-            longdatetimeformat = "%Y-%m-%d %H:%M";
-            weeknumbers = "right";
           };
         })
       ]

--- a/modules/programs/khal.nix
+++ b/modules/programs/khal.nix
@@ -20,6 +20,10 @@ let
     findSingle (a: a.primary) null null
     (mapAttrsToList (n: v: v // {name= n;}) khalAccounts);
 
+  toKeyValueListIfDefined = attrs:
+    mapAttrsToList (n: v: "${n} = ${toString v}")
+      (filterAttrs (_: v: !isNull v) attrs);
+
   genCalendarStr = name: value:
     concatStringsSep "\n" (
       [
@@ -27,7 +31,7 @@ let
         "path = ${value.local.path + "/" + (optionalString (value.khal.type == "discover") value.khal.glob)}"
       ]
       ++ optional (value.khal.readOnly) "readonly = True"
-      ++ optional (!isNull value.khal.type) "type = ${value.khal.type}"
+      ++ toKeyValueListIfDefined (getAttrs [ "type" "color" "priority" ] value.khal)
       ++ ["\n"]
     );
 
@@ -52,7 +56,6 @@ in
           default = optionalAttrs (!isNull primaryAccount) {
             default_calendar = if isNull primaryAccount.primaryCollection then primaryAccount.name else primaryAccount.primaryCollection;
           };
-
           locale = {
             timeformat = "%H:%M";
             dateformat = "%Y-%m-%d";

--- a/modules/programs/vdirsyncer.nix
+++ b/modules/programs/vdirsyncer.nix
@@ -36,7 +36,8 @@ let
   ((getAttrs [
     "type"
     "url"
-    "userNameCommand"
+    "userName"
+    #"userNameCommand"
     "passwordCommand"
   ] a.remote) //
   (if a.vdirsyncer == null


### PR DESCRIPTION
* khal: add option `locale`

Plus same changes as in #775 which got lost, probably when 8450842e4957915243decef882f3cece2b54463d was force-pushed, now manually rebased on top of the latter:

* vdirsyncer: fix options `userName`, `userNameCommand`
* khal: add khal-account options `color` and `priority`