### PR TITLE
emacs: Don't use emacsPackagesNg

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -12,7 +12,7 @@ let
   # overrides.
   emacsPackages =
     let
-      epkgs = pkgs.emacsPackagesNgGen cfg.package;
+      epkgs = pkgs.emacsPackagesGen cfg.package;
     in
       epkgs.overrideScope' cfg.overrides;
   emacsWithPackages = emacsPackages.emacsWithPackages;
@@ -42,7 +42,7 @@ in
         description = ''
           Extra packages available to Emacs. To get a list of
           available packages run:
-          <command>nix-env -f '&lt;nixpkgs&gt;' -qaP -A emacsPackagesNg</command>.
+          <command>nix-env -f '&lt;nixpkgs&gt;' -qaP -A emacsPackages</command>.
         '';
       };
 


### PR DESCRIPTION
It's deprecated and since Nixos 19.09 it's an alias to `emacsPackages`.
This fixes using home-manager with the [emacs overlay](https://github.com/nix-community/emacs-overlay).

Note: This will break for users on 19.03.