### PR TITLE
vscode:corrected the base path from which to pull the extensions

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -71,7 +71,7 @@ in
     # Adapted from https://discourse.nixos.org/t/vscode-extensions-setup/1801/2
     home.file =
       let
-        toPaths = p:
+        toPaths = path: let p ="${path}/share/vscode/extensions";in
           # Links every dir in p to the extension path.
           mapAttrsToList (k: v:
             {


### PR DESCRIPTION
Should fix https://github.com/rycee/home-manager/issues/888 