### PR TITLE
xdg-mime: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1268,6 +1268,18 @@ in
           A new module is available: 'services.unison'.
         '';
       }
+
+      {
+        time = "2019-12-01T21:34:03+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'xdg.mime'.
+
+          If enabled, which it is by default, this module will
+          create the XDG mime database and desktop file database
+          caches from programs installed via Home Manager.
+        '';
+      }
     ];
   };
 }

--- a/modules/misc/xdg-mime.nix
+++ b/modules/misc/xdg-mime.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.xdg.mime;
+
+in
+
+{
+  options = {
+    xdg.mime.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install programs and files to support the
+        XDG Shared MIME-info specification and XDG MIME Applications
+        specification at
+        <link xlink:href="https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html"/>
+        and
+        <link xlink:href="https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html"/>,
+        respectively.
+      '';
+    };
+  };
+
+  config = mkIf config.xdg.mime.enable {
+    home.packages = [
+      # explicitly install package to provide basic mimetypes
+      pkgs.shared-mime-info
+    ];
+
+    home.extraProfileCommands = ''
+      if [[ -w $out/share/mime && -d $out/share/mime/packages ]]; then
+          XDG_DATA_DIRS=$out/share \
+          PKGSYSTEM_ENABLE_FSYNC=0 \
+          ${pkgs.buildPackages.shared-mime-info}/bin/update-mime-database \
+            -V $out/share/mime > /dev/null
+      fi
+
+      if [[ -w $out/share/applications ]]; then
+          ${pkgs.buildPackages.desktop-file-utils}/bin/update-desktop-database \
+            $out/share/applications
+      fi
+    '';
+  };
+
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -33,6 +33,7 @@ let
     (loadModule ./misc/qt.nix { })
     (loadModule ./misc/submodule-support.nix { })
     (loadModule ./misc/version.nix { })
+    (loadModule ./misc/xdg-mime.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime-apps.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-user-dirs.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg.nix { })


### PR DESCRIPTION
This is a direct translation of the [NixOS module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/xdg/mime.nix).

If enabled, this module will create the XDG mime database 
and desktop file database caches from programs installed  
via home-manager. The 'XDG_DATA_DIRS' environment variable
is extended so that programs like 'xdg-open' can find and 
make use of these databases.

Not sure if it makes sense to add a test here; the files are auto-generated, big, and one of them even uses a binary format.