### PR TITLE
Revert "astroid: require notmuch synchronize flags"

### DIFF
--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -106,14 +106,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = config.programs.notmuch.maildir.synchronizeFlags;
-        message = "The astroid module requires"
-          + " 'programs.notmuch.maildir.synchronizeFlags = true'.";
-      }
-    ];
-
     home.packages =  [ pkgs.astroid ];
 
     xdg.configFile."astroid/config".source =


### PR DESCRIPTION
The Astroid program can work without this option,
which should be disabled when synchronising emails with muchsync for example.

This reverts commit fa3d1f98e001eab0e0514414a6429e082962915a.