### PR TITLE
astroid: fix maildir folder paths

### DIFF
--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -20,9 +20,9 @@ let
     sendmail = astroid.sendMailCommand;
     additional_sent_tags = "";
     default = boolOpt primary;
-    save_drafts_to = folders.drafts;
+    save_drafts_to = "${maildir.absPath}/${folders.drafts}";
     save_sent = "true";
-    save_sent_to = folders.sent;
+    save_sent_to = "${maildir.absPath}/${folders.sent}";
     select_query = "";
   }
   // optionalAttrs (signature.showSignature != "none") {


### PR DESCRIPTION
Using the absolute path of maildir folders is required for Astroid to save
messages in those.