### PR TITLE
lorri: add service

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -115,6 +115,7 @@ let
     (loadModule ./services/kdeconnect.nix { })
     (loadModule ./services/keepassx.nix { })
     (loadModule ./services/keybase.nix { })
+    (loadModule ./services/lorri.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/mbsync.nix { })
     (loadModule ./services/mpd.nix { })
     (loadModule ./services/mpdris2.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.lorri;
+in
+
+{
+  meta.maintainers = [ maintainers.gerschtli ];
+
+  options = {
+    services.lorri.enable = mkEnableOption "lorri build daemon";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.lorri ];
+
+    systemd.user = {
+      services.lorri = {
+        Unit = {
+          Description = "lorri build daemon";
+          Requires = "lorri.socket";
+          After = "lorri.socket";
+        };
+
+        Service = {
+          ExecStart = "${pkgs.lorri}/bin/lorri daemon";
+          PrivateTmp = true;
+          ProtectSystem = "strict";
+          ProtectHome = "read-only";
+          Restart = "on-failure";
+          Environment =
+            let path = with pkgs; makeSearchPath "bin" [ nix gnutar gzip ];
+            in "PATH=${path}";
+        };
+      };
+
+      sockets.lorri = {
+        Unit = {
+          Description = "Socket for lorri build daemon";
+        };
+
+        Socket = {
+          ListenStream = "%t/lorri/daemon.socket";
+          RuntimeDirectory = "lorri";
+        };
+
+        Install = {
+          WantedBy = [ "sockets.target" ];
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Hey, this PR adds a systemd user service for lorri and installs it as package.

Service definition originates from https://github.com/NixOS/nixpkgs/blob/release-19.09/nixos/modules/services/development/lorri.nix.

To fully support non NixOS systems, https://github.com/rycee/home-manager/pull/797 needs to merged.