### PR TITLE
Fix issue when `/nix/store` is symlinked

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -244,7 +244,11 @@ in
 
           # Figure out the real absolute path to the target.
           local target
-          target="$(realpath -m "$out/$relTarget")"
+          maybe_path="$(realpath -m "$out/$relTarget")"
+          
+          # Strip the leading /usr/local off if it exists. 
+          target=''${maybe_path#/usr/local}
+          
 
           # Target path must be within $HOME.
           if [[ ! $target == $out* ]] ; then


### PR DESCRIPTION
I'm running OSX Catalina which doesn't allow the nix store to be on the root volume anymore. Therefore, the new nix installer creates a symlink for `/nix` -> `/usr/local/nix`

This causes a bug since `realpath` thinks files like .bashrc which should be in the nix-store are somewhere else when running the `insertFile()` method

Not sure if this is a good fix (I haven't thought too much about how this might affect other uses of this function) but this works for me.  