### PR TITLE
Fix mpdris2 service so it may start automatically

### DIFF
--- a/modules/services/mpdris2.nix
+++ b/modules/services/mpdris2.nix
@@ -86,6 +86,10 @@ in
     xdg.configFile."mpDris2/mpDris2.conf".text = toIni mpdris2Conf;
 
     systemd.user.services.mpdris2 = {
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+
       Unit = {
         Description = "MPRIS 2 support for MPD";
         After = [ "graphical-session-pre.target" "mpd.service" ];

--- a/modules/services/mpdris2.nix
+++ b/modules/services/mpdris2.nix
@@ -100,6 +100,7 @@ in
         Restart = "on-failure";
         RestartSec = "5s";
         ExecStart = "${cfg.package}/bin/mpDris2";
+        BusName = "org.mpris.MediaPlayer2.mpd";
       };
     };
   };

--- a/modules/services/mpdris2.nix
+++ b/modules/services/mpdris2.nix
@@ -92,12 +92,13 @@ in
 
       Unit = {
         Description = "MPRIS 2 support for MPD";
-        After = [ "graphical-session-pre.target" "mpd.service" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ "mpd.service" ];
       };
 
       Service = {
         Type = "simple";
+        Restart = "on-failure";
+        RestartSec = "5s";
         ExecStart = "${cfg.package}/bin/mpDris2";
       };
     };


### PR DESCRIPTION
The mpdris2 service doesn't currently seem to start, as it isn't WantedBy anything.

This PR fixes said issue.