### PR TITLE
emacs: add emacsclient desktop file

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1245,6 +1245,16 @@ in
           A new module is available: 'services.spotifyd'.
         '';
       }
+
+      {
+        time = "2019-11-25T13:25:33+00:00";
+        message = ''
+          A new option in the 'emacs' module is available : 'programs.emacs.client'.
+
+          It can be used to enable a desktop file for the Emacs client.
+        '';
+      }
+
     ];
   };
 }

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -57,7 +57,9 @@ in
         args = mkOption {
           type = with types; listOf str;
           default = [ "-c" ];
-          description = "Command-line arguments to pass to emacsclient.";
+          description = ''
+            Command-line arguments to pass to <command>emacsclient</command>.
+          '';
         };
       };
 

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -112,7 +112,7 @@ in
   config = mkIf cfg.enable {
     home.packages =
       [ cfg.finalPackage ]
-      ++ (lib.optional cfg.client.enable clientDesktopFile);
+      ++ lib.optional cfg.client.enable clientDesktopFile;
     programs.emacs.finalPackage = emacsWithPackages cfg.extraPackages;
   };
 }

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -57,7 +57,6 @@ in
         args = mkOption {
           type = with types; listOf str;
           default = [ "-c" ];
-          example = literalExample [ "-c" ];
           description = "Command-line arguments to pass to emacsclient.";
         };
       };


### PR DESCRIPTION
Add an option to enable a .desktop file for the Emacs client.

- I didn't use the `isLinux` check as `emacsclient` can be used remotely
- I'm not sure if this should be added to `programs.emacs.client` or if I should create an independent `programs.emacsclient`. If needed I can update the PR to the latter.
- Actually, I'm not sure if this PR  should be accepted, or if it's better to let the users create such desktop file themselves.