### PR TITLE
vscode: don't create an empty settings.json

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -85,7 +85,10 @@ in
         foldr
           (a: b: a // b)
           {
-            "${configFilePath}".text = builtins.toJSON cfg.userSettings;
+            "${configFilePath}" =
+              mkIf (cfg.userSettings != {}) {
+                text = builtins.toJSON cfg.userSettings;
+              };
           }
           toSymlink;
   };


### PR DESCRIPTION
If I enable this module without using the userSettings option it will
create an empty settings.json. We use mkIf to prevent this on the default
value.