### PR TITLE
parcellite: fix GTK theme

### DIFF
--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -33,12 +33,6 @@ in
       };
 
       Service = {
-        # PATH have been added in nixpkgs.parcellite, keeping it here for
-        # backward compatibility. XDG_DATA_DIRS is necessary to make it pick up
-        # icons correctly.
-        Environment = ''
-          PATH=${package}/bin:${pkgs.which}/bin:${pkgs.xdotool}/bin XDG_DATA_DIRS=${pkgs.hicolor_icon_theme}/share
-        '';
         ExecStart = "${package}/bin/parcellite";
         Restart = "on-abort";
       };


### PR DESCRIPTION
The `gtk.theme` option is not picked up due to hardcoded `XDG_DATA_DIRS`.

Since icons do show up without this environment variable in the service unit I don't think it is necessary (anymore). According to the `basic` test we [hope `XDG_DATA_DIRS` is set](https://github.com/rycee/home-manager/blob/master/tests/modules/misc/xsession/basic-xprofile-expected.txt#L12) anyway.

cc @gleber 