### PR TITLE
tmux: reorder tmux.conf -> put `extraConfig` in the end

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -31,6 +31,13 @@ let
   boolToStr = value: if value then "on" else "off";
 
   tmuxConf = ''
+    ${optionalString cfg.sensibleOnTop ''
+      # ============================================= #
+      # Start with defaults from the Sensible plugin  #
+      # --------------------------------------------- #
+      run-shell ${pkgs.tmuxPlugins.sensible.rtp}
+      # ============================================= #
+    ''}
     set  -g default-terminal "${cfg.terminal}"
     set  -g base-index      ${toString cfg.baseIndex}
     setw -g pane-base-index ${toString cfg.baseIndex}
@@ -76,6 +83,38 @@ let
     set  -g history-limit     ${toString cfg.historyLimit}
   '';
 
+  configPlugins = {
+    assertions = [(
+      let
+        hasBadPluginName = p: !(hasPrefix "tmuxplugin" (pluginName p));
+        badPlugins = filter hasBadPluginName cfg.plugins;
+      in
+        {
+          assertion = badPlugins == [];
+          message =
+            "Invalid tmux plugin (not prefixed with \"tmuxplugins\"): "
+            + concatMapStringsSep ", " pluginName badPlugins;
+        }
+    )];
+
+    home.file.".tmux.conf".text = ''
+      # ============================================= #
+      # Load plugins with Home Manager                #
+      # --------------------------------------------- #
+
+      ${(concatMapStringsSep "\n\n" (p: ''
+          # ${pluginName p}
+          # ---------------------
+          ${p.extraConfig or ""}
+          run-shell ${
+            if types.package.check p
+            then p.rtp
+            else p.plugin.rtp
+          }
+      '') cfg.plugins)}
+      # ============================================= #
+    '';
+  };
 in
 
 {
@@ -256,65 +295,22 @@ in
   };
 
   config = mkIf cfg.enable (
-    mkMerge [
+    mkMerge ([
       {
         home.packages = [ cfg.package ]
           ++ optional cfg.tmuxinator.enable pkgs.tmuxinator
           ++ optional cfg.tmuxp.enable      pkgs.tmuxp;
-
-        home.file.".tmux.conf".text = tmuxConf;
       }
-
-      (mkIf cfg.sensibleOnTop {
-        home.file.".tmux.conf".text = mkBefore ''
-          # ============================================= #
-          # Start with defaults from the Sensible plugin  #
-          # --------------------------------------------- #
-          run-shell ${pkgs.tmuxPlugins.sensible.rtp}
-          # ============================================= #
-        '';
-      })
-
       (mkIf cfg.secureSocket {
         home.sessionVariables = {
           TMUX_TMPDIR = ''''${XDG_RUNTIME_DIR:-"/run/user/\$(id -u)"}'';
         };
       })
 
-      (mkIf (cfg.plugins != []) {
-        assertions = [(
-          let
-            hasBadPluginName = p: !(hasPrefix "tmuxplugin" (pluginName p));
-            badPlugins = filter hasBadPluginName cfg.plugins;
-          in
-            {
-              assertion = badPlugins == [];
-              message =
-                "Invalid tmux plugin (not prefixed with \"tmuxplugins\"): "
-                + concatMapStringsSep ", " pluginName badPlugins;
-            }
-        )];
-
-        home.file.".tmux.conf".text = mkAfter ''
-          # ============================================= #
-          # Load plugins with Home Manager                #
-          # --------------------------------------------- #
-
-          ${(concatMapStringsSep "\n\n" (p: ''
-              # ${pluginName p}
-              # ---------------------
-              ${p.extraConfig or ""}
-              run-shell ${
-                if types.package.check p
-                then p.rtp
-                else p.plugin.rtp
-              }
-          '') cfg.plugins)}
-          # ============================================= #
-        '';
-      })
-
-      { home.file.".tmux.conf".text = mkOrder 1600 cfg.extraConfig; }
-    ]
+      # config file ~/.tmux.conf
+      { home.file.".tmux.conf".text = mkBefore tmuxConf; }
+      (mkIf (cfg.plugins != []) configPlugins)
+      { home.file.".tmux.conf".text = mkAfter cfg.extraConfig; }
+    ])
   );
 }

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -74,8 +74,6 @@ let
     setw -g clock-mode-style  ${if cfg.clock24 then "24" else "12"}
     set  -s escape-time       ${toString cfg.escapeTime}
     set  -g history-limit     ${toString cfg.historyLimit}
-
-    ${cfg.extraConfig}
   '';
 
 in
@@ -315,6 +313,8 @@ in
           # ============================================= #
         '';
       })
+
+      { home.file.".tmux.conf".text = mkOrder 1600 cfg.extraConfig; }
     ]
   );
 }

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.conf
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.conf
@@ -28,4 +28,3 @@ setw -g clock-mode-style  12
 set  -s escape-time       500
 set  -g history-limit     2000
 
-

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -28,8 +28,6 @@ setw -g clock-mode-style  24
 set  -s escape-time       500
 set  -g history-limit     2000
 
-
-
 # ============================================= #
 # Load plugins with Home Manager                #
 # --------------------------------------------- #
@@ -52,3 +50,4 @@ run-shell @tmuxplugin_prefix_highlight_rtp@
 run-shell @tmuxplugin_fzf_tmux_url_rtp@
 
 # ============================================= #
+

--- a/tests/modules/programs/tmux/vi-all-true.conf
+++ b/tests/modules/programs/tmux/vi-all-true.conf
@@ -28,4 +28,3 @@ setw -g clock-mode-style  24
 set  -s escape-time       500
 set  -g history-limit     2000
 
-


### PR DESCRIPTION
This allows overriding of every tmux.conf setting via `extraConfig`, even plugin settings.

See also [#875](https://github.com/rycee/home-manager/pull/875#issuecomment-545555727).