### PR TITLE
systemd: fix degraded warning

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -251,7 +251,7 @@ in
             if [[ $systemdStatus == 'running' || $systemdStatus == 'degraded' ]]; then
               if [[ $systemdStatus == 'degraded' ]]; then
                 warnEcho "The user systemd session is degraded:"
-                systemctl --user --state=failed
+                ${systemctl} --user --state=failed
                 warnEcho "Attempting to reload services anyway..."
               fi
 


### PR DESCRIPTION
The reload can actually fail when trying to warn about degraded units because it was running the `--state=failed` query incorrectly, and then it wouldn't actually reload anything:

```
The user systemd session is degraded:
Failed to connect to bus: No such file or directory
home-manager.service: Main process exited, code=exited, status=1/FAILURE
```