### PR TITLE
blueman: updated advice for removing error message

### DIFF
--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -12,7 +12,7 @@ with lib;
         since it requires running 'blueman-mechanism' service activated via dbus.
         You can add it to the dbus packages in system configuration:
 
-          services.dbus.packages = [ pkgs.blueman ];
+          services.blueman.enable = true;
       '';
     };
   };

--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -8,9 +8,9 @@ with lib;
       enable = mkEnableOption ''
         Blueman applet.
 
-        Note, for the applet to work, 'blueman' package should also be installed system-wide
-        since it requires running 'blueman-mechanism' service activated via dbus.
-        You can add it to the dbus packages in system configuration:
+        Note, for the applet to work, 'blueman' service should be enabled system-wide
+        since it requires running 'blueman-mechanism' service activated.
+        You can enable it in system configuration:
 
           services.blueman.enable = true;
       '';


### PR DESCRIPTION
Older method for hiding the error no longer works in NixOS 19.09, and ends up breaking blueman-applet entirely. Enable the service instead.