### PR TITLE
install: add state version to initial configuration

### DIFF
--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -21,6 +21,16 @@ runCommand
       {
         # Let Home Manager install and manage itself.
         programs.home-manager.enable = true;
+
+        # This value determines the Home Manager release that your
+        # configuration is compatible with. This helps avoid breakage
+        # when a new Home Manager release introduces backwards
+        # incompatible changes.
+        #
+        # You can update Home Manager without changing this value. See
+        # the Home Manager release notes for a list of state version
+        # changes in each release.
+        home.stateVersion = "19.09";
       }
       EOF
       fi


### PR DESCRIPTION
This sets the state version in recent installs to the latest released version. It is beneficial for people to be aware of this option and it is also good to help new users get a more recent setup.