### PR TITLE
Fix option passing

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -93,14 +93,14 @@ function doBuildAttr() {
         nix build \
             -f "<home-manager/home-manager/home-manager.nix>" \
             $extraArgs \
-            ${PASSTHROUGH_OPTS[*]} \
+            "${PASSTHROUGH_OPTS[@]}" \
             --argstr confPath "$HOME_MANAGER_CONFIG" \
             --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"
     else
         nix-build \
             "<home-manager/home-manager/home-manager.nix>" \
             $extraArgs \
-            ${PASSTHROUGH_OPTS[*]} \
+            "${PASSTHROUGH_OPTS[@]}" \
             --argstr confPath "$HOME_MANAGER_CONFIG" \
             --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"
     fi


### PR DESCRIPTION
Currently, home-manager runs into an error when passing empty arguments
like `--option builders ''`. This PR fixes the bug.