### PR TITLE
WIP: grobi: init

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1295,6 +1295,14 @@ in
           A new module is available: 'services.cbatticon'.
         '';
       }
+
+      {
+        time = "2020-01-16T10:02:00+00:00";
+        message = ''
+          A new module is available: 'services.grobi'.
+        '';
+      }
+
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -113,7 +113,7 @@ let
     (loadModule ./services/getmail.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/gnome-keyring.nix { })
     (loadModule ./services/gpg-agent.nix { })
-    (loadModule ./services/grobi.nix { })
+    (loadModule ./services/grobi.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/hound.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/imapnotify.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/kbfs.nix { })

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -113,6 +113,7 @@ let
     (loadModule ./services/getmail.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/gnome-keyring.nix { })
     (loadModule ./services/gpg-agent.nix { })
+    (loadModule ./services/grobi.nix { })
     (loadModule ./services/hound.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/imapnotify.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/kbfs.nix { })

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -1,0 +1,107 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.grobi;
+  eitherStrBoolIntList = with types; either str (either bool (either int (listOf str)));
+
+in
+
+{
+  meta.maintainers = [ maintainers.mbrgm ];
+
+  options = {
+    services.grobi = {
+
+      enable = mkEnableOption "the grobi display setup daemon";
+
+      executeAfter = mkOption {
+        type = with types; listOf str;
+        default = [];
+        description = ''
+          Commands to be run after an output configuration was changed. The Nix
+          value declared here will be translated to JSON and written to the
+          `execute_after` key in ~/.config/grobi.conf.
+        '';
+        example = literalExample ''
+          [ "setxkbmap dvorak" ]
+        '';
+      };
+
+      rules = mkOption {
+        type = with types; listOf (attrsOf eitherStrBoolIntList);
+        default = [];
+        description = ''
+          These are the rules grobi tries to match to the current output
+          configuration. The rules are evaluated top to bottom, the first
+          matching rule is applied and processing stops. See
+          https://github.com/fd0/grobi/blob/master/doc/grobi.conf for more
+          information. The Nix value declared here will be translated to JSON
+          and written to the `rules` key in ~/.config/grobi.conf.
+        '';
+        example = literalExample ''
+          [
+            {
+              name = "Home";
+              outputs_connected = [ "DP-2" ];
+              configure_single = "DP-2";
+              primary = true;
+              atomic = true;
+              execute_after = [
+                "${pkgs.xorg.xrandr}/bin/xrandr --dpi 96"
+                "${pkgs.xmonad-with-packages}/bin/xmonad --restart";
+              ];
+            }
+            {
+              name = "Mobile";
+              outputs_disconnected = [ "DP-2" ];
+              configure_single = "eDP-1";
+              primary = true;
+              atomic = true;
+              execute_after = [
+                "${pkgs.xorg.xrandr}/bin/xrandr --dpi 120"
+                "${pkgs.xmonad-with-packages}/bin/xmonad --restart";
+              ];
+            }
+          ]
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable (
+    mkMerge [
+      {
+        systemd.user.services.grobi = {
+          Unit = {
+            Description = "Automatically configure monitors/outputs for Xorg via RANDR";
+            After = [ "graphical-session-pre.target" ];
+            PartOf = [ "graphical-session.target" ];
+          };
+
+          Service = {
+            Type = "simple";
+            ExecStart = "${pkgs.grobi}/bin/grobi watch -v";
+            Restart = "always";
+            RestartSec = "2s";
+            Environment = "PATH=${pkgs.xorg.xrandr}/bin:${pkgs.bash}/bin";
+          };
+
+          Install = {
+            WantedBy = [ "graphical-session.target" ];
+          };
+        };
+      }
+
+      {
+        xdg.configFile."grobi.conf".text = builtins.toJSON {
+          execute_after = cfg.executeAfter;
+          rules = cfg.rules;
+        };
+      }
+    ]
+  );
+}

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -25,9 +25,7 @@ in
           value declared here will be translated to JSON and written to the
           <option>execute_after</option> key in <filename>~/.config/grobi.conf</filename>.
         '';
-        example = literalExample ''
-          [ "setxkbmap dvorak" ]
-        '';
+        example = [ "setxkbmap dvorak" ];
       };
 
       rules = mkOption {

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -23,7 +23,7 @@ in
         description = ''
           Commands to be run after an output configuration was changed. The Nix
           value declared here will be translated to JSON and written to the
-          `execute_after` key in ~/.config/grobi.conf.
+          <option>execute_after</option> key in <filename>~/.config/grobi.conf</filename>.
         '';
         example = literalExample ''
           [ "setxkbmap dvorak" ]
@@ -37,9 +37,9 @@ in
           These are the rules grobi tries to match to the current output
           configuration. The rules are evaluated top to bottom, the first
           matching rule is applied and processing stops. See
-          https://github.com/fd0/grobi/blob/master/doc/grobi.conf for more
+          <link xlink:href="https://github.com/fd0/grobi/blob/master/doc/grobi.conf"/> for more
           information. The Nix value declared here will be translated to JSON
-          and written to the `rules` key in ~/.config/grobi.conf.
+          and written to the <option>rules</option> key in <filename>~/.config/grobi.conf</filename>.
         '';
         example = literalExample ''
           [


### PR DESCRIPTION
This adds a service module for [grobi](https://github.com/fd0/grobi), which can
be used to automatically configure monitors/outputs for Xorg via RANDR.