### PR TITLE
neovim: un-deprecate the `configure` option

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -148,8 +148,8 @@ in
 
           </para><para>
 
-          This option is deprecated. Please use the options <varname>extraConfig</varname>
-          and <varname>plugins</varname> which are mutually exclusive with this option.
+          This option is mutually exclusive with <varname>extraConfig</varname>
+          and <varname>plugins</varname>.
         '';
       };
 
@@ -192,11 +192,6 @@ in
           + " with extraConfig and plugins.";
       }
     ];
-
-    warnings = optional (cfg.configure != {}) ''
-      The programs.neovim.configure option is deprecated. Please use
-      extraConfig and package option.
-    '';
 
     home.packages = [ cfg.finalPackage ];
 


### PR DESCRIPTION
The `programs.neovim.configure` option is consistent with NixOS's [`wrapNeovim`](https://github.com/NixOS/nixpkgs/blob/bd62dd3bb37a5d9686a92e4be8a36d2e13637b2b/pkgs/applications/editors/neovim/wrapper.nix#L22).

closes #971
closes https://github.com/kalbasit/shabka/issues/286