### PR TITLE
lsd: add shell aliases for fish

### DIFF
--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -37,5 +37,7 @@ in
     programs.bash.shellAliases = mkIf cfg.enableAliases aliases;
 
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
+
+    programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
   };
 }


### PR DESCRIPTION
Introduces a fish (Friendly Interactive SHell) support for the `programs.lsd.enableAliases` option.