### PR TITLE
modules/lorri: remove isLinux condition

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -119,7 +119,7 @@ let
     (loadModule ./services/kdeconnect.nix { })
     (loadModule ./services/keepassx.nix { })
     (loadModule ./services/keybase.nix { })
-    (loadModule ./services/lorri.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./services/lorri.nix { })
     (loadModule ./services/mbsync.nix { })
     (loadModule ./services/mpd.nix { })
     (loadModule ./services/mpdris2.nix { condition = hostPlatform.isLinux; })


### PR DESCRIPTION
Lorri works just fine on macOS, I don't see why keep this condition.