### PR TITLE
modules: pkgs.path instead of <nixpkgs>

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -157,8 +157,8 @@ let
     (loadModule ./xcursor.nix { })
     (loadModule ./xresources.nix { })
     (loadModule ./xsession.nix { })
-    (loadModule <nixpkgs/nixos/modules/misc/assertions.nix> { })
-    (loadModule <nixpkgs/nixos/modules/misc/meta.nix> { })
+    (loadModule (pkgs.path + "/nixos/modules/misc/assertions.nix") { })
+    (loadModule (pkgs.path + "/nixos/modules/misc/meta.nix") { })
   ];
 
   modules = map (getAttr "file") (filter (getAttr "condition") allModules);


### PR DESCRIPTION
I've run into this when trying to use home-manager with an empty `NIX_PATH`, this small change helps with making the evaluation more agnostic to the external environment.