### PR TITLE
nixpkgs: add indirection to _module.args.pkgs

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -142,7 +142,7 @@ in
 
   config = {
     _module.args = {
-      pkgs = _pkgs;
+      pkgs = mkOverride modules.defaultPriority _pkgs;
       pkgs_i686 =
         if _pkgs.stdenv.isLinux && _pkgs.stdenv.hostPlatform.isx86
         then _pkgs.pkgsi686Linux


### PR DESCRIPTION
In combination with the changes from #992, this makes it possible to use home-manager without having `NIX_PATH` set in your environment. This change allows the module system to merge `_module.args.pkgs` without having to actually evaluate `_pkgs`, which:

1. Requires importing from `<nixpkgs>`, and thus requires that the `NIX_PATH` environment variable is set up (in some of my CI and deployment environments it is not, thus my interest in making this change)
2. Evaluates part of nixpkgs even if it ends up being unused and overridden by another part of the config (in my case this PR shaves about a second off of my nixos evaluation time).

A few misc thoughts:

- While `mkDefault` could be used here instead with the same results, that would subtly change the behaviour compared to the current implementation. There's also maybe `mkIf true` to consider, but that feels silly.
- Long-term some sort of solution to #616 should probably be considered, like adopting a `nixpkgs.pkgs` option that behaves in the same way that the nixos one does. Then perhaps also expose a `nixpkgs.path` option that defaults to `<nixpkgs>`.
- `pkgs_i686` could probably be changed to a `mkIf` for similar reasons, though now that `args` is a lazy attrset in nixpkgs it only matters if you use it, and I don't even know what it's for so decided not to touch it.