### PR TITLE
Add link to manual to top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ using the [Nix][] package manager together with the Nix libraries
 found in [Nixpkgs][]. Before attempting to use Home Manager please
 read the warning below.
 
+For a more systematic overview of all the options Home Manager
+provides please see the [Home Manager manual][configuration options].
+
 Words of warning
 ----------------
 


### PR DESCRIPTION
Add a link to the manual to almost the very top of readme.

I was learning to use this for the very first time, and although there is quite a lot of info in the readme, resorted to googling. This googling found the xml's under the `doc/` folder and later I found out that the manual generated is actually linked from the readme itself, just not very prominently. So maybe adding the link to the top would help get newcomers faster on their way.