### PR TITLE
keyboard: make `layout` and `variant` lists

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -107,8 +107,10 @@ in
               with config.home.keyboard;
               let
                 args =
-                  optional (layout != null) "-layout '${layout}'"
-                  ++ optional (variant != null) "-variant '${variant}'"
+                  optional (layouts != []) (let
+                  layouts' = zipAttrsWith (name: values: concatStringsSep "," values) layouts;
+                  in
+                  "-layout '${layouts'.name}' -variant '${layouts'.variant}'")
                   ++ optional (model != null) "-model '${model}'"
                   ++ map (v: "-option '${v}'") options;
               in


### PR DESCRIPTION
This PR allows using lists instead of strings in home.keyboard.layout and home.keyboard.variant.
