### PR TITLE
Enable extension config directory based on vscode version

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -79,7 +79,7 @@ in
       let
         toPaths = path:
           let
-            p = "${path}/share/vscode/extensions";
+            p = "${path}/share/${extensionDir}/extensions";
           in
             # Links every dir in p to the extension path.
             mapAttrsToList (k: v:


### PR DESCRIPTION
This PR try to solve problem when adding extension if vscode is insider/vscodium version. For example I have the following vscode overlay:
```
  vscode = (super.vscode.override { isInsiders = true; }).overrideAttrs (
    _: rec {
      name = "vscode-insiders-${version}";
      version = "1.41.1";
      pname = "vscode-insiders";

      src = super.fetchurl {
        name = "VSCode_latest_linux-x64.tar.gz";
        url = "https://vscode-update.azurewebsites.net/latest/linux-x64/insider";
        sha256 = "010b3c7p4lxk3cbbvxb9q4dqxna8gwmqy5jv8c3w62k4g7x60y3l";
      };
    }
  );
```

Once the insider is set `true` then the config directory become `vscode-insiders`
