### PR TITLE
password-store: Change default PASSWORD_STORE_DIR value

### DIFF
--- a/modules/programs/password-store.nix
+++ b/modules/programs/password-store.nix
@@ -29,10 +29,10 @@ in {
       type = with types; attrsOf str;
       apply = mergeAttrs default;
       default = {
-        PASSWORD_STORE_DIR = "${config.xdg.dataHome}/password-store";
+        PASSWORD_STORE_DIR = "${config.home.homeDirectory}/.password-store";
       };
       defaultText = literalExample ''
-        { PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; }
+        { PASSWORD_STORE_DIR = "$HOME/.password-store"; }
       '';
       example = literalExample ''
         {


### PR DESCRIPTION
The default value of $PASSWORD_STORE_DIR according to the password
store man page is ~/.password-store and a number of other programs
rely on this default value (for instance the mbsync service).