### PR TITLE
lieer: add module

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -384,7 +384,7 @@ in
     };
 
     accounts = mkOption {
-      type = types.attrsOf (types.submodule [
+      type = types.attrsOf (types.submodule ([
         mailAccountOpts
         (import ../programs/alot-accounts.nix pkgs)
         (import ../programs/astroid-accounts.nix)
@@ -395,7 +395,9 @@ in
         (import ../programs/neomutt-accounts.nix)
         (import ../programs/notmuch-accounts.nix)
         (import ../programs/offlineimap-accounts.nix)
-      ]);
+      ] ++ optionals pkgs.stdenv.hostPlatform.isLinux [
+        (import ../services/lieer-accounts.nix)
+      ]));
       default = {};
       description = "List of email accounts.";
     };

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -389,6 +389,7 @@ in
         (import ../programs/alot-accounts.nix pkgs)
         (import ../programs/astroid-accounts.nix)
         (import ../programs/getmail-accounts.nix)
+        (import ../programs/lieer-accounts.nix)
         (import ../programs/mbsync-accounts.nix)
         (import ../programs/msmtp-accounts.nix)
         (import ../programs/neomutt-accounts.nix)

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1340,6 +1340,14 @@ in
           A new module is available: 'programs.lieer'.
         '';
       }
+
+      {
+        time = "2020-02-28T00:05:22+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.lieer'.
+        '';
+      }
     ];
   };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1333,6 +1333,13 @@ in
           A new module is available: 'wayland.windowManager.sway'
         '';
       }
+
+      {
+        time = "2020-02-28T00:05:22+00:00";
+        message = ''
+          A new module is available: 'programs.lieer'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -65,6 +65,7 @@ let
     (loadModule ./programs/htop.nix { })
     (loadModule ./programs/info.nix { })
     (loadModule ./programs/irssi.nix { })
+    (loadModule ./programs/lieer.nix { })
     (loadModule ./programs/jq.nix { })
     (loadModule ./programs/kakoune.nix { })
     (loadModule ./programs/keychain.nix { })

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -123,6 +123,7 @@ let
     (loadModule ./services/kdeconnect.nix { })
     (loadModule ./services/keepassx.nix { })
     (loadModule ./services/keybase.nix { })
+    (loadModule ./services/lieer.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/lorri.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/mbsync.nix { })
     (loadModule ./services/mpd.nix { })

--- a/modules/programs/lieer-accounts.nix
+++ b/modules/programs/lieer-accounts.nix
@@ -1,0 +1,69 @@
+{ lib, ... }:
+
+with lib;
+
+{
+  options.lieer = {
+    enable = mkEnableOption "lieer Gmail synchronization for notmuch";
+
+    timeout = mkOption {
+      type = types.ints.unsigned;
+      default = 0;
+      description = ''
+        HTTP timeout in seconds. 0 means forever or system timeout.
+      '';
+    };
+
+    replaceSlashWithDot = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Replace '/' with '.' in Gmail labels.
+      '';
+    };
+
+    dropNonExistingLabels = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Allow missing labels on the Gmail side to be dropped.
+      '';
+    };
+
+    ignoreTagsLocal = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Set custom tags to ignore when syncing from local to
+        remote (after translations).
+      '';
+    };
+
+    ignoreTagsRemote = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "CATEGORY_FORUMS"
+        "CATEGORY_PROMOTIONS"
+        "CATEGORY_UPDATES"
+        "CATEGORY_SOCIAL"
+        "CATEGORY_PERSONAL"
+      ];
+      description = ''
+        Set custom tags to ignore when syncing from remote to
+        local (before translations).
+      '';
+    };
+
+    notmuchSetupWarning = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Warn if Notmuch is not also enabled for this account.
+        </para><para>
+        This can safely be disabled if <command>notmuch init</command>
+        has been used to configure this account outside of Home
+        Manager.
+      '';
+    };
+  };
+}

--- a/modules/programs/lieer.nix
+++ b/modules/programs/lieer.nix
@@ -1,0 +1,89 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.lieer;
+
+  lieerAccounts =
+    filter (a: a.lieer.enable) (attrValues config.accounts.email.accounts);
+
+  nonGmailAccounts =
+    map (a: a.name) (filter (a: a.flavor != "gmail.com") lieerAccounts);
+
+  nonGmailConfigHelp =
+    map (name: ''accounts.email.accounts.${name}.flavor = "gmail.com";'')
+    nonGmailAccounts;
+
+  missingNotmuchAccounts = map (a: a.name)
+    (filter (a: !a.notmuch.enable && a.lieer.notmuchSetupWarning)
+      lieerAccounts);
+
+  notmuchConfigHelp =
+    map (name: "accounts.email.accounts.${name}.notmuch.enable = true;")
+    missingNotmuchAccounts;
+
+  configFile = account: {
+    name = "${account.maildir.absPath}/.gmailieer.json";
+    value = {
+      text = builtins.toJSON {
+        inherit (account.lieer) timeout;
+        account = account.address;
+        replace_slash_with_dot = account.lieer.replaceSlashWithDot;
+        drop_non_existing_label = account.lieer.dropNonExistingLabels;
+        ignore_tags = account.lieer.ignoreTagsLocal;
+        ignore_remote_labels = account.lieer.ignoreTagsRemote;
+      } + "\n";
+    };
+  };
+
+in {
+  meta.maintainers = [ maintainers.tadfisher ];
+
+  options = {
+    programs.lieer.enable =
+      mkEnableOption "lieer Gmail synchronization for notmuch";
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (missingNotmuchAccounts != [ ]) {
+      warnings = [''
+        lieer is enabled for the following email accounts, but notmuch is not:
+
+            ${concatStringsSep "\n    " missingNotmuchAccounts}
+
+        Notmuch can be enabled with:
+
+            ${concatStringsSep "\n    " notmuchConfigHelp}
+
+        If you have configured notmuch outside of Home Manager, you can suppress this
+        warning with:
+
+            programs.lieer.notmuchSetupWarning = false;
+      ''];
+    })
+
+    {
+      assertions = [{
+        assertion = nonGmailAccounts == [ ];
+        message = ''
+          lieer is enabled for non-Gmail accounts:
+
+              ${concatStringsSep "\n    " nonGmailAccounts}
+
+          If these accounts are actually Gmail accounts, you can
+          fix this error with:
+
+              ${concatStringsSep "\n    " nonGmailConfigHelp}
+        '';
+      }];
+
+      home.packages = [ pkgs.gmailieer ];
+
+      # Notmuch should ignore non-mail files created by lieer.
+      programs.notmuch.new.ignore = [ "/.*[.](json|lock|bak)$/" ];
+
+      home.file = listToAttrs (map configFile lieerAccounts);
+    }
+  ]);
+}

--- a/modules/services/lieer-accounts.nix
+++ b/modules/services/lieer-accounts.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+
+with lib;
+
+{
+  options.lieer.sync = {
+    enable = mkEnableOption "lieer synchronization service";
+
+    frequency = mkOption {
+      type = types.str;
+      default = "*:0/5";
+      description = ''
+        How often to synchronize the account.
+        </para><para>
+        This value is passed to the systemd timer configuration as the
+        onCalendar option. See
+        <citerefentry>
+          <refentrytitle>systemd.time</refentrytitle>
+          <manvolnum>7</manvolnum>
+        </citerefentry>
+        for more information about the format.
+      '';
+    };
+  };
+}

--- a/modules/services/lieer.nix
+++ b/modules/services/lieer.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.lieer;
+
+  syncAccounts = filter (a: a.lieer.enable && a.lieer.sync.enable)
+    (attrValues config.accounts.email.accounts);
+
+  escapeUnitName = name:
+    let
+      good = upperChars ++ lowerChars ++ stringToCharacters "0123456789-_";
+      subst = c: if any (x: x == c) good then c else "-";
+    in stringAsChars subst name;
+
+  serviceUnit = account: {
+    name = escapeUnitName "lieer-${account.name}";
+    value = {
+      Unit = {
+        Description = "lieer Gmail synchronization for ${account.name}";
+        ConditionPathExists = "${account.maildir.absPath}/.gmailieer.json";
+      };
+
+      Service = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.gmailieer}/bin/gmi sync";
+        WorkingDirectory = account.maildir.absPath;
+      };
+    };
+  };
+
+  timerUnit = account: {
+    name = escapeUnitName "lieer-${account.name}";
+    value = {
+      Unit = {
+        Description = "lieer Gmail synchronization for ${account.name}";
+      };
+
+      Timer = {
+        OnCalendar = account.lieer.sync.frequency;
+        RandomizedDelaySec = 30;
+      };
+
+      Install = { WantedBy = [ "timers.target" ]; };
+    };
+  };
+
+in {
+  meta.maintainers = [ maintainers.tadfisher ];
+
+  options = {
+    services.lieer.enable =
+      mkEnableOption "lieer Gmail synchronization service";
+  };
+
+  config = mkIf cfg.enable {
+    programs.lieer.enable = true;
+    systemd.user.services = listToAttrs (map serviceUnit syncAccounts);
+    systemd.user.timers = listToAttrs (map timerUnit syncAccounts);
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -32,6 +32,7 @@ import nmt {
     ./modules/programs/fish
     ./modules/programs/git
     ./modules/programs/gpg
+    ./modules/programs/lieer
     ./modules/programs/mbsync
     ./modules/programs/neomutt
     ./modules/programs/newsboat

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -48,6 +48,7 @@ import nmt {
     ./modules/misc/xsession
     ./modules/programs/firefox
     ./modules/programs/getmail
+    ./modules/services/lieer
     ./modules/programs/rofi
     ./modules/services/sxhkd
     ./modules/services/window-managers/i3

--- a/tests/modules/programs/lieer/default.nix
+++ b/tests/modules/programs/lieer/default.nix
@@ -1,0 +1,1 @@
+{ lieer = ./lieer.nix; }

--- a/tests/modules/programs/lieer/lieer-expected.json
+++ b/tests/modules/programs/lieer/lieer-expected.json
@@ -1,0 +1,1 @@
+{"account":"hm@example.com","drop_non_existing_label":false,"ignore_remote_labels":["CATEGORY_FORUMS","CATEGORY_PROMOTIONS","CATEGORY_UPDATES","CATEGORY_SOCIAL","CATEGORY_PERSONAL"],"ignore_tags":[],"replace_slash_with_dot":false,"timeout":0}

--- a/tests/modules/programs/lieer/lieer.nix
+++ b/tests/modules/programs/lieer/lieer.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    home.username = "hm-user";
+    home.homeDirectory = "/home/hm-user";
+
+    programs.lieer.enable = true;
+
+    accounts.email.accounts = { "hm@example.com".lieer.enable = true; };
+
+    nmt.script = ''
+      assertFileExists home-files/Mail/hm@example.com/.gmailieer.json
+      assertFileContent home-files/Mail/hm@example.com/.gmailieer.json \
+                        ${./lieer-expected.json}
+    '';
+  };
+}

--- a/tests/modules/services/lieer/default.nix
+++ b/tests/modules/services/lieer/default.nix
@@ -1,0 +1,1 @@
+{ lieer-service = ./lieer-service.nix; }

--- a/tests/modules/services/lieer/lieer-service-expected.service
+++ b/tests/modules/services/lieer/lieer-service-expected.service
@@ -1,0 +1,8 @@
+[Service]
+ExecStart=@lieer@/bin/gmi sync
+Type=oneshot
+WorkingDirectory=/home/hm-user/Mail/hm@example.com
+
+[Unit]
+ConditionPathExists=/home/hm-user/Mail/hm@example.com/.gmailieer.json
+Description=lieer Gmail synchronization for hm@example.com

--- a/tests/modules/services/lieer/lieer-service-expected.timer
+++ b/tests/modules/services/lieer/lieer-service-expected.timer
@@ -1,0 +1,9 @@
+[Install]
+WantedBy=timers.target
+
+[Timer]
+OnCalendar=*:0/5
+RandomizedDelaySec=30
+
+[Unit]
+Description=lieer Gmail synchronization for hm@example.com

--- a/tests/modules/services/lieer/lieer-service.nix
+++ b/tests/modules/services/lieer/lieer-service.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    home.username = "hm-user";
+    home.homeDirectory = "/home/hm-user";
+
+    services.lieer.enable = true;
+
+    accounts.email.accounts = {
+      "hm@example.com".lieer.enable = true;
+      "hm@example.com".lieer.sync.enable = true;
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        gmailieer = super.gmailieer // { outPath = "@lieer@"; };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/systemd/user/lieer-hm-example-com.service
+      assertFileExists home-files/.config/systemd/user/lieer-hm-example-com.timer
+
+      assertFileContent home-files/.config/systemd/user/lieer-hm-example-com.service \
+                        ${./lieer-service-expected.service}
+      assertFileContent home-files/.config/systemd/user/lieer-hm-example-com.timer \
+                        ${./lieer-service-expected.timer}
+    '';
+  };
+}


### PR DESCRIPTION
Add 'programs.lieer', a tool for synchronizing a Gmail account with a
local maildir and notmuch database. Per-account configuration lives in
'accounts.email.accounts.<name>.lieer'.

Add 'services.lieer', which generates systemd timer and service units
to synchronize a Gmail account with lieer. Per-account configuration
lives in 'accounts.email.accounts.<name>.lieer.sync'.
