### PR TITLE
newsboat: show queries before urls

### DIFF
--- a/doc/release-notes/rl-2003.adoc
+++ b/doc/release-notes/rl-2003.adoc
@@ -81,3 +81,6 @@ changes are only active if the `home.stateVersion` option is set to
   using the xdg module. Also, the default value is fixed to
   `$HOME/.zsh_history` and `dotDir` path is not prepended to it
   anymore.
+* The newsboat module will now default in displaying `queries` before `urls` in
+  its main window. This makes sense in the case when one has a lot of urls and a
+  few queries.

--- a/modules/programs/newsboat.nix
+++ b/modules/programs/newsboat.nix
@@ -102,7 +102,7 @@ in {
 
       mkQueryEntry = n: v: ''"query:${n}:${escape [ ''"'' ] v}"'';
       queries = mapAttrsToList mkQueryEntry cfg.queries;
-    in concatStringsSep "\n" (urls ++ queries) + "\n";
+    in concatStringsSep "\n" (queries ++ urls) + "\n";
 
     home.file.".newsboat/config".text = ''
       max-items ${toString cfg.maxItems}

--- a/modules/programs/newsboat.nix
+++ b/modules/programs/newsboat.nix
@@ -102,7 +102,11 @@ in {
 
       mkQueryEntry = n: v: ''"query:${n}:${escape [ ''"'' ] v}"'';
       queries = mapAttrsToList mkQueryEntry cfg.queries;
-    in concatStringsSep "\n" (queries ++ urls) + "\n";
+    in concatStringsSep "\n" (
+    if versionAtLeast config.home.stateVersion "20.03"
+    then queries ++ urls
+    else urls ++ queries
+    ) + "\n";
 
     home.file.".newsboat/config".text = ''
       max-items ${toString cfg.maxItems}

--- a/tests/modules/programs/newsboat/default.nix
+++ b/tests/modules/programs/newsboat/default.nix
@@ -1,1 +1,4 @@
-{ newsboat-basics = ./newsboat-basics.nix; }
+{
+  newsboat-basics = ./newsboat-basics.nix;
+  newsboat-basics-2003 = ./newsboat-basics-2003.nix;
+}

--- a/tests/modules/programs/newsboat/newsboat-basics-2003.nix
+++ b/tests/modules/programs/newsboat/newsboat-basics-2003.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "20.03";
+
+    programs.newsboat = {
+      enable = true;
+
+      urls = [
+        {
+          url = "http://example.org/feed.xml";
+          tags = [ "tag1" "tag2" ];
+          title = "Cool feed";
+        }
+
+        { url = "http://example.org/feed2.xml"; }
+      ];
+
+      queries = { "foo" = ''rssurl =~ "example.com"''; };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { newsboat = pkgs.writeScriptBin "dummy-newsboat" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.newsboat/urls \
+        ${./newsboat-basics-urls-2003.txt}
+    '';
+  };
+}

--- a/tests/modules/programs/newsboat/newsboat-basics-urls-2003.txt
+++ b/tests/modules/programs/newsboat/newsboat-basics-urls-2003.txt
@@ -1,3 +1,3 @@
+"query:foo:rssurl =~ \"example.com\""
 http://example.org/feed.xml "tag1" "tag2" "~Cool feed"
 http://example.org/feed2.xml
-"query:foo:rssurl =~ \"example.com\""

--- a/tests/modules/programs/newsboat/newsboat-basics-urls.txt
+++ b/tests/modules/programs/newsboat/newsboat-basics-urls.txt
@@ -1,3 +1,3 @@
+"query:foo:rssurl =~ \"example.com\""
 http://example.org/feed.xml "tag1" "tag2" "~Cool feed"
 http://example.org/feed2.xml
-"query:foo:rssurl =~ \"example.com\""


### PR DESCRIPTION
One quickly has a lot of urls, but only a few queries which pick the interesting parts. I think it would make sense to show queries before urls in newsboat main page.