### PR TITLE
Add support for `debug`-outputs from Nix packages

### DIFF
--- a/modules/misc/debug.nix
+++ b/modules/misc/debug.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+{
+  options.home = {
+    enableDebugInfo = mkEnableOption "debug info" // {
+      description = ''
+        Some Nix(OS)-packages provide debug-symbols for <command>gdb</command>
+        in the <literal>debug</literal>-output. This option ensures that those are
+        automatically fetched from the binary cache if available and <command>gdb</command>
+        is configured to find those symbols.
+      '';
+    };
+  };
+
+  config = mkIf config.home.enableDebugInfo {
+    home.extraOutputsToInstall = [ "debug" ];
+
+    home.sessionVariables = {
+      NIX_DEBUG_INFO_DIRS =
+        "$NIX_DEBUG_INFO_DIRS\${NIX_DEBUG_INFO_DIRS:+:}${config.home.profileDirectory}/lib/debug";
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -25,6 +25,7 @@ let
     (loadModule ./home-environment.nix { })
     (loadModule ./manual.nix { })
     (loadModule ./misc/dconf.nix { })
+    (loadModule ./misc/debug.nix { })
     (loadModule ./misc/fontconfig.nix { })
     (loadModule ./misc/gtk.nix { })
     (loadModule ./misc/lib.nix { })

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -25,6 +25,7 @@ import nmt {
     ./lib/types
     ./modules/files
     ./modules/home-environment
+    ./modules/misc/debug.nix
     ./modules/misc/fontconfig
     ./modules/programs/alacritty
     ./modules/programs/bash

--- a/tests/modules/misc/debug.nix
+++ b/tests/modules/misc/debug.nix
@@ -14,11 +14,13 @@
       assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
           'NIX_DEBUG_INFO_DIRS=.*/lib/debug'
 
-      # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evalutes to the home
-      # of the user who executes this testcase :/
-      { echo quit | PATH="$TESTED/home-path/bin''${PATH:+:}$PATH" NIX_DEBUG_INFO_DIRS=$TESTED/home-path/lib/debug \
-        gdb nix 2>&1 | \
-        grep 'Reading symbols from ${builtins.storeDir}/'; } || fail "Failed to read debug symbols from nix in gdb"
+      ${lib.optionalString (!pkgs.stdenv.isDarwin) ''
+        # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evalutes to the home
+        # of the user who executes this testcase :/
+        { echo quit | PATH="$TESTED/home-path/bin''${PATH:+:}$PATH" NIX_DEBUG_INFO_DIRS=$TESTED/home-path/lib/debug \
+          gdb nix 2>&1 | \
+          grep 'Reading symbols from ${builtins.storeDir}/'; } || fail "Failed to read debug symbols from nix in gdb"
+      ''}
     '';
   };
 }

--- a/tests/modules/misc/debug.nix
+++ b/tests/modules/misc/debug.nix
@@ -7,9 +7,12 @@
       [ -L $TESTED/home-path/lib/debug/nix ] \
         || fail "Debug-symbols for pkgs.nix should exist in \`/home-path/lib/debug'!"
 
-      source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
-      [[ "$NIX_DEBUG_INFO_DIRS" =~ /lib/debug$ ]] \
-        || fail "Invalid NIX_DEBUG_INFO_DIRS!"
+      #source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
+      #[[ "$NIX_DEBUG_INFO_DIRS" =~ /lib/debug$ ]] \
+        #|| fail "Invalid NIX_DEBUG_INFO_DIRS!"
+      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+          'NIX_DEBUG_INFO_DIRS=.*/lib/debug'
 
       # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evalutes to the home
       # of the user who executes this testcase :/

--- a/tests/modules/misc/debug.nix
+++ b/tests/modules/misc/debug.nix
@@ -1,0 +1,21 @@
+{
+  debug = { pkgs, config, lib, ... }: {
+    home.enableDebugInfo = true;
+    home.packages = with pkgs; [ nix gdb ];
+
+    nmt.script = ''
+      [ -L $TESTED/home-path/lib/debug/nix ] \
+        || fail "Debug-symbols for pkgs.nix should exist in \`/home-path/lib/debug'!"
+
+      source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
+      [[ "$NIX_DEBUG_INFO_DIRS" =~ /lib/debug$ ]] \
+        || fail "Invalid NIX_DEBUG_INFO_DIRS!"
+
+      # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evalutes to the home
+      # of the user who executes this testcase :/
+      { echo quit | PATH="$TESTED/home-path/bin''${PATH:+:}$PATH" NIX_DEBUG_INFO_DIRS=$TESTED/home-path/lib/debug \
+        gdb nix 2>&1 | \
+        grep 'Reading symbols from ${builtins.storeDir}/'; } || fail "Failed to read debug symbols from nix in gdb"
+    '';
+  };
+}


### PR DESCRIPTION
A few Nix-packages provide a [`debug`-output](https://nixos.wiki/wiki/Debug_Symbols) with debug-symbols for e.g. `gdb` (those will be removed from the actual binary in `$out/bin` in the `fixupPhase` using `strip(1)`).

This change is pretty much inspired from the NixOS-option [`environment.enableDebugInfo`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/debug-info.nix).

I tested the functionality of the newly introduced module by using a [simple package](https://gitlab.com/Ma27/nix-gdb-example) that causes a segfault on purpose and writes debug-symbols to `$debug`.