### PR TITLE
home-manager: handle args with spaces to doBuildAttr

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -78,28 +78,28 @@ function doBuildAttr() {
     setConfigFile
     setHomeManagerNixPath
 
-    local extraArgs="$*"
+    local extraArgs=("$@")
 
     for p in "${EXTRA_NIX_PATH[@]}"; do
-        extraArgs="$extraArgs -I $p"
+        extraArgs=("${extraArgs[@]}" "-I" "$p")
     done
 
     if [[ -v VERBOSE ]]; then
-        extraArgs="$extraArgs --show-trace"
+        extraArgs=("${extraArgs[@]}" "--show-trace")
     fi
 
     # shellcheck disable=2086
     if [[ -v USE_NIX2_COMMAND ]]; then
         nix build \
             -f "<home-manager/home-manager/home-manager.nix>" \
-            $extraArgs \
+            "${extraArgs[@]}" \
             "${PASSTHROUGH_OPTS[@]}" \
             --argstr confPath "$HOME_MANAGER_CONFIG" \
             --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"
     else
         nix-build \
             "<home-manager/home-manager/home-manager.nix>" \
-            $extraArgs \
+            "${extraArgs[@]}" \
             "${PASSTHROUGH_OPTS[@]}" \
             --argstr confPath "$HOME_MANAGER_CONFIG" \
             --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"


### PR DESCRIPTION
Presently, if you pass an argument with spaces in it to doBuildAttr, it will be split it into multiple arguments to `nix build` or `nix-build`. I came across this situation when I tried to use home-manager on a system with spaces in `XDG_DATA_HOME`. Specifically, the `home-manager` script errored out in trying to address the read-news state file. With this change, I believe argument separation should be preserved properly in `doBuildAttr`, and in fact the problem seems fixed on my machine with this change.