### PR TITLE
neovim: add vimdiffAlias

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -55,6 +55,14 @@ in
         '';
       };
 
+      vimdiffAlias = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Alias `vimdiff` to `nvim -d`.
+        '';
+      };
+
       withNodeJs = mkOption {
         type = types.bool;
         default = false;
@@ -203,5 +211,9 @@ in
 
       configure = cfg.configure // moduleConfigure;
     };
+
+    programs.bash.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
+    programs.fish.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
+    programs.zsh.shellAliases  = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
   };
 }


### PR DESCRIPTION
Git's merge.tool needs to "point" to a binary. For vim's case will provide a separate executable known as vimdiff which can simulate `vim -d`, however, neovim doesn't have this, and needs an explicilt alias.

If you want to use neovim as a diff tool, you would have to do `programs.<shell>.shellAliases = { vimdiff = "nvim -d"; };`.

Not sure if we want neovim to be "aware" of the shell, but I think this is a little nicer than explicitly adding the vimdiff entry to <shell>.shellAliases