### PR TITLE
fish: allow arguments to functions

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1333,6 +1333,15 @@ in
           A new module is available: 'wayland.windowManager.sway'
         '';
       }
+
+      {
+        time = "2020-03-01T21:20:44+00:00";
+        message = ''
+          The option 'programs.fish.functions' has been reworked in
+          order to support all available flags, such as
+          '--description', '--on-event', and more.
+        '';
+      }
     ];
   };
 }

--- a/tests/modules/programs/fish/functions.nix
+++ b/tests/modules/programs/fish/functions.nix
@@ -10,12 +10,24 @@ let
     end
   '';
 
+  funcEvent = pkgs.writeText "func-event.fish" ''
+    function func-event --on-event="fish_command_not_found"
+      echo "Not found!"
+    end
+  '';
+
 in {
   config = {
     programs.fish = {
       enable = true;
 
-      functions = { func = ''echo "Hello"''; };
+      functions = {
+        func = ''echo "Hello"'';
+        func-event = {
+          body = ''echo "Not found!"'';
+          onEvent = "fish_command_not_found";
+        };
+      };
     };
 
     nmt = {
@@ -25,6 +37,10 @@ in {
         assertFileExists home-files/.config/fish/functions/func.fish
         echo ${func}
         assertFileContent home-files/.config/fish/functions/func.fish ${func}
+
+        assertFileExists home-files/.config/fish/functions/func-event.fish
+        echo ${funcEvent}
+        assertFileContent home-files/.config/fish/functions/func-event.fish ${funcEvent}
       '';
 
     };


### PR DESCRIPTION
This allows the ability to provide arguments to a function, such as
`--on-event` in order to trigger a function on the
`fish_command_not_found` event, for example.

---

The main reason for this was so that I could change
`__fish_command_not_found_handler` because, on Arch, it looks for any
packages that might contain the misspelled binary. Previously, you might
have been able to get away with a hack like specifying the flags in the
function name, but now all you need to do is specify the submodule and
desired flags.

I added a test and news for this, but is there any better way to
document the available options? As it stands, I believe any interested
parties would need to browse the source to find out what is available
and what isn't.

~I formatted the `mapAttrs'` block with `nixfmt`, but it looks really
ugly. I left as-is because the fish module hasn't been blacklisted in
the format script yet, but it would look better if I went back and
manually formatted it.~

Finally, please let me know if anything is not ideal, or is bad Nix, or
whatever. I'm still new to the language and stumbling around, but
interested in becoming more comfortable with it.

(Special thanks to @d-goldin for pointing me in the right direction)