### PR TITLE
git: fix the config output

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -21,8 +21,8 @@ let
 
   # generation for multiple ini values
   mkKeyValue = k: v:
-    let mkKeyValue = generators.mkKeyValueDefault { } "=" k;
-    in concatStringsSep "\n" (map mkKeyValue (toList v));
+    let mkKeyValue = generators.mkKeyValueDefault { } " = " k;
+    in concatStringsSep "\n" (map (kv: "	" + mkKeyValue kv) (toList v));
 
   # converts { a.b.c = 5; } to { "a.b".c = 5; } for toINI
   gitFlattenAttrs = let

--- a/tests/modules/programs/git/git-expected-include.conf
+++ b/tests/modules/programs/git/git-expected-include.conf
@@ -1,5 +1,3 @@
-This can be anything.
-
 [user]
 	email = user@example.org
 	name = John Doe

--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -1,42 +1,42 @@
 [alias]
-a1=foo
-a2=baz
+	a1 = foo
+	a2 = baz
 
 [commit]
-gpgSign=true
+	gpgSign = true
 
 [extra]
-boolean=true
-integer=38
-multiple=1
-multiple=2
-name=value
+	boolean = true
+	integer = 38
+	multiple = 1
+	multiple = 2
+	name = value
 
 [extra "backcompat.with.dots"]
-previously=worked
+	previously = worked
 
 [extra "subsection"]
-value=test
+	value = test
 
 [filter "lfs"]
-clean=git-lfs clean -- %f
-process=git-lfs filter-process
-required=true
-smudge=git-lfs smudge -- %f
+	clean = git-lfs clean -- %f
+	process = git-lfs filter-process
+	required = true
+	smudge = git-lfs smudge -- %f
 
 [gpg]
-program=path-to-gpg
+	program = path-to-gpg
 
 [user]
-email=user@example.org
-name=John Doe
-signingKey=00112233445566778899AABBCCDDEEFF
+	email = user@example.org
+	name = John Doe
+	signingKey = 00112233445566778899AABBCCDDEEFF
 
 [include]
-path=~/path/to/config.inc
+	path = ~/path/to/config.inc
 
 [includeIf "gitdir:~/src/dir"]
-path=~/path/to/conditional.inc
+	path = ~/path/to/conditional.inc
 
 [includeIf "gitdir:~/src/dir"]
-path=@git_include_path@
+	path = @git_include_path@

--- a/tests/modules/programs/git/git-with-email-expected.conf
+++ b/tests/modules/programs/git/git-with-email-expected.conf
@@ -1,15 +1,15 @@
 [sendemail "hm-account"]
-from=hm@example.org
-smtpEncryption=tls
-smtpServer=smtp.example.org
-smtpUser=home.manager.jr
+	from = hm@example.org
+	smtpEncryption = tls
+	smtpServer = smtp.example.org
+	smtpUser = home.manager.jr
 
 [sendemail "hm@example.com"]
-from=hm@example.com
-smtpEncryption=tls
-smtpServer=smtp.example.com
-smtpUser=home.manager
+	from = hm@example.com
+	smtpEncryption = tls
+	smtpServer = smtp.example.com
+	smtpUser = home.manager
 
 [user]
-email=hm@example.com
-name=H. M. Test
+	email = hm@example.com
+	name = H. M. Test

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -16,7 +16,7 @@ let
       src = path;
 
       git_include_path =
-        pkgs.writeText "contents" (generators.toINI { } gitInclude);
+        pkgs.writeText "contents" (builtins.readFile ./git-expected-include.conf);
     };
 
 in {


### PR DESCRIPTION
When setting values using the `git config --set` command, git formats
the file a bit differently. This changes the output so it maps to that
format.

Differences:

* each `key = value` in a section is prefixed by a tab character
* the `=` between the key and the value is surrounded by spaces