### PR TITLE
Prefer rec attribute set for example

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -190,9 +190,9 @@ in
         session variable, then do so inside Nix instead. The above
         example then becomes
         <programlisting language="nix">
-        home.sessionVariables = {
+        home.sessionVariables = rec {
           FOO = "Hello";
-          BAR = "''${config.home.sessionVariables.FOO} World!";
+          BAR = "${FOO} World!";
         };
         </programlisting>
       '';


### PR DESCRIPTION
Two things:
1. Use a recursive attribute set in the example where one environment variable's value depends on another's.
2. Remove leading `''` from `BAR = "''${...} World!"`. I'm unsure why that's there.

I'm still learning Nix, so if anything that I'm suggesting is erroneous, please let me know. Thank you.