### PR TITLE
Firefox: Support userContent CSS

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -137,7 +137,7 @@ in
             userChrome = mkOption {
               type = types.lines;
               default = "";
-              description = "Custom Firefox CSS.";
+              description = "Custom Firefox userChrome CSS";
               example = ''
                 /* Hide tab bar in FF Quantum */
                 @-moz-document url("chrome://browser/content/browser.xul") {
@@ -150,6 +150,16 @@ in
                     visibility: collapse !important;
                   }
                 }
+              '';
+            };
+
+            userContent = mkOption {
+              type = types.lines;
+              default = "";
+              description = "Custom Firefox userContent CSS";
+              example = ''
+                /* Hide scrollbar in FF Quantum */
+                *{scrollbar-width:none !important}
               '';
             };
 
@@ -293,6 +303,11 @@ in
         "${profilesPath}/${profile.path}/chrome/userChrome.css" =
           mkIf (profile.userChrome != "") {
             text = profile.userChrome;
+          };
+          
+        "${profilesPath}/${profile.path}/chrome/userContent.css" =
+          mkIf (profile.userContent != "") {
+            text = profile.userContent;
           };
 
         "${profilesPath}/${profile.path}/user.js" =


### PR DESCRIPTION
Greetings, first PR here :)

userContent.css is similar to userChrome.css, it's a CSS file that you can use to change the way websites and e-mails look.

You can also use it to do things like hide your scrollbar or apply a theme to extensions like uBlock Origin.

See: http://kb.mozillazine.org/index.php?title=UserContent.css
userContent Example: https://github.com/jeremyperkin/FireFox-uBo-rice