### PR TITLE
Support keynav service

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -155,6 +155,7 @@ let
     (loadModule ./services/taskwarrior-sync.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/udiskie.nix { })
     (loadModule ./services/unclutter.nix { })
+    (loadModule ./services/keynav.nix { })
     (loadModule ./services/unison.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/window-managers/awesome.nix { })
     (loadModule ./services/window-managers/bspwm/default.nix { condition = hostPlatform.isLinux; })

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -155,7 +155,7 @@ let
     (loadModule ./services/taskwarrior-sync.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/udiskie.nix { })
     (loadModule ./services/unclutter.nix { })
-    (loadModule ./services/keynav.nix { })
+    (loadModule ./services/keynav.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/unison.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/window-managers/awesome.nix { })
     (loadModule ./services/window-managers/bspwm/default.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/keynav.nix
+++ b/modules/services/keynav.nix
@@ -6,15 +6,7 @@ let cfg = config.services.keynav;
 
 in {
   options.services.keynav = {
-
     enable = mkEnableOption "keynav";
-
-    package = mkOption {
-      description = "keynav derivation to use.";
-      type = types.package;
-      default = pkgs.keynav;
-      defaultText = literalExample "pkgs.keynav";
-    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/services/keynav.nix
+++ b/modules/services/keynav.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.keynav;
+
+in {
+  options.services.keynav = {
+
+    enable = mkEnableOption "keynav";
+
+    package = mkOption {
+      description = "keynav derivation to use.";
+      type = types.package;
+      default = pkgs.keynav;
+      defaultText = literalExample "pkgs.keynav";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.keynav = {
+      Unit = {
+        Description = "keynav";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/keynav";
+        RestartSec = 3;
+        Restart = "always";
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+    };
+  };
+}


### PR DESCRIPTION
keynav lets users control their mouse with the keyboard.

For most users, `services.keynav.enable = true` should support their workflows.

However, keynav offers many configuration options, which home-manager could
eventually support. For now, why not support the default configuration and allow
open source contributors to fill in the rest as needed?