### PR TITLE
sway: fix onChange when defunct sockets exist

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -379,7 +379,7 @@ in {
     xdg.configFile."sway/config" = {
       source = configFile;
       onChange = ''
-        swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.*.sock
+        swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway).sock
         if [ -S $swaySocket ]; then
           echo "Reloading sway"
           $DRY_RUN_CMD ${cfg.package}/bin/swaymsg -s $swaySocket reload


### PR DESCRIPTION
Fixes `..../generation/activate: line 181: [: too many arguments` when,
for whatever reason, the user has multiple `sway-ipc` sockets.

---

~~For some reason, I have three sockets right now, with only 1 that actually corresponds to my running session. My original solution was to `$(pgrep -x sway)` where the glob is, but I wasn't sure if `pgrep` is always available. This solution is more portable.~~

A shortcoming of this solution is that, if a user has nested sway sessions, it might act on the nested session rather than the parent. However, I think it's better than throwing the above error when there are multiple "available" sockets.

cc @alexarice 