### PR TITLE
activation-init: ignore error from `find` when `/nix/var/nix/profiles/per-user/$USER` doesn't exist

### DIFF
--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -9,7 +9,7 @@ function setupVars() {
         find "$profilesPath" -name 'home-manager-*-link' \
             | sed 's/^.*-\([0-9]*\)-link$/\1/' \
             | sort -rn \
-            | head -1)
+            | head -1 || true)
 
     if [[ -n $greatestGenNum ]] ; then
         oldGenNum=$greatestGenNum


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description
Fix for https://github.com/rycee/home-manager/issues/1050 https://github.com/rycee/home-manager/issues/1119 https://github.com/rycee/home-manager/issues/948 

Before this fix:
```bash
% DRY_RUN=1 VERBOSE_ECHO=echo ./activate
Starting home manager activation
find: ‘/nix/var/nix/profiles/per-user/misuzu’: No such file or directory
```

After this fix:
```bash
% DRY_RUN=1 VERBOSE_ECHO=echo ./activate
Starting home manager activation
find: ‘/nix/var/nix/profiles/per-user/misuzu’: No such file or directory
This is a dry run
Activating checkFilesChanged
Activating checkLinkTargets
Activating writeBoundary
Activating installPackages
nix-env -i /nix/store/v7920bpgyql4jwkr0q01bg63i5cpq93n-home-manager-path
Activating linkGeneration
Creating profile generation 1
nix-env --profile /nix/var/nix/profiles/per-user/misuzu/home-manager --set /nix/store/cv1bql7155rhx1jlqnay8pd578wba257-home-manager-generation
ln -Tsf /nix/store/cv1bql7155rhx1jlqnay8pd578wba257-home-manager-generation /nix/var/nix/gcroots/per-user/misuzu/current-home
Creating home file links in /home/misuzu
mkdir -p /home/misuzu/.cache
ln -nsf /nix/store/gf6m6hbrwg41wcxb98a1pbfigghq9zzf-home-manager-files/.cache/.keep /home/misuzu/.cache/.keep
mkdir -p /home/misuzu/.config/git
ln -nsf /nix/store/gf6m6hbrwg41wcxb98a1pbfigghq9zzf-home-manager-files/.config/git/config /home/misuzu/.config/git/config
mkdir -p /home/misuzu/.config/git
ln -nsf /nix/store/gf6m6hbrwg41wcxb98a1pbfigghq9zzf-home-manager-files/.config/git/ignore /home/misuzu/.config/git/ignore
mkdir -p /home/misuzu/.config/htop
ln -nsf /nix/store/gf6m6hbrwg41wcxb98a1pbfigghq9zzf-home-manager-files/.config/htop/htoprc /home/misuzu/.config/htop/htoprc
mkdir -p /home/misuzu/.config/mc
ln -nsf /nix/store/gf6m6hbrwg41wcxb98a1pbfigghq9zzf-home-manager-files/.config/mc/ini /home/misuzu/.config/mc/ini
mkdir -p /home/misuzu
ln -nsf /nix/store/gf6m6hbrwg41wcxb98a1pbfigghq9zzf-home-manager-files/.tmux.conf /home/misuzu/.tmux.conf
Activating onFilesChange
Activating reloadSystemD
systemctl --user daemon-reload
% ./activate
Starting home manager activation
find: ‘/nix/var/nix/profiles/per-user/misuzu’: No such file or directory
Activating checkFilesChanged
Activating checkLinkTargets
Activating writeBoundary
Activating installPackages
installing 'home-manager-path'
Activating linkGeneration
Creating profile generation 1
Creating home file links in /home/misuzu
Activating onFilesChange
Activating reloadSystemD
% ./activate
Starting home manager activation
Activating checkFilesChanged
Activating checkLinkTargets
Activating writeBoundary
Activating installPackages
replacing old 'home-manager-path'
installing 'home-manager-path'
Activating linkGeneration
Cleaning up orphan links from /home/misuzu
No change so reusing latest profile generation 1
Creating home file links in /home/misuzu
Activating onFilesChange
Activating reloadSystemD
```


### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`. (after merge to master)

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
