### PR TITLE
Fix the key for bold foreground color in termite

### DIFF
--- a/modules/programs/termite.nix
+++ b/modules/programs/termite.nix
@@ -362,7 +362,7 @@ in {
       ${optionalString "cursor" cfg.cursorColor}
       ${optionalString "cursor_foreground" cfg.cursorForegroundColor}
       ${optionalString "foreground" cfg.foregroundColor}
-      ${optionalString "foregroundBold" cfg.foregroundBoldColor}
+      ${optionalString "foreground_bold" cfg.foregroundBoldColor}
       ${optionalString "highlight" cfg.highlightColor}
 
       ${cfg.colorsExtra}


### PR DESCRIPTION
The key is `foreground_bold`, not `foregroundBold`. (https://github.com/thestinger/termite/blob/0ea077c248299eb9928d0abae9401cf28173bac2/termite.cc#L1406)