### PR TITLE
Add home-manager instantiate subcommand

### DIFF
--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -18,6 +18,10 @@
    </arg>
     
    <arg choice="plain">
+    instantiate
+   </arg>
+    
+   <arg choice="plain">
     edit
    </arg>
     
@@ -160,6 +164,16 @@
      <listitem>
       <para>
        Build configuration into a <filename>result</filename> directory.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option>instantiate</option>
+     </term>
+     <listitem>
+      <para>
+       Instantiate the configuration and print the resulting derivation.
       </para>
      </listitem>
     </varlistentry>

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -278,7 +278,7 @@ _home-manager_completions ()
     #--------------------------#
 
     local Subcommands
-    Subcommands=( "help" "edit" "build" "switch" "generations" "remove-generations" "expire-generations" "packages" "news" "uninstall" )
+    Subcommands=( "help" "edit" "build" "instantiate" "switch" "generations" "remove-generations" "expire-generations" "packages" "news" "uninstall" )
 
     # ^ « home-manager »'s subcommands.
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -74,6 +74,28 @@ function setHomeManagerNixPath() {
     done
 }
 
+function doInstantiate() {
+    setConfigFile
+    setHomeManagerNixPath
+
+    local extraArgs=("$@")
+
+    for p in "${EXTRA_NIX_PATH[@]}"; do
+        extraArgs=("${extraArgs[@]}" "-I" "$p")
+    done
+
+    if [[ -v VERBOSE ]]; then
+        extraArgs=("${extraArgs[@]}" "--show-trace")
+    fi
+
+    nix-instantiate \
+        "<home-manager/home-manager/home-manager.nix>" \
+        "${extraArgs[@]}" \
+        "${PASSTHROUGH_OPTS[@]}" \
+        --argstr confPath "$HOME_MANAGER_CONFIG" \
+        --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"
+}
+
 function doBuildAttr() {
     setConfigFile
     setHomeManagerNixPath
@@ -441,6 +463,8 @@ function doHelp() {
     echo
     echo "  build        Build configuration into result directory"
     echo
+    echo "  instantiate  Instantiate the configuration and print the resulting derivation"
+    echo
     echo "  switch       Build and activate configuration"
     echo
     echo "  generations  List all home environment generations"
@@ -471,7 +495,7 @@ while [[ $# -gt 0 ]]; do
     opt="$1"
     shift
     case $opt in
-        build|edit|expire-generations|generations|help|news|packages|remove-generations|switch|uninstall)
+        build|instantiate|edit|expire-generations|generations|help|news|packages|remove-generations|switch|uninstall)
             COMMAND="$opt"
             ;;
         -2)
@@ -541,6 +565,9 @@ case $COMMAND in
         ;;
     build)
         doBuild
+        ;;
+    instantiate)
+        doInstantiate
         ;;
     switch)
         doSwitch


### PR DESCRIPTION
It can be useful to simply instantiate a home-manager configuration
without actually building it, for example for the purpose of
pre-building it with some custom command.

One recent usage example: I was [trying](https://discourse.nixos.org/t/nix-bisect-bisect-nix-builds/5584/10?u=timokau) to build a home-manager configuration with a custom tool (`nix-bisect`) before switching to the configuration. That would be much simpler and less hacky if `home-manager` provided a way to instantiate a configuration.