### PR TITLE
programs.vscode: fix extension path symlink error

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -79,7 +79,7 @@ in
       let
         toPaths = path:
           let
-            p = "${path}/share/vscode/extensions";
+            p = "${path}";
           in
             # Links every dir in p to the extension path.
             mapAttrsToList (k: v:

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -78,14 +78,11 @@ in
     home.file =
       let
         toPaths = path:
-          let
-            p = "${path}";
-          in
-            # Links every dir in p to the extension path.
-            mapAttrsToList (k: v:
-              {
-                "${extensionPath}/${k}".source = "${p}/${k}";
-              }) (builtins.readDir p);
+          # Links every dir in p to the extension path.
+          mapAttrsToList (k: v:
+            {
+              "${extensionPath}/${k}".source = "${path}/${k}";
+            }) (builtins.readDir path);
         toSymlink = concatMap toPaths cfg.extensions;
       in
         foldr


### PR DESCRIPTION
Fix extension path symlink error caused by https://github.com/NixOS/nixpkgs/pull/71251, which removes `/share/{wrappedPkgName}/extensions` from the extension install path.