### PR TITLE
rofi: add plugins

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -272,6 +272,13 @@ in {
       '';
     };
 
+    plugins = mkOption {
+      default = [ ];
+      type = with types; listOf package;
+      description = "Plugins to compile rofi with.";
+      example = literalExample "[ pkgs.rofi-calc ]";
+    };
+
     configPath = mkOption {
       default = "${config.xdg.configHome}/rofi/config";
       defaultText = "$XDG_CONFIG_HOME/rofi/config";
@@ -295,7 +302,7 @@ in {
       '';
     }];
 
-    home.packages = [ pkgs.rofi ];
+    home.packages = [ (pkgs.rofi.override { inherit (cfg) plugins; }) ];
 
     home.file."${cfg.configPath}".text = ''
       ${setOption "width" cfg.width}


### PR DESCRIPTION
I've added an option that rebuilds the rofi wrapper with specific plugins

This PR needs https://github.com/NixOS/nixpkgs/pull/83136 to be merged first for this to work

Example of this feature in use:

```nix
{ pkgs, ... }:

{
programs.rofi = {
  enable = true;
  plugins = with pkgs; [ rofi-calc ];
};
}
```