### PR TITLE
Fix and improve systemd activation

### DIFF
--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -41,7 +41,7 @@ def setup_services(old_gen_path, new_gen_path, start_timeout_ms_string)
 
   # Exclude services that aren't allowed to be manually started or stopped
   no_manual_start, no_manual_stop, no_restart = get_restricted_units(to_stop + to_restart + to_start)
-  to_stop -= no_manual_stop + no_restart
+  to_stop -= no_manual_stop
   to_restart -= no_manual_stop + no_manual_start + no_restart
   to_start -= no_manual_start
 

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -39,13 +39,12 @@ def setup_services(old_gen_path, new_gen_path, start_timeout_ms_string)
 
   raise "daemon-reload failed" unless run_cmd('systemctl', '--user', 'daemon-reload')
 
-  # Exclude services that aren't allowed to be manually started or stopped
+  # Exclude units that shouldn't be (re)started or stopped
   no_manual_start, no_manual_stop, no_restart = get_restricted_units(to_stop + to_restart + to_start)
+  notify_skipped_units(to_restart & no_restart)
   to_stop -= no_manual_stop
   to_restart -= no_manual_stop + no_manual_start + no_restart
   to_start -= no_manual_start
-
-  puts "Not restarting: #{no_restart.join(' ')}" unless no_restart.empty?
 
   if to_stop.empty? && to_start.empty? && to_restart.empty?
     print_service_msg("All services are already running", services_to_run)
@@ -195,6 +194,10 @@ def print_service_msg(msg, services)
   else
     puts msg
   end
+end
+
+def notify_skipped_units(no_restart)
+  puts "Not restarting: #{no_restart.join(' ')}" unless no_restart.empty?
 end
 
 setup_services(*ARGV)

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -146,6 +146,10 @@ def get_inactive_units(units)
   filter_units(units) { |state| state != 'active' }
 end
 
+def get_failed_units(units)
+  filter_units(units) { |state| state == 'failed' }
+end
+
 def filter_units(units)
   return [] if units.empty?
   states = systemctl('is-active', *units).split
@@ -173,7 +177,7 @@ def wait_and_get_failed_services(services, start_timeout_ms)
   # Force the previous message to always be visible before sleeping
   STDOUT.flush
   sleep(start_timeout_ms / 1000.0)
-  get_inactive_units(services)
+  get_failed_units(services)
 end
 
 def show_failed_services_status(services)

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -159,7 +159,6 @@ end
 def get_restricted_units(units)
   infos = systemctl('show', '-p', 'RefuseManualStart', '-p', 'RefuseManualStop', *units)
           .split("\n\n")
-  no_restart = []
   no_manual_start = []
   no_manual_stop = []
   infos.zip(units).each do |info, unit|
@@ -169,11 +168,7 @@ def get_restricted_units(units)
   end
   # Get units that should not be restarted even if a change has been detected.
   no_restart_regexp = /^\s*X-RestartIfChanged\s*=\s*false\b/
-  units.each do |unit|
-    if systemctl('cat', unit) =~ no_restart_regexp
-      no_restart << unit
-    end
-  end
+  no_restart = units.select { |unit| systemctl('cat', unit) =~ no_restart_regexp }
   [no_manual_start, no_manual_stop, no_restart]
 end
 

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -139,20 +139,17 @@ def print_cmd(cmd)
 end
 
 def get_active_units(units)
-  get_units_by_activity(units, true)
+  filter_units(units) { |state| state == 'active' }
 end
 
 def get_inactive_units(units)
-  get_units_by_activity(units, false)
+  filter_units(units) { |state| state != 'active' }
 end
 
-def get_units_by_activity(units, active)
+def filter_units(units)
   return [] if units.empty?
-  units = units.to_a
-  is_active = systemctl('is-active', *units).split
-  units.select.with_index do |_, i|
-    (is_active[i] == 'active') == active
-  end
+  states = systemctl('is-active', *units).split
+  units.select.with_index { |_, i| yield states[i] }
 end
 
 def get_restricted_units(units)

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -52,9 +52,9 @@ def setup_services(old_gen_path, new_gen_path, start_timeout_ms_string)
     print_service_msg("All services are already running", services_to_run)
   else
     puts "Setting up services" if @verbose
-    systemctl('stop', to_stop)
-    systemctl('start', to_start)
-    systemctl('restart', to_restart)
+    systemctl_action('stop', to_stop)
+    systemctl_action('start', to_start)
+    systemctl_action('restart', to_restart)
     started_services = to_start + to_restart
     if start_timeout_ms > 0 && !started_services.empty? && !@dry_run
       failed = wait_and_get_failed_services(started_services, start_timeout_ms)
@@ -106,7 +106,7 @@ def run_cmd(*cmd)
   @dry_run || system(*cmd)
 end
 
-def systemctl(cmd, services)
+def systemctl_action(cmd, services)
   return if services.empty?
 
   verb = (cmd == 'stop') ? 'Stopping' : "#{cmd.capitalize}ing"

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -27,14 +27,17 @@ def setup_services(old_gen_path, new_gen_path, start_timeout_ms_string)
 
   exit if old_services.empty? && new_services.empty?
 
+  all_services = get_active_targets_units(new_units_path)
+  maybe_changed = all_services & old_services
+  changed_services = get_changed_services(old_units_path, new_units_path, maybe_changed)
+
   # These services should be running when this script is finished
-  services_to_run = get_active_targets_units(new_units_path)
-  maybe_changed_services = services_to_run & old_services
+  services_to_run = all_services
 
   # Only stop active services, otherwise we might get a 'service not loaded' error
   # for inactive services that were removed in the current generation.
   to_stop = get_active_units(old_services - new_services)
-  to_restart = get_changed_services(old_units_path, new_units_path, maybe_changed_services)
+  to_restart = changed_services
   to_start = get_inactive_units(services_to_run - to_restart)
 
   raise "daemon-reload failed" unless run_cmd('systemctl', '--user', 'daemon-reload')

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -167,11 +167,10 @@ def get_restricted_units(units)
     no_manual_start << unit if no_start.end_with?('yes')
     no_manual_stop << unit if no_stop.end_with?('yes')
   end
-  # Regular expression that indicates that a service should not be
-  # restarted even if a change has been detected.
-  restartRe = /^[ \t]*X-RestartIfChanged[ \t]*=[ \t]*false[ \t]*(?:#.*)?$/
+  # Get units that should not be restarted even if a change has been detected.
+  no_restart_regexp = /^\s*X-RestartIfChanged\s*=\s*false\b/
   units.each do |unit|
-    if systemctl('cat', unit) =~ restartRe
+    if systemctl('cat', unit) =~ no_restart_regexp
       no_restart << unit
     end
   end

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -28,7 +28,7 @@ def setup_services(old_gen_path, new_gen_path, start_timeout_ms_string)
   exit if old_services.empty? && new_services.empty?
 
   # These services should be running when this script is finished
-  services_to_run = get_services_to_run(new_units_path)
+  services_to_run = get_active_targets_units(new_units_path)
   maybe_changed_services = services_to_run & old_services
 
   # Only stop active services, otherwise we might get a 'service not loaded' error
@@ -87,15 +87,15 @@ end
 
 TargetDirRegexp = /^(.*\.target)\.wants$/
 
-# @return all services wanted by active targets
-def get_services_to_run(units_dir)
+# @return all units wanted by active targets
+def get_active_targets_units(units_dir)
   return Set.new unless Dir.exists?(units_dir)
   targets = Dir.entries(units_dir).map { |entry| entry[TargetDirRegexp, 1] }.compact
   active_targets = get_active_units(targets)
-  services_to_run = active_targets.map do |target|
+  active_units = active_targets.map do |target|
     get_service_files(File.join(units_dir, "#{target}.wants"))
   end.flatten
-  Set.new(services_to_run)
+  Set.new(active_units)
 end
 
 # @return true on success

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -38,7 +38,7 @@ def setup_services(old_gen_path, new_gen_path, start_timeout_ms_string)
   to_restart = get_changed_services(old_units_path, new_units_path, maybe_changed_services)
   to_start = get_inactive_units(services_to_run - to_restart)
 
-  raise "daemon-reload failed" unless run_cmd('systemctl --user daemon-reload')
+  raise "daemon-reload failed" unless run_cmd('systemctl', '--user', 'daemon-reload')
 
   # Exclude services that aren't allowed to be manually started or stopped
   no_manual_start, no_manual_stop, no_restart = get_restricted_units(to_stop + to_restart + to_start)
@@ -101,9 +101,9 @@ def get_services_to_run(units_dir)
 end
 
 # @return true on success
-def run_cmd(cmd)
+def run_cmd(*cmd)
   print_cmd cmd
-  @dry_run || system(cmd)
+  @dry_run || system(*cmd)
 end
 
 def systemctl(cmd, services)
@@ -132,7 +132,7 @@ def systemctl(cmd, services)
 end
 
 def print_cmd(cmd)
-  puts cmd if @verbose || @dry_run
+  puts [*cmd].join(' ') if @verbose || @dry_run
 end
 
 def get_active_units(units)
@@ -186,7 +186,7 @@ end
 def show_failed_services_status(services)
   puts
   services.each do |service|
-    run_cmd("systemctl --user status #{service.shellescape}")
+    run_cmd('systemctl', '--user', 'status', service)
     puts
   end
 end

--- a/modules/systemd-activate.rb
+++ b/modules/systemd-activate.rb
@@ -113,7 +113,7 @@ def systemctl_action(cmd, services)
 
   cmd = ['systemctl', '--user', cmd, *services]
   if @dry_run
-    puts cmd
+    puts cmd.join(' ')
     return
   end
 


### PR DESCRIPTION
The first three commits remove the dependency on shellwords.
Instead of shell quoting a command and passing it to a subshell, it's idiomatic Ruby to bypass the shell and directly start a subprocess.

[This script](https://gist.github.com/0a2badcf3ac688e2a01f20484f579565) tests all features from this PR.