### PR TITLE
vim: avoid using alias of vim-sensible

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.programs.vim;
-  defaultPlugins = [ pkgs.vimPlugins.sensible ];
+  defaultPlugins = [ pkgs.vimPlugins.vim-sensible ];
 
   knownSettings = {
     background = types.enum [ "dark" "light" ];


### PR DESCRIPTION
I am doing some work on the nixpkgs vim infra that broke vim aliases for me, which made me spot this.