### PR TITLE
modules.services.xscreensaver: Add user service command

### DIFF
--- a/modules/services/xscreensaver.nix
+++ b/modules/services/xscreensaver.nix
@@ -25,6 +25,13 @@ in {
           The settings to use for XScreenSaver.
         '';
       };
+
+      command = mkOption {
+        type = types.str;
+        default = "${pkgs.xscreensaver}/bin/xscreensaver -no-splash";
+        example = "${config.home.homeDirectory}/bin/wrapped-xscreensaver";
+        description = "Command to start the xscreensaver";
+      };
     };
   };
 
@@ -42,9 +49,7 @@ in {
         PartOf = [ "graphical-session.target" ];
       };
 
-      Service = {
-        ExecStart = "${pkgs.xscreensaver}/bin/xscreensaver -no-splash";
-      };
+      Service = { ExecStart = services.xscreensaver.command; };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };
     };


### PR DESCRIPTION
Users may want to define their own command to start the service.

Personally, i cannot use the nix's xscreensaver program on my debian box (once
locked, no password prompt and plenty of pam errors). With the exact same home
on a nixos box, no issue whatsoever. I have searched and tried to fix it to no
avail so far. I think it's related to pam (/etc/pam.d/xscreensaver is clearly
different between debian and NixOS). That's another issue altogether (other lockers
face the same issue either way ;)

Anyway, right now, i'm working around it using an xscreensaver-wrapper script.
It fallbacks to use /usr/bin/xscreensaver (if found) over the one installed in
my nix profile (the debian one has no issue either).

But right now, to do so, i'm defining my own systemd service. As the need could
be shared, i thought of opening this command option here.

Note:
Even though i read the docs, looked through issues, and was hinted at `home-manager -f` command on irc (thanks again), i did not find the right command stanza to try and build locally. So i rely on the ci to tell me if i messed up or not.

Cheers,
