### PR TITLE
firefox: backport extensions fix to release-19.09

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1222,6 +1222,32 @@ in
           A new module is available: 'programs.readline'.
         '';
       }
+
+      {
+        time = "2020-03-15T16:55:28+00:00";
+        condition = config.programs.firefox.enable;
+        message = ''
+          In anticipation of Firefox dropping support for extension
+          sideloading[1], we now install extensions directly to
+          Firefox profiles managed through Home Manager's
+
+            'programs.firefox.profiles'
+
+          option.
+
+          Unfortunately this will most likely trigger an "Existing
+          file is in the way" error when activating your configuration
+          since Firefox keeps a copy of the add-on in the location
+          Home Manager wants to overwrite. If this is the case, remove
+          the listed '.xpi' files and try again.
+
+          This change also means that extensions installed through
+          Home Manager may disappear from unmanaged profiles in future
+          Firefox releases.
+
+          [1] https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/
+        '';
+      }
     ];
   };
 }


### PR DESCRIPTION
Backport of fixes for `programs.firefox.extensions` from `master` to `release-19.09`.
`master` commit with the changes: https://github.com/rycee/home-manager/commit/cc386e4b3b3dbb6fb5d02e657afeacf218911d96.
Related issue: https://github.com/rycee/home-manager/issues/1096.

Successfully tested with Firefox `74.0.1` against https://github.com/acmilanfan/nixos-configs/blob/master/home-manager/configs/firefox.nix#L4. (A new clean profile was used).
NixOS version: `19.09`
Home-manager channel: `release-19.09`