### PR TITLE
qutebrowser: add support for list values in settings

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -15,6 +15,8 @@ let
           (if v then "True" else "False")
         else if builtins.isString v then
           ''"${v}"''
+        else if builtins.isList v then
+          "[${concatStringsSep ", " (map formatValue v)}]"
         else
           builtins.toString v;
     in if builtins.isAttrs v then

--- a/tests/modules/programs/qutebrowser/settings.nix
+++ b/tests/modules/programs/qutebrowser/settings.nix
@@ -15,6 +15,7 @@ with lib;
           };
           tabs.bar.bg = "#000000";
         };
+        spellcheck.languages = [ "en-US" "sv-SE" ];
         tabs.tabs_are_windows = true;
       };
 
@@ -37,6 +38,7 @@ with lib;
             c.colors.hints.bg = "#000000"
             c.colors.hints.fg = "#ffffff"
             c.colors.tabs.bar.bg = "#000000"
+            c.spellcheck.languages = ["en-US", "sv-SE"]
             c.tabs.tabs_are_windows = True
             # Extra qutebrowser configuration.
           ''


### PR DESCRIPTION
### Description

Add support for list values in qutebrowser settings.

Input:
```
settings.spellcheck.languages = [ "en-US" "sv-SE" ];
```

Output:
```
c.spellcheck.languages = ["en-US", "sv-SE"]
```

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
  (Partly lie, I get an unrelated error
   `lieer-service: FAILED Expected home-files/.config/systemd/user/lieer-hm-example-com.service to exist but it was not found.`, also got this same error on master)


- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
