### PR TITLE
gnome-terminal: add `cursorBlinkMode` option

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -81,6 +81,12 @@ let
         description = "The terminal colors, null to use system default.";
       };
 
+      cursorBlinkMode = mkOption {
+        default = "system";
+        type = types.enum [ "system" "on" "off" ];
+        description = "The cursor blink mode.";
+      };
+
       cursorShape = mkOption {
         default = "block";
         type = types.enum [ "block" "ibeam" "underline" ];
@@ -130,6 +136,7 @@ let
       scrollbar-policy = if pcfg.showScrollbar then "always" else "never";
       scrollback-lines = pcfg.scrollbackLines;
       cursor-shape = pcfg.cursorShape;
+      cursor-blink-mode = pcfg.cursorBlinkMode;
     } // (if (pcfg.font == null) then {
       use-system-font = true;
     } else {


### PR DESCRIPTION
### Description

Option to configure blink mode for GNOME terminal.

First time contributing to HM so please let me know if any changes are needed.


### Checklist

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
  
  `xsession` and `lieer-services` tests are failing but this appears to be unrelated and are also
  failing for me on master

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.