### PR TITLE
kanshi: add service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,6 +134,9 @@
 
 /modules/services/imapnotify.nix                      @nickhu
 
+/modules/services/kanshi.nix                          @nurelin
+/tests/modules/services/kanshi                        @nurelin
+
 /modules/services/kdeconnect.nix                      @adisbladis
 
 /modules/services/keepassx.nix                        @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1619,6 +1619,14 @@ in
           A new module is available: 'services.dropbox'.
         '';
       }
+
+      {
+        time = "2020-07-26T09:30:10+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.kanshi'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -139,6 +139,7 @@ let
     (loadModule ./services/grobi.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/hound.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/imapnotify.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./services/kanshi.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/kbfs.nix { })
     (loadModule ./services/kdeconnect.nix { })
     (loadModule ./services/keepassx.nix { })

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -1,0 +1,194 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.kanshi;
+
+  outputModule = types.submodule {
+    options = {
+
+      criteria = mkOption {
+        type = types.str;
+        description = ''
+          The criteria can either be an output name, an output description or "*".
+          The latter can be used to match any output.
+
+          On
+          <citerefentry>
+            <refentrytitle>sway</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>
+          , output names and descriptions can be obtained via
+          <literal>swaymsg -t get_outputs</literal>.
+        '';
+      };
+
+      status = mkOption {
+        type = types.nullOr (types.enum [ "enable" "disable" ]);
+        default = null;
+        description = ''
+          Enables or disables the specified output.
+        '';
+      };
+
+      mode = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "1920x1080@60Hz";
+        description = ''
+          &lt;width&gt;x&lt;height&gt;[@&lt;rate&gt;[Hz]]
+          </para><para>
+          Configures the specified output to use the specified mode.
+          Modes are a combination of width and height (in pixels) and
+          a refresh rate (in Hz) that your display can be configured to use.
+        '';
+      };
+
+      position = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "1600,0";
+        description = ''
+          &lt;x&gt;,&lt;y&gt;
+          </para><para>
+          Places the output at the specified position in the global coordinates
+          space.
+        '';
+      };
+
+      scale = mkOption {
+        type = types.nullOr types.float;
+        default = null;
+        example = 2;
+        description = ''
+          Scales the output by the specified scale factor.
+        '';
+      };
+
+      transform = mkOption {
+        type = types.nullOr (types.enum [
+          "normal"
+          "90"
+          "180"
+          "270"
+          "flipped"
+          "flipped-90"
+          "flipped-180"
+          "flipped-270"
+        ]);
+        default = null;
+        description = ''
+          Sets the output transform.
+        '';
+      };
+    };
+  };
+
+  outputStr = { criteria, status, mode, position, scale, transform, ... }:
+    ''output "${criteria}"'' + optionalString (status != null) " ${status}"
+    + optionalString (mode != null) " mode ${mode}"
+    + optionalString (position != null) " position ${position}"
+    + optionalString (scale != null) " scale ${toString scale}"
+    + optionalString (transform != null) " transform ${transform}";
+
+  profileModule = types.submodule {
+    options = {
+      outputs = mkOption {
+        type = types.listOf outputModule;
+        default = [ ];
+        description = ''
+          Outputs configuration.
+        '';
+      };
+
+      exec = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = literalExample
+          "\${pkg.sway}/bin/swaymsg workspace 1, move workspace to eDP-1";
+        description = ''
+          Command executed after the profile is succesfully applied.
+        '';
+      };
+    };
+  };
+
+  profileStr = name:
+    { outputs, exec, ... }:
+    ''
+      profile ${name} {
+        ${concatStringsSep "\n  " (map outputStr outputs)}
+    '' + optionalString (exec != null) "  ${exec}" + ''
+      }
+    '';
+in {
+
+  meta.maintainers = [ maintainers.nurelin ];
+
+  options.services.kanshi = {
+    enable = mkEnableOption
+      "kanshi, a Wayland daemon that automatically configures outputs";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.kanshi;
+      defaultText = literalExample "pkgs.kanshi";
+      description = ''
+        kanshi derivation to use.
+      '';
+    };
+
+    profiles = mkOption {
+      type = types.attrsOf profileModule;
+      default = { };
+      description = ''
+        List of profiles.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra configuration lines to append to the kanshi
+        configuration file.
+      '';
+    };
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "sway-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    xdg.configFile."kanshi/config".text = ''
+      ${concatStringsSep "\n" (mapAttrsToList profileStr cfg.profiles)}
+      ${cfg.extraConfig}
+    '';
+
+    systemd.user.services.kanshi = {
+      Unit = {
+        Description = "Dynamic output configuration";
+        Documentation = "man:kanshi(1)";
+        PartOf = cfg.systemdTarget;
+        Requires = cfg.systemdTarget;
+        After = cfg.systemdTarget;
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/kanshi";
+        Restart = "always";
+      };
+
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -82,6 +82,7 @@ import nmt {
     ./modules/programs/getmail
     ./modules/services/lieer
     ./modules/programs/rofi
+    ./modules/services/kanshi
     ./modules/services/polybar
     ./modules/services/sxhkd
     ./modules/services/fluidsynth

--- a/tests/modules/services/kanshi/basic-configuration.conf
+++ b/tests/modules/services/kanshi/basic-configuration.conf
@@ -1,0 +1,14 @@
+profile desktop {
+  output "eDP-1" disable
+  output "Iiyama North America PLE2483H-DP" enable position 0,0
+  output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
+}
+
+profile nomad {
+  output "eDP-1" enable
+}
+
+profile test {
+  output "*" enable
+}
+

--- a/tests/modules/services/kanshi/basic-configuration.nix
+++ b/tests/modules/services/kanshi/basic-configuration.nix
@@ -1,0 +1,51 @@
+{ config, pkgs, ... }: {
+  config = {
+    services.kanshi = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-kanshi" "";
+      profiles = {
+        nomad = {
+          outputs = [{
+            criteria = "eDP-1";
+            status = "enable";
+          }];
+        };
+        desktop = {
+          outputs = [
+            {
+              criteria = "eDP-1";
+              status = "disable";
+            }
+            {
+              criteria = "Iiyama North America PLE2483H-DP";
+              status = "enable";
+              position = "0,0";
+            }
+            {
+              criteria = "Iiyama North America PLE2483H-DP 1158765348486";
+              status = "enable";
+              position = "1920,0";
+              scale = 2.1;
+              mode = "1920x1080";
+              transform = "flipped-270";
+            }
+          ];
+        };
+      };
+      extraConfig = ''
+        profile test {
+          output "*" enable
+        }
+      '';
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/kanshi.service
+      assertFileExists $serviceFile
+
+      assertFileExists home-files/.config/kanshi/config
+      assertFileContent home-files/.config/kanshi/config \
+                ${./basic-configuration.conf}
+    '';
+  };
+}

--- a/tests/modules/services/kanshi/default.nix
+++ b/tests/modules/services/kanshi/default.nix
@@ -1,0 +1,1 @@
+{ kanshi-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

Add kanshi service for use as output configuration with wayland windows manager (e.g. sway)

### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

Some tests have failed but I do not think that I caused this:

```
lieer-service: FAILED
Expected home-files/.config/systemd/user/lieer-hm-example-com.service to exist but it was not found.
For further reference please introspect /nix/store/7ddwv7mgcr9dg9x41haxi3pfs5jkv8xl-nmt-report-lieer-service

xsession-basic: FAILED
Expected home-files/.config/systemd/user/setxkbmap.service to exist but it was not found.
For further reference please introspect /nix/store/1g4jyzj1qsmbdi0yjn0ai9qblnbplshc-nmt-report-xsession-basic

xsession-keyboard-without-layout: FAILED
Expected home-files/.config/systemd/user/setxkbmap.service to exist but it was not found.
For further reference please introspect /nix/store/agmafi4b5hgw3djmgac063lx2c8lgzf8-nmt-report-xsession-keyboard-without-layout
```

- [X] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
