### PR TITLE
tmpfiles: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,8 @@
 
 /modules/misc/submodule-support.nix                   @rycee
 
+/modules/misc/tmpfiles.nix                            @dawidsowa
+
 /modules/misc/xdg-mime-apps.nix                       @pacien
 
 /modules/misc/xdg-user-dirs.nix                       @pacien

--- a/modules/misc/tmpfiles.nix
+++ b/modules/misc/tmpfiles.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.systemd.user.tmpfiles;
+in {
+  meta.maintainers = [ maintainers.dawidsowa ];
+
+  options.systemd.user.tmpfiles.rules = mkOption {
+    type = types.listOf types.str;
+    default = [ ];
+    example = [ "L /home/user/Documents - - - - /mnt/data/Documents" ];
+    description = ''
+      Rules for creating and cleaning up temporary files
+      automatically. See
+      <citerefentry><refentrytitle>tmpfiles.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+      for the exact format.
+    '';
+  };
+
+  config = mkIf (cfg.rules != [ ]) {
+    xdg = {
+      dataFile."user-tmpfiles.d/home-manager.conf" = {
+        text = ''
+          # This file is created automatically and should not be modified.
+          # Please change the option ‘systemd.user.tmpfiles.rules’ instead.
+          ${concatStringsSep "\n" cfg.rules}
+        '';
+        onChange = "${pkgs.systemd}/bin/systemd-tmpfiles --user --create";
+      };
+      configFile = {
+        "systemd/user/basic.target.wants/systemd-tmpfiles-setup.service".source =
+          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";
+        "systemd/user/systemd-tmpfiles-setup.service".source =
+          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";
+        "systemd/user/timers.target.wants/systemd-tmpfiles-clean.timer".source =
+          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-clean.timer";
+        "systemd/user/systemd-tmpfiles-clean.service".source =
+          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-clean.service";
+      };
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -36,6 +36,7 @@ let
     (loadModule ./misc/pam.nix { })
     (loadModule ./misc/qt.nix { })
     (loadModule ./misc/submodule-support.nix { })
+    (loadModule ./misc/tmpfiles.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/xdg-mime.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime-apps.nix { condition = hostPlatform.isLinux; })


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

This module allows configuring [user-tmpfiles.d](https://www.freedesktop.org/software/systemd/man/tmpfiles.d.html#) similarily to NixOS's [systemd.tmpfiles.rules](https://nixos.org/nixos/options.html#systemd.tmpfiles.rules).
### Checklist

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
