### PR TITLE
lorri: allow customization of the lorri package

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -9,10 +9,19 @@ let
 in {
   meta.maintainers = [ maintainers.gerschtli ];
 
-  options = { services.lorri.enable = mkEnableOption "lorri build daemon"; };
+  options.services.lorri = {
+    enable = mkEnableOption "lorri build daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.lorri;
+      defaultText = literalExample "pkgs.lorri";
+      description = "Which lorri package to install";
+    };
+  };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.lorri ];
+    home.packages = [ cfg.package ];
 
     systemd.user = {
       services.lorri = {
@@ -24,7 +33,7 @@ in {
         };
 
         Service = {
-          ExecStart = "${pkgs.lorri}/bin/lorri daemon";
+          ExecStart = "${cfg.package}/bin/lorri daemon";
           PrivateTmp = true;
           ProtectSystem = "strict";
           ProtectHome = "read-only";


### PR DESCRIPTION
### Description

Allow me to install a different Lorri package with the new package option.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
