### PR TITLE
fish: add initFile option

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -14,7 +14,7 @@ let
           Path to the plugin folder.
           </para><para>
           Relevant pieces will be added to the fish function path and
-          the completion path. The <filename>init.fish</filename> and
+          the completion path. The <filename>$initFile</filename> and
           <filename>key_binding.fish</filename> files are sourced if
           they exist.
         '';
@@ -24,6 +24,14 @@ let
         type = types.str;
         description = ''
           The name of the plugin.
+        '';
+      };
+
+      initFile = mkOption {
+        type = types.str;
+        default = "init.fish";
+        description = ''
+          Path to the init file that will be sourced.
         '';
       };
     };
@@ -448,8 +456,8 @@ in {
             source $plugin_dir/key_bindings.fish
           end
 
-          if test -f $plugin_dir/init.fish
-            source $plugin_dir/init.fish
+          if test -f $plugin_dir/${plugin.initFile}.fish
+            source $plugin_dir/${plugin.initFile}.fish
           end
         '';
       }) cfg.plugins));


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

Now you can specify plugin init file.


### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
