### PR TITLE
kakoune: implement whitespace highlighter

### DIFF
--- a/format
+++ b/format
@@ -17,6 +17,7 @@ esac
 # requests and we want to avoid merge conflicts.
 find . -name '*.nix' \
   ! -path ./modules/programs/irssi.nix \
+  ! -path ./tests/modules/programs/kakoune/whitespace-highlighter.nix \
   \
   ! -path ./home-manager/default.nix \
   ! -path ./home-manager/home-manager.nix \

--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -513,6 +513,15 @@ let
         "${optionalString (separator != null) " -separator ${separator}"}"
       ];
 
+    showWhitespaceOptions = with cfg.config.showWhitespace;
+      concatStrings [
+        (optionalString (tab != null) " -tab ${tab}")
+        (optionalString (tabStop != null) " -tabpad ${tabStop}")
+        (optionalString (space != null) " -spc ${space}")
+        (optionalString (nonBreakingSpace != null) " -nbsp ${nonBreakingSpace}")
+        (optionalString (lineFeed != null) " -lf ${lineFeed}")
+      ];
+
     uiOptions = with cfg.config.ui;
       concatStringsSep " " [
         "ncurses_set_title=${if setTitle then "true" else "false"}"
@@ -572,6 +581,8 @@ let
         ++ optional (numberLines != null && numberLines.enable)
         "add-highlighter global/ number-lines${numberLinesOptions}"
         ++ optional showMatching "add-highlighter global/ show-matching"
+        ++ optional (showWhitespace != null && showWhitespace.enable)
+        "add-highlighter global/ show-whitespaces${showWhitespaceOptions}"
         ++ optional (scrollOff != null)
         "set-option global scrolloff ${toString scrollOff.lines},${
           toString scrollOff.columns

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -32,6 +32,7 @@ import nmt {
     ./modules/programs/fish
     ./modules/programs/git
     ./modules/programs/gpg
+    ./modules/programs/kakoune
     ./modules/programs/lieer
     ./modules/programs/mbsync
     ./modules/programs/neomutt

--- a/tests/modules/programs/kakoune/default.nix
+++ b/tests/modules/programs/kakoune/default.nix
@@ -1,0 +1,1 @@
+{ kakoune-whitespace-highlighter = ./whitespace-highlighter.nix; }

--- a/tests/modules/programs/kakoune/whitespace-highlighter.nix
+++ b/tests/modules/programs/kakoune/whitespace-highlighter.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.kakoune = {
+      enable = true;
+      config.showWhitespace = {
+        enable = true;
+        lineFeed = "1";
+        space = "2";
+        nonBreakingSpace = "3";
+        tab = "4";
+        tabStop = "5";
+      };
+    };
+
+    nmt.script = let
+      lineStart =
+        ''^add-highlighter\s\+global\/\?\s\+show-whitespaces\s\+'' +
+        ''\(-\w\+\s\+.\s\+\)*'';
+    in ''
+      assertFileExists home-files/.config/kak/kakrc
+      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-lf\s\+1\b'
+      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-spc\s\+2\b'
+      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-nbsp\s\+3\b'
+      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-tab\s\+4\b'
+      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-tabpad\s\+5\b'
+    '';
+  };
+}


### PR DESCRIPTION
`programs.kakoune.config.showWhitespace` existed but was not implemented.

I added the test to the formatter's skip list because it adds even more escapes to the regex.

### Checklist

- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`. *(no new failures)*
- [x] Test cases updated/added.
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```