### PR TITLE
FAQ: Documents command to add the nixpkgs-unstable channel

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -146,7 +146,13 @@ in
 }
 ```
 
-should work provided you have a Nix channel called `nixpkgs-unstable`.
+should work provided you have a Nix channel called `nixpkgs-unstable`. 
+
+You can add the `nixpkgs-unstable` channel running:
+```
+nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs-unstable
+```
+
 Note, the package will not be affected by any package overrides,
 overlays, etc.
 


### PR DESCRIPTION
### Description

Adds the necessary command to install the `nixpkgs-unstable` channel
