### PR TITLE
nixos: profile/gcroot creation

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -88,6 +88,17 @@ in {
       (mapAttrs (username: usercfg: { packages = usercfg.home.packages; })
         cfg.users);
 
+    # make sure the home-manager gcroot and the profile is created
+    system.activationScripts = mapAttrs' (_: usercfg:
+      let username = usercfg.home.username;
+      in nameValuePair "hm-base-dirs-${username}" {
+        text = ''
+          mkdir -p /nix/var/nix/profiles/per-user/${username}/
+          mkdir -p /nix/var/nix/gcroots/per-user/${username}/
+        '';
+        deps = [ ];
+      }) cfg.users;
+
     systemd.services = mapAttrs' (_: usercfg:
       let username = usercfg.home.username;
       in nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {


### PR DESCRIPTION
# Description
make sure that the profile directory and the gcroot of the user exists
while starting the home-manager user unit. This fixes #948

### Checklist

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
