### PR TITLE
systemd: don't page failed user units

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -249,7 +249,7 @@ in
             if [[ $systemdStatus == 'running' || $systemdStatus == 'degraded' ]]; then
               if [[ $systemdStatus == 'degraded' ]]; then
                 warnEcho "The user systemd session is degraded:"
-                ${systemctl} --user --state=failed
+                ${systemctl} --user --no-pager --state=failed
                 warnEcho "Attempting to reload services anyway..."
               fi
 


### PR DESCRIPTION

<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

Otherwise, the pager (typically `less`) pauses execution of
`home-manager switch` until the pager is dismissed, if the content is
larger than would fit on the screen.


### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
  - No more tests fail than fail on master (there are 3 that do, at least on my system: `xsession-keyboard-without-layout`, `xsession-basic`, `lieer-service`).

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are properly formatted.

---

I ran into this when trying to run `home-manager switch` in a floating terminal. `less` popped up and paused execution, which I didn't notice until 18 minutes later.

Additionally, when running tests, I see the following (on master, as well):

```
trace: warning: In file /home/vin/workspace/vcs/home-manager/tests/lib/types/list-or-dag-merge.nix
a list is being assigned to the option 'tested.dag'.
This will soon be an error due to the list form being deprecated.
Please use the attribute set form instead with DAG functions to
express the desired order of entries.
```