### PR TITLE
fish: fix fish plugins complete path update

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -436,7 +436,7 @@ in {
           end
 
           if test -d $plugin_dir/completions
-            set fish_complete_path $fish_function_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
+            set fish_complete_path $fish_complete_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
           end
 
           # Source initialization code if it exists.

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -16,7 +16,7 @@ let
     end
 
     if test -d $plugin_dir/completions
-      set fish_complete_path $fish_function_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
+      set fish_complete_path $fish_complete_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
     end
 
     # Source initialization code if it exists.


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

Currently when installing plugins with completions it will update the completion and due to a type pop the first item and then add the function path into there. Resulting in functions being loaded as completions and also the first item in the completion list being lost.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
