### PR TITLE
kakoune: add missing hook name

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -49,6 +49,7 @@ let
           "InsertCompletionShow"
           "InsertCompletionHide"
           "InsertCompletionSelect"
+          "ModuleLoaded"
         ];
         example = "SetOption";
         description = ''


### PR DESCRIPTION
### Description

The `ModuleLoaded` hook was missing.

### Checklist

- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- ~[ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```