### PR TITLE
genericLinux: fix infinite recursion error

### DIFF
--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -16,7 +16,7 @@ in {
 
   config = mkIf config.targets.genericLinux.enable {
     home.sessionVariables = let
-      profiles = [ "/nix/var/nix/profiles/default" profileDirectory ];
+      profiles = [ "/nix/var/nix/profiles/default" "$HOME/.nix-profile" ];
       dataDirs =
         concatStringsSep ":" (map (profile: "${profile}/share") profiles);
     in { XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"; };

--- a/tests/modules/targets/generic-linux-session-vars-expected.txt
+++ b/tests/modules/targets/generic-linux-session-vars-expected.txt
@@ -2,5 +2,5 @@
 if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
 export __HM_SESS_VARS_SOURCED=1
 
-export XDG_DATA_DIRS="/nix/var/nix/profiles/default/share:/homeless-shelter/.nix-profile/share${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"
+export XDG_DATA_DIRS="/nix/var/nix/profiles/default/share:$HOME/.nix-profile/share${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"
 . "@nix@/etc/profile.d/nix.sh"


### PR DESCRIPTION
### Description

I found an "infinite recursion error" when using home-manager as submodule.
The reason for this error is that `home.profileDirectory` is set to `home.path` if in submodule mode. The `home.sessionVariables` in turn are needed to create `home.path`.

Do you see an issue in this PR? IMO this should work for all cases.

Follow up to https://github.com/rycee/home-manager/pull/797

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
