### PR TITLE
starship: check if $TERM == "dumb" to fix issue with emacs tramp

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -89,7 +89,7 @@ in {
       mkIf (cfg.settings != { }) { source = configFile cfg.settings; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      if [[ -z $INSIDE_EMACS ]]; then
+      if [[ -z $INSIDE_EMACS ]] && [[ $TERM != "dumb" ]]; then
         eval "$(${cfg.package}/bin/starship init bash)"
       fi
     '';

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -89,7 +89,7 @@ in {
       mkIf (cfg.settings != { }) { source = configFile cfg.settings; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      if [[ -z $INSIDE_EMACS ]] && [[ $TERM != "dumb" ]]; then
+      if [ "$TERM" != "dumb" -o -n "$INSIDE_EMACS" ]; then
         eval "$(${cfg.package}/bin/starship init bash)"
       fi
     '';


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

`INSIDE_EMACS` is not set when using emacs TRAMP. https://emacs.stackexchange.com/questions/57977/tramp-inside-emacs-isnt-defined-while-bashrc-is-processed

I didn't touch `zsh` and `fish` since I couldn't test them.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
