### PR TITLE
vdirsyncer: fix undefined variable 'mkList'

### DIFF
--- a/modules/programs/vdirsyncer.nix
+++ b/modules/programs/vdirsyncer.nix
@@ -107,14 +107,14 @@ let
     let
            contents = map (c: if (isString c)
                           then ''"${c}"''
-                          else mkList (map wrapString c)) v;
+                          else listString (map wrap c)) v;
     in ''collections = ${if ((isNull v) || v == []) then "null" else listString contents}''
   else if (n == "conflictResolution") then
     if v == "remote wins"
       then ''conflict_resolution = "a wins"''
       else if v == "local wins"
       then ''conflict_resolution = "b wins"''
-      else ''conflict_resolution = ${mkList (map wrapString (["command"] ++ v))}''
+      else ''conflict_resolution = ${listString (map wrap (["command"] ++ v))}''
   else throw "Unrecognized option: ${n}";
 
   attrsString = a: concatStringsSep "\n" (mapAttrsToList optionString a);


### PR DESCRIPTION
... at .../modules/programs/vdirsyncer.nix:117:38
change to listString

<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description



### Checklist

- [ ] Code formatted with `./format`. **This would change about all files, since this draft branch is based on an old master.**

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```