### PR TITLE
tmux: use stable plugin names (name -> pname)

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.programs.tmux;
 
-  pluginName = p: if types.package.check p then p.name else p.plugin.name;
+  pluginName = p: if types.package.check p then p.pname else p.plugin.pname;
 
   pluginModule = types.submodule {
     options = {

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -302,7 +302,9 @@ in
           # Load plugins with Home Manager                #
           # --------------------------------------------- #
 
-          ${(concatMapStringsSep "\n" (p: ''
+          ${(concatMapStringsSep "\n\n" (p: ''
+              # ${pluginName p}
+              # ---------------------
               ${p.extraConfig or ""}
               run-shell ${
                 if types.package.check p

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -34,12 +34,20 @@ set  -g history-limit     2000
 # Load plugins with Home Manager                #
 # --------------------------------------------- #
 
+# tmuxplugin-logging
+# ---------------------
 
 run-shell @tmuxplugin_logging_rtp@
 
 
+# tmuxplugin-prefix-highlight
+# ---------------------
+
 run-shell @tmuxplugin_prefix_highlight_rtp@
 
+
+# tmuxplugin-fzf-tmux-url
+# ---------------------
 
 run-shell @tmuxplugin_fzf_tmux_url_rtp@
 


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description



### Checklist

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Code tested through tmux related tests:
  ```
  nix-shell --pure tests -A list \
  | sed -nE 's/(.*tmux.*)/run.&/p' \
  | xargs -i nix-shell --pure tests -A '{}'
  ```

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Except for the revert, commit messages are formatted as described below.

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```