### PR TITLE
fish: source each file in plugin conf.d separately

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -441,7 +441,9 @@ in {
 
           # Source initialization code if it exists.
           if test -d $plugin_dir/conf.d
-            source $plugin_dir/conf.d/*.fish
+            for f in $plugin_dir/conf.d/*.fish
+              source $f
+            end
           end
 
           if test -f $plugin_dir/key_bindings.fish

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -21,7 +21,9 @@ let
 
     # Source initialization code if it exists.
     if test -d $plugin_dir/conf.d
-      source $plugin_dir/conf.d/*.fish
+      for f in $plugin_dir/conf.d/*.fish
+        source $f
+      end
     end
 
     if test -f $plugin_dir/key_bindings.fish


### PR DESCRIPTION
# Description
According to [`source(1)`](https://fishshell.com/docs/current/cmds/source.html), only one file can  be sourced at a time: "If additional arguments are specified after the file name, they will be inserted into the $argv variable."


### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
