### PR TITLE
git: escape string values in configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,10 +11,7 @@ stages:
 Run tests:
   stage: test
   script:
-    - nix-shell tests -A run.files-text
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master"
-      when: always
+    - nix-shell --pure tests -A run.files-text
 
 pages:
   stage: deploy

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -19,9 +19,19 @@ let
     else
       ''${section} "${subsection}"'';
 
+  mkValueString = v:
+    let
+      escapedV = ''
+        "${
+          replaceStrings [ "\n" "	" ''"'' "\\" ] [ "\\n" "\\t" ''\"'' "\\\\" ] v
+        }"'';
+    in generators.mkValueStringDefault { } (if isString v then escapedV else v);
+
   # generation for multiple ini values
   mkKeyValue = k: v:
-    let mkKeyValue = generators.mkKeyValueDefault { } " = " k;
+    let
+      mkKeyValue =
+        generators.mkKeyValueDefault { inherit mkValueString; } " = " k;
     in concatStringsSep "\n" (map (kv: "	" + mkKeyValue kv) (toList v));
 
   # converts { a.b.c = 5; } to { "a.b".c = 5; } for toINI

--- a/tests/modules/programs/git/git-expected-include.conf
+++ b/tests/modules/programs/git/git-expected-include.conf
@@ -1,3 +1,3 @@
 [user]
-	email = user@example.org
-	name = John Doe
+	email = "user@example.org"
+	name = "John Doe"

--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -1,6 +1,7 @@
 [alias]
-	a1 = foo
-	a2 = baz
+	a1 = "foo"
+	a2 = "baz"
+	escapes = "\"\\n\t"
 
 [commit]
 	gpgSign = true
@@ -10,33 +11,33 @@
 	integer = 38
 	multiple = 1
 	multiple = 2
-	name = value
+	name = "value"
 
 [extra "backcompat.with.dots"]
-	previously = worked
+	previously = "worked"
 
 [extra "subsection"]
-	value = test
+	value = "test"
 
 [filter "lfs"]
-	clean = git-lfs clean -- %f
-	process = git-lfs filter-process
+	clean = "git-lfs clean -- %f"
+	process = "git-lfs filter-process"
 	required = true
-	smudge = git-lfs smudge -- %f
+	smudge = "git-lfs smudge -- %f"
 
 [gpg]
-	program = path-to-gpg
+	program = "path-to-gpg"
 
 [user]
-	email = user@example.org
-	name = John Doe
-	signingKey = 00112233445566778899AABBCCDDEEFF
+	email = "user@example.org"
+	name = "John Doe"
+	signingKey = "00112233445566778899AABBCCDDEEFF"
 
 [include]
-	path = ~/path/to/config.inc
+	path = "~/path/to/config.inc"
 
 [includeIf "gitdir:~/src/dir"]
-	path = ~/path/to/conditional.inc
+	path = "~/path/to/conditional.inc"
 
 [includeIf "gitdir:~/src/dir"]
-	path = @git_include_path@
+	path = "@git_include_path@"

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -28,6 +28,7 @@ in {
         aliases = {
           a1 = "foo";
           a2 = "bar";
+          escapes = ''"\n	'';
         };
         extraConfig = {
           extra = {


### PR DESCRIPTION
This should handle the special characters that typically occur.

Fixes #1206