### PR TITLE
i3status: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,8 @@
 
 /modules/programs/home-manager.nix                    @rycee
 
+/modules/programs/i3status.nix                        @JustinLovinger
+
 /modules/programs/keychain.nix                        @marsam
 
 /modules/programs/lesspipe.nix                        @rycee

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -7,6 +7,12 @@
 # [1] https://github.com/NixOS/nixpkgs/blob/fca0d6e093c82b31103dc0dacc48da2a9b06e24b/maintainers/maintainer-list.nix#LC1
 
 {
+  justinlovinger = {
+    name = "Justin Lovinger";
+    email = "git@justinlovinger.com";
+    github = "JustinLovinger";
+    githubId = 7183441;
+  };
   owm111 = {
     email = "7798336+owm111@users.noreply.github.com";
     name = "Owen McGrath";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -68,6 +68,7 @@ let
     (loadModule ./programs/gpg.nix { })
     (loadModule ./programs/home-manager.nix { })
     (loadModule ./programs/htop.nix { })
+    (loadModule ./programs/i3status.nix { })
     (loadModule ./programs/info.nix { })
     (loadModule ./programs/irssi.nix { })
     (loadModule ./programs/lieer.nix { })

--- a/modules/programs/i3status.nix
+++ b/modules/programs/i3status.nix
@@ -1,0 +1,208 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.i3status;
+
+  enabledModules = filterAttrs (n: v: v.enable) cfg.modules;
+
+  formatOrder = n: ''order += "${n}"'';
+
+  formatModule = n: v:
+    let
+      formatLine = n: v:
+        let
+          formatValue = v:
+            if isBool v then
+              (if v then "true" else "false")
+            else if isString v then
+              ''"${v}"''
+            else
+              toString v;
+        in "${n} = ${formatValue v}";
+    in ''
+      ${n} {
+        ${concatStringsSep "\n  " (mapAttrsToList formatLine v)}
+      }
+    '';
+
+  settingsType = with types; attrsOf (oneOf [ bool int str ]);
+
+  sortAttrNamesByPosition = comparator: set:
+    let pos = n: set."${n}".position;
+    in sort (a: b: comparator (pos a) (pos b)) (attrNames set);
+in {
+  meta.maintainers = [ hm.maintainers.justinlovinger ];
+
+  options.programs.i3status = {
+    enable = mkEnableOption "i3status";
+
+    enableDefault = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether or not to enable
+        the default configuration.
+      '';
+    };
+
+    general = mkOption {
+      type = settingsType;
+      default = { };
+      description = ''
+        Configuration to add to i3status <filename>config</filename>
+        <code>general</code> section.
+        See
+        <citerefentry>
+         <refentrytitle>i3status</refentrytitle>
+         <manvolnum>1</manvolnum>
+        </citerefentry>
+        for options.
+      '';
+      example = literalExample ''
+        {
+          colors = true;
+          color_good = "#e0e0e0";
+          color_degraded = "#d7ae00";
+          color_bad = "#f69d6a";
+          interval = 1;
+        }
+      '';
+    };
+
+    modules = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Whether or not to enable this module.
+            '';
+          };
+          position = mkOption {
+            type = with types; either int float;
+            description = ''
+              Position of this module in i3status <code>order</code>.
+            '';
+          };
+          settings = mkOption {
+            type = settingsType;
+            default = { };
+            description = ''
+              Configuration to add to this i3status module.
+              See
+              <citerefentry>
+               <refentrytitle>i3status</refentrytitle>
+               <manvolnum>1</manvolnum>
+              </citerefentry>
+              for options.
+            '';
+            example = literalExample ''
+              {
+                format = "♪ %volume";
+                format_muted = "♪ muted (%volume)";
+                device = "pulse:1";
+              }
+            '';
+          };
+        };
+      });
+      default = { };
+      description = ''
+        Modules to add to i3status <filename>config</filename> file.
+        See
+        <citerefentry>
+         <refentrytitle>i3status</refentrytitle>
+         <manvolnum>1</manvolnum>
+        </citerefentry>
+        for options.
+      '';
+      example = literalExample ''
+        {
+          "volume master" = {
+            position = 1;
+            settings = {
+              format = "♪ %volume";
+              format_muted = "♪ muted (%volume)";
+              device = "pulse:1";
+            };
+          };
+          "disk /" = {
+            position = 2;
+            settings = {
+              format = "/ %avail";
+            };
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.i3status = mkIf cfg.enableDefault {
+      general = {
+        colors = mkDefault true;
+        interval = mkDefault 5;
+      };
+
+      modules = {
+        ipv6 = { position = mkDefault 1; };
+
+        "wireless _first_" = {
+          position = mkDefault 2;
+          settings = {
+            format_up = mkDefault "W: (%quality at %essid) %ip";
+            format_down = mkDefault "W: down";
+          };
+        };
+
+        "ethernet _first_" = {
+          position = mkDefault 3;
+          settings = {
+            format_up = mkDefault "E: %ip (%speed)";
+            format_down = mkDefault "E: down";
+          };
+        };
+
+        "battery all" = {
+          position = mkDefault 4;
+          settings = { format = mkDefault "%status %percentage %remaining"; };
+        };
+
+        "disk /" = {
+          position = mkDefault 5;
+          settings = { format = mkDefault "%avail"; };
+        };
+
+        load = {
+          position = mkDefault 6;
+          settings = { format = mkDefault "%1min"; };
+        };
+
+        memory = {
+          position = mkDefault 7;
+          settings = {
+            format = mkDefault "%used | %available";
+            threshold_degraded = mkDefault "1G";
+            format_degraded = mkDefault "MEMORY < %available";
+          };
+        };
+
+        "tztime local" = {
+          position = mkDefault 8;
+          settings = { format = mkDefault "%Y-%m-%d %H:%M:%S"; };
+        };
+      };
+    };
+
+    home.packages = [ pkgs.i3status ];
+
+    xdg.configFile."i3status/config".text = concatStringsSep "\n" ([ ]
+      ++ optional (cfg.general != { }) (formatModule "general" cfg.general)
+      ++ map formatOrder (sortAttrNamesByPosition lessThan enabledModules)
+      ++ mapAttrsToList formatModule
+      (mapAttrs (n: v: v.settings) enabledModules));
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,6 +41,7 @@ import nmt {
     ./modules/programs/fish
     ./modules/programs/git
     ./modules/programs/gpg
+    ./modules/programs/i3status
     ./modules/programs/kakoune
     ./modules/programs/lf
     ./modules/programs/lieer

--- a/tests/modules/programs/i3status/default.nix
+++ b/tests/modules/programs/i3status/default.nix
@@ -1,0 +1,4 @@
+{
+  i3status-with-custom = ./with-custom.nix;
+  i3status-with-default = ./with-default.nix;
+}

--- a/tests/modules/programs/i3status/with-custom.nix
+++ b/tests/modules/programs/i3status/with-custom.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.i3status = {
+      enable = true;
+      enableDefault = false;
+
+      general = {
+        colors = true;
+        color_good = "#e0e0e0";
+        color_degraded = "#d7ae00";
+        color_bad = "#f69d6a";
+        interval = 1;
+      };
+
+      modules = {
+        "volume master" = {
+          position = 1;
+          settings = {
+            format = "♪ %volume";
+            format_muted = "♪ muted (%volume)";
+            device = "pulse:1";
+          };
+        };
+        "disk /" = {
+          position = 2;
+          settings = { format = "/ %avail"; };
+        };
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { i3status = pkgs.writeScriptBin "dummy-i3status" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/i3status/config \
+        ${
+          pkgs.writeText "i3status-expected-config" ''
+            general {
+              color_bad = "#f69d6a"
+              color_degraded = "#d7ae00"
+              color_good = "#e0e0e0"
+              colors = true
+              interval = 1
+            }
+
+            order += "volume master"
+            order += "disk /"
+            disk / {
+              format = "/ %avail"
+            }
+
+            volume master {
+              device = "pulse:1"
+              format = "♪ %volume"
+              format_muted = "♪ muted (%volume)"
+            }
+          ''
+        }
+    '';
+  };
+}

--- a/tests/modules/programs/i3status/with-default.nix
+++ b/tests/modules/programs/i3status/with-default.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.i3status = {
+      enable = true;
+      enableDefault = true;
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { i3status = pkgs.writeScriptBin "dummy-i3status" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/i3status/config \
+        ${
+          pkgs.writeText "i3status-expected-config" ''
+            general {
+              colors = true
+              interval = 5
+            }
+
+            order += "ipv6"
+            order += "wireless _first_"
+            order += "ethernet _first_"
+            order += "battery all"
+            order += "disk /"
+            order += "load"
+            order += "memory"
+            order += "tztime local"
+            battery all {
+              format = "%status %percentage %remaining"
+            }
+
+            disk / {
+              format = "%avail"
+            }
+
+            ethernet _first_ {
+              format_down = "E: down"
+              format_up = "E: %ip (%speed)"
+            }
+
+            ipv6 {
+              
+            }
+
+            load {
+              format = "%1min"
+            }
+
+            memory {
+              format = "%used | %available"
+              format_degraded = "MEMORY < %available"
+              threshold_degraded = "1G"
+            }
+
+            tztime local {
+              format = "%Y-%m-%d %H:%M:%S"
+            }
+
+            wireless _first_ {
+              format_down = "W: down"
+              format_up = "W: (%quality at %essid) %ip"
+            }
+          ''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

An i3status module, built in the spirit of RFC 42, if not the letter. It deviates from the RFC 42 `settings` set because order matters for `order` entries in the config file. Instead, `general` and `modules.<name>.settings` are each built like RFC 42 `settings`. `general` contains the contents of the config files `general` entry, and `modules.<name>.settings` contains the contents of an `i3status` `<name>` module. `modules.<name>.position` is used to arrange the `order` entries.

I opted to put the default `i3status` configuration behind an `enableDefault` option (enabled by default) so the user doesn't have to individually disable 8 different modules to get a bare configuration.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
