### PR TITLE
qutebrowser: add options and keybindings

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -26,6 +26,12 @@ let
 
   formatDictLine = o: n: v: ''${o}['${n}'] = "${v}"'';
 
+  formatKeyBindings = m: b:
+    let
+      formatKeyBinding = m: k: c:
+        ''config.bind("${k}", "${escape [ ''"'' ] c}", mode="${m}")'';
+    in concatStringsSep "\n" (mapAttrsToList (formatKeyBinding m) b);
+
 in {
   options.programs.qutebrowser = {
     enable = mkEnableOption "qutebrowser";
@@ -84,6 +90,82 @@ in {
       '';
     };
 
+    disableDefaultBindings = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable to load no default keybindings at all.
+      '';
+    };
+
+    keybindings = mkOption {
+      type = types.attrsOf (types.attrsOf types.str);
+      default = { };
+      description = ''
+        Keybindings mapping keys to commands in different modes. This setting is a dictionary containing mode names and dictionaries mapping keys to commands: <literal>{mode: {key: command}}</literal> If you want to map a key to another key, check the <literal>keyMappings</literal> setting instead. For modifiers, you can use either <literal>-</literal> or <literal>+</literal> as delimiters, and these names:
+
+        <itemizedlist>
+          <listitem><para>Control: <literal>Control</literal>, <literal>Ctrl</literal></para></listitem>
+          <listitem><para>Meta: <literal>Meta</literal>, <literal>Windows</literal>, <literal>Mod4</literal></para></listitem>
+          <listitem><para>Alt: <literal>Alt</literal>, <literal>Mod1</literal></para></listitem>
+          <listitem><para>Shift: <literal>Shift</literal></para></listitem>
+        </itemizedlist>
+
+        For simple keys (no <literal>&lt;&gt;</literal>-signs), a capital letter means the key is pressed with Shift. For special keys (with <literal>&lt;&gt;</literal>-signs), you need to explicitly add <literal>Shift-</literal> to match a key pressed with shift. If you want a binding to do nothing, bind it to the <literal>nop</literal> command. If you want a default binding to be passed through to the website, bind it to null. Note that some commands which are only useful for bindings (but not used interactively) are hidden from the command completion. See <literal>:</literal>help for a full list of available commands. The following modes are available:
+
+        <variablelist>
+          <varlistentry>
+            <term><literal>normal</literal></term>
+            <listitem><para>Default mode, where most commands are invoked.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>insert</literal></term>
+            <listitem><para>Entered when an input field is focused on a website, or by pressing i in normal mode. Passes through almost all keypresses to the website, but has some bindings like <literal>&lt;Ctrl-e&gt;</literal> to open an external editor. Note that single keys can’t be bound in this mode.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>hint</literal></term>
+            <listitem><para>Entered when f is pressed to select links with the keyboard. Note that single keys can’t be bound in this mode.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>passthrough</literal></term>
+            <listitem><para>Similar to insert mode, but passes through all keypresses except <literal>&lt;Escape&gt;</literal> to leave the mode. It might be useful to bind <literal>&lt;Escape&gt;</literal> to some other key in this mode if you want to be able to send an Escape key to the website as well. Note that single keys can’t be bound in this mode.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>command</literal></term>
+            <listitem><para>Entered when pressing the : key in order to enter a command. Note that single keys can’t be bound in this mode.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>prompt</literal></term>
+            <listitem><para>Entered when there’s a prompt to display, like for download locations or when invoked from JavaScript.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>yesno</literal></term>
+            <listitem><para>Entered when there’s a yes/no prompt displayed.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>caret</literal></term>
+            <listitem><para>Entered when pressing the v mode, used to select text using the keyboard.</para></listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>register</literal></term>
+            <listitem><para>Entered when qutebrowser is waiting for a register name/key for commands like <literal>:set-mark</literal>.</para></listitem>
+          </varlistentry>
+        </variablelist>
+      '';
+      example = literalExample ''
+        {
+          normal = {
+            "<Ctrl-v>" = "spawn mpv {url}";
+            ",p" = "spawn --userscript qute-pass";
+            ",l" = '''config-cycle spellcheck.languages ["en-GB"] ["en-US"]''';
+          };
+          prompt = {
+            "<Ctrl-y>" = "prompt-yes";
+          };
+        }
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -101,6 +183,9 @@ in {
       ++ mapAttrsToList (formatDictLine "c.aliases") cfg.aliases
       ++ mapAttrsToList (formatDictLine "c.url.searchengines") cfg.searchEngines
       ++ mapAttrsToList (formatDictLine "c.bindings.key_mappings")
-      cfg.keyMappings ++ optional (cfg.extraConfig != "") cfg.extraConfig);
+      cfg.keyMappings
+      ++ optional cfg.disableDefaultBindings [ "c.bindings.default = {}" ]
+      ++ mapAttrsToList formatKeyBindings cfg.keybindings
+      ++ optional (cfg.extraConfig != "") cfg.extraConfig);
   };
 }

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -48,7 +48,17 @@ in {
       type = types.attrsOf types.str;
       default = { };
       description = ''
-        Search engines which can be used via the address bar. Maps a search engine name (such as <literal>DEFAULT</literal>, or <literal>ddg</literal>) to a URL with a <literal>{}</literal> placeholder. The placeholder will be replaced by the search term, use <literal>{{</literal> and <literal>}}</literal> for literal <literal>{/}</literal> signs. The search engine named <literal>DEFAULT</literal> is used when <literal>url.auto_search</literal> is turned on and something else than a URL was entered to be opened. Other search engines can be used by prepending the search engine name to the search term, e.g. <literal>:open google qutebrowser</literal>.
+        Search engines which can be used via the address bar. Maps a search
+        engine name (such as <literal>DEFAULT</literal>, or
+        <literal>ddg</literal>) to a URL with a <literal>{}</literal>
+        placeholder. The placeholder will be replaced by the search term, use
+        <literal>{{</literal> and <literal>}}</literal> for literal
+        <literal>{/}</literal> signs. The search engine named
+        <literal>DEFAULT</literal> is used when
+        <literal>url.auto_search</literal> is turned on and something else than
+        a URL was entered to be opened. Other search engines can be used by
+        prepending the search engine name to the search term, e.g.
+        <literal>:open google qutebrowser</literal>.
       '';
       example = literalExample ''
         {
@@ -86,7 +96,12 @@ in {
       type = types.attrsOf types.str;
       default = { };
       description = ''
-        This setting can be used to map keys to other keys. When the key used as dictionary-key is pressed, the binding for the key used as dictionary-value is invoked instead. This is useful for global remappings of keys, for example to map Ctrl-[ to Escape. Note that when a key is bound (via <literal>bindings.default</literal> or <literal>bindings.commands</literal>), the mapping is ignored.
+        This setting can be used to map keys to other keys. When the key used
+        as dictionary-key is pressed, the binding for the key used as
+        dictionary-value is invoked instead. This is useful for global
+        remappings of keys, for example to map Ctrl-[ to Escape. Note that when
+        a key is bound (via <literal>bindings.default</literal> or
+        <literal>bindings.commands</literal>), the mapping is ignored.
       '';
     };
 
@@ -102,53 +117,108 @@ in {
       type = types.attrsOf (types.attrsOf types.str);
       default = { };
       description = ''
-        Keybindings mapping keys to commands in different modes. This setting is a dictionary containing mode names and dictionaries mapping keys to commands: <literal>{mode: {key: command}}</literal> If you want to map a key to another key, check the <literal>keyMappings</literal> setting instead. For modifiers, you can use either <literal>-</literal> or <literal>+</literal> as delimiters, and these names:
+        Keybindings mapping keys to commands in different modes. This setting
+        is a dictionary containing mode names and dictionaries mapping keys to
+        commands: <literal>{mode: {key: command}}</literal> If you want to map
+        a key to another key, check the <literal>keyMappings</literal> setting
+        instead. For modifiers, you can use either <literal>-</literal> or
+        <literal>+</literal> as delimiters, and these names:
 
         <itemizedlist>
-          <listitem><para>Control: <literal>Control</literal>, <literal>Ctrl</literal></para></listitem>
-          <listitem><para>Meta: <literal>Meta</literal>, <literal>Windows</literal>, <literal>Mod4</literal></para></listitem>
-          <listitem><para>Alt: <literal>Alt</literal>, <literal>Mod1</literal></para></listitem>
-          <listitem><para>Shift: <literal>Shift</literal></para></listitem>
+          <listitem><para>
+            Control: <literal>Control</literal>, <literal>Ctrl</literal>
+          </para></listitem>
+          <listitem><para>
+            Meta: <literal>Meta</literal>, <literal>Windows</literal>,
+            <literal>Mod4</literal>
+          </para></listitem>
+          <listitem><para>
+            Alt: <literal>Alt</literal>, <literal>Mod1</literal>
+          </para></listitem>
+          <listitem><para>
+            Shift: <literal>Shift</literal>
+          </para></listitem>
         </itemizedlist>
 
-        For simple keys (no <literal>&lt;&gt;</literal>-signs), a capital letter means the key is pressed with Shift. For special keys (with <literal>&lt;&gt;</literal>-signs), you need to explicitly add <literal>Shift-</literal> to match a key pressed with shift. If you want a binding to do nothing, bind it to the <literal>nop</literal> command. If you want a default binding to be passed through to the website, bind it to null. Note that some commands which are only useful for bindings (but not used interactively) are hidden from the command completion. See <literal>:</literal>help for a full list of available commands. The following modes are available:
+        For simple keys (no <literal>&lt;&gt;</literal>-signs), a capital
+        letter means the key is pressed with Shift. For special keys (with
+        <literal>&lt;&gt;</literal>-signs), you need to explicitly add
+        <literal>Shift-</literal> to match a key pressed with shift. If you
+        want a binding to do nothing, bind it to the <literal>nop</literal>
+        command. If you want a default binding to be passed through to the
+        website, bind it to null. Note that some commands which are only useful
+        for bindings (but not used interactively) are hidden from the command
+        completion. See <literal>:</literal>help for a full list of available
+        commands. The following modes are available:
 
         <variablelist>
           <varlistentry>
             <term><literal>normal</literal></term>
-            <listitem><para>Default mode, where most commands are invoked.</para></listitem>
+            <listitem><para>
+              Default mode, where most commands are invoked.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>insert</literal></term>
-            <listitem><para>Entered when an input field is focused on a website, or by pressing i in normal mode. Passes through almost all keypresses to the website, but has some bindings like <literal>&lt;Ctrl-e&gt;</literal> to open an external editor. Note that single keys can’t be bound in this mode.</para></listitem>
+            <listitem><para>
+              Entered when an input field is focused on a website, or by
+              pressing i in normal mode. Passes through almost all keypresses
+              to the website, but has some bindings like
+              <literal>&lt;Ctrl-e&gt;</literal> to open an external editor.
+              Note that single keys can’t be bound in this mode.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>hint</literal></term>
-            <listitem><para>Entered when f is pressed to select links with the keyboard. Note that single keys can’t be bound in this mode.</para></listitem>
+            <listitem><para>
+              Entered when f is pressed to select links with the keyboard. Note
+              that single keys can’t be bound in this mode.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>passthrough</literal></term>
-            <listitem><para>Similar to insert mode, but passes through all keypresses except <literal>&lt;Escape&gt;</literal> to leave the mode. It might be useful to bind <literal>&lt;Escape&gt;</literal> to some other key in this mode if you want to be able to send an Escape key to the website as well. Note that single keys can’t be bound in this mode.</para></listitem>
+            <listitem><para>
+              Similar to insert mode, but passes through all keypresses except
+              <literal>&lt;Escape&gt;</literal> to leave the mode. It might be
+              useful to bind <literal>&lt;Escape&gt;</literal> to some other
+              key in this mode if you want to be able to send an Escape key to
+              the website as well. Note that single keys can’t be bound in this
+              mode.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>command</literal></term>
-            <listitem><para>Entered when pressing the : key in order to enter a command. Note that single keys can’t be bound in this mode.</para></listitem>
+            <listitem><para>
+              Entered when pressing the : key in order to enter a command. Note
+              that single keys can’t be bound in this mode.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>prompt</literal></term>
-            <listitem><para>Entered when there’s a prompt to display, like for download locations or when invoked from JavaScript.</para></listitem>
+            <listitem><para>
+              Entered when there’s a prompt to display, like for download
+              locations or when invoked from JavaScript.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>yesno</literal></term>
-            <listitem><para>Entered when there’s a yes/no prompt displayed.</para></listitem>
+            <listitem><para>
+              Entered when there’s a yes/no prompt displayed.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>caret</literal></term>
-            <listitem><para>Entered when pressing the v mode, used to select text using the keyboard.</para></listitem>
+            <listitem><para>
+              Entered when pressing the v mode, used to select text using the
+              keyboard.
+            </para></listitem>
           </varlistentry>
           <varlistentry>
             <term><literal>register</literal></term>
-            <listitem><para>Entered when qutebrowser is waiting for a register name/key for commands like <literal>:set-mark</literal>.</para></listitem>
+            <listitem><para>
+              Entered when qutebrowser is waiting for a register name/key for
+              commands like <literal>:set-mark</literal>.
+            </para></listitem>
           </varlistentry>
         </variablelist>
       '';

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -105,11 +105,11 @@ in {
       '';
     };
 
-    disableDefaultBindings = mkOption {
+    enableDefaultBindings = mkOption {
       type = types.bool;
-      default = false;
+      default = true;
       description = ''
-        Enable to load no default keybindings at all.
+        Disable to prevent loading default keybindings.
       '';
     };
 
@@ -254,7 +254,7 @@ in {
       ++ mapAttrsToList (formatDictLine "c.url.searchengines") cfg.searchEngines
       ++ mapAttrsToList (formatDictLine "c.bindings.key_mappings")
       cfg.keyMappings
-      ++ optional cfg.disableDefaultBindings [ "c.bindings.default = {}" ]
+      ++ optional (!cfg.enableDefaultBindings) [ "c.bindings.default = {}" ]
       ++ mapAttrsToList formatKeyBindings cfg.keybindings
       ++ optional (cfg.extraConfig != "") cfg.extraConfig);
   };

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -24,9 +24,35 @@ let
     else
       "${o}${n} = ${formatValue v}";
 
+  formatDictLine = o: n: v: ''${o}['${n}'] = "${v}"'';
+
 in {
   options.programs.qutebrowser = {
     enable = mkEnableOption "qutebrowser";
+
+    aliases = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Aliases for commands.
+      '';
+    };
+
+    searchEngines = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Search engines which can be used via the address bar. Maps a search engine name (such as <literal>DEFAULT</literal>, or <literal>ddg</literal>) to a URL with a <literal>{}</literal> placeholder. The placeholder will be replaced by the search term, use <literal>{{</literal> and <literal>}}</literal> for literal <literal>{/}</literal> signs. The search engine named <literal>DEFAULT</literal> is used when <literal>url.auto_search</literal> is turned on and something else than a URL was entered to be opened. Other search engines can be used by prepending the search engine name to the search term, e.g. <literal>:open google qutebrowser</literal>.
+      '';
+      example = literalExample ''
+        {
+          w = "https://en.wikipedia.org/wiki/Special:Search?search={}&go=Go&ns0=1";
+          aw = "https://wiki.archlinux.org/?search={}";
+          nw = "https://nixos.wiki/index.php?search={}";
+          g = "https://www.google.com/search?hl=en&q={}";
+        }
+      '';
+    };
 
     settings = mkOption {
       type = types.attrs;
@@ -50,6 +76,14 @@ in {
       '';
     };
 
+    keyMappings = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        This setting can be used to map keys to other keys. When the key used as dictionary-key is pressed, the binding for the key used as dictionary-value is invoked instead. This is useful for global remappings of keys, for example to map Ctrl-[ to Escape. Note that when a key is bound (via <literal>bindings.default</literal> or <literal>bindings.commands</literal>), the mapping is ignored.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -64,6 +98,9 @@ in {
 
     xdg.configFile."qutebrowser/config.py".text = concatStringsSep "\n" ([ ]
       ++ mapAttrsToList (formatLine "c.") cfg.settings
-      ++ optional (cfg.extraConfig != "") cfg.extraConfig);
+      ++ mapAttrsToList (formatDictLine "c.aliases") cfg.aliases
+      ++ mapAttrsToList (formatDictLine "c.url.searchengines") cfg.searchEngines
+      ++ mapAttrsToList (formatDictLine "c.bindings.key_mappings")
+      cfg.keyMappings ++ optional (cfg.extraConfig != "") cfg.extraConfig);
   };
 }

--- a/tests/modules/programs/qutebrowser/default.nix
+++ b/tests/modules/programs/qutebrowser/default.nix
@@ -1,1 +1,4 @@
-{ qutebrowser-settings = ./settings.nix; }
+{
+  qutebrowser-settings = ./settings.nix;
+  qutebrowser-keybindings = ./keybindings.nix;
+}

--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.qutebrowser = {
+      enable = true;
+
+      keybindings = {
+        normal = {
+          "<Ctrl-v>" = "spawn mpv {url}";
+          ",l" = ''config-cycle spellcheck.languages ["en-GB"] ["en-US"]'';
+        };
+        prompt = { "<Ctrl-y>" = "prompt-yes"; };
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        qutebrowser = pkgs.writeScriptBin "dummy-qutebrowser" "";
+      })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/qutebrowser/config.py \
+        ${
+          pkgs.writeText "qutebrowser-expected-config.py" ''
+            config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")
+            config.bind("<Ctrl-v>", "spawn mpv {url}", mode="normal")
+            config.bind("<Ctrl-y>", "prompt-yes", mode="prompt")''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

Following #1132 and #1149.

I added 3 settings directly as options since they require to be formatted as python dictionary: `aliases`, `url.searchengines` and `bindings.key_mappings`.
I didn't add `content.headers.custom`, `content.javascript.log` and `hints.selectors`, while they are the 3 other dictionaries they are also probably less used.

I'm not sure how to handle default value, I didn't put anything but qutebrowser do have some default values for `aliases` and `url.searchengines`. Should I redefine them to make them appear in the documentation? We would need to keep them in sync then, it would maybe even require to set them to empty dictionaries before.

I also added a keybindings option.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
