### PR TITLE
Emacsclient desktop file

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -7,9 +7,40 @@ let
   cfg = config.services.emacs;
   emacsCfg = config.programs.emacs;
   emacsBinPath = "${emacsCfg.finalPackage}/bin";
+  # Adapted from upstream emacs.desktop
+  clientDesktopItem = pkgs.makeDesktopItem rec {
+    name = "emacsclient";
+    desktopName = "Emacs Client";
+    genericName = "Text Editor";
+    comment = "Edit text";
+    mimeType =
+      "text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;";
+    exec = "${emacsBinPath}/emacsclient ${
+        concatStringsSep " " cfg.client.arguments
+      } %F";
+    icon = "emacs";
+    type = "Application";
+    terminal = "false";
+    categories = "Utility;TextEditor;";
+    extraEntries = ''
+      StartupWMClass=Emacs
+    '';
+  };
 
 in {
-  options.services.emacs = { enable = mkEnableOption "the Emacs daemon"; };
+  options.services.emacs = {
+    enable = mkEnableOption "the Emacs daemon";
+    client = {
+      enable = mkEnableOption "generation of Emacs client desktop file";
+      arguments = mkOption {
+        type = with types; listOf str;
+        default = [ "-c" ];
+        description = ''
+          Command-line arguments to pass to <command>emacsclient</command>.
+        '';
+      };
+    };
+  };
 
   config = mkIf cfg.enable {
     assertions = [{
@@ -38,5 +69,7 @@ in {
 
       Install = { WantedBy = [ "default.target" ]; };
     };
+
+    home.packages = optional cfg.client.enable clientDesktopItem;
   };
 }


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description
Succeeds #927 

### TODO ###

- [ ] emacsclient shortcut shows up as separate icon in KDE taskbar (not sure what to do about this) and can't be pinned directly from active emacs

- [x] replace writeTextFile with mkDesktopEntry

- [ ] Squash commits

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
