### PR TITLE
Add option "package" to Rofi module

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -131,6 +131,17 @@ in {
     enable = mkEnableOption
       "Rofi: A window switcher, application launcher and dmenu replacement";
 
+    package = mkOption {
+      default = pkgs.rofi;
+      type = types.package;
+      description = ''
+        Package providing the <command>rofi</command> binary.
+      '';
+      example = literalExample ''
+        pkgs.rofi.override { plugins = [ pkgs.rofi-emoji ]; };
+      '';
+    };
+
     width = mkOption {
       default = null;
       type = types.nullOr types.int;
@@ -295,7 +306,7 @@ in {
       '';
     }];
 
-    home.packages = [ pkgs.rofi ];
+    home.packages = [ cfg.package ];
 
     home.file."${cfg.configPath}".text = ''
       ${setOption "width" cfg.width}


### PR DESCRIPTION
Sometimes you want to compile your own, custom rofi build, or maybe just want to include modules with `programs.rofi.package = pkgs.rofi.override { plugins = [ pkgs.rofi-emoji ]; };`

### Description



### Checklist

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
