### PR TITLE
gnome-terminal: allow for 'system' theme variant

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -186,7 +186,7 @@ in {
 
       themeVariant = mkOption {
         default = "default";
-        type = types.enum [ "default" "light" "dark" ];
+        type = types.enum [ "default" "light" "dark" "system" ];
         description = "The theme variation to request";
       };
 


### PR DESCRIPTION
### Description

I upgraded to Fedora 32 which uses Gnome v3.36 and noticed my gnome-terminal theme variant 
wasn't getting set. Looking at `dconf watch /` I see that the value (string) when toggling the UI preferences references `system`, so adding `system` to the list of allowable values.

### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

