### PR TITLE
Various small sway improvements

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -10,8 +10,9 @@ rec {
 
   keybindingsStr = keybindings:
     concatStringsSep "\n" (mapAttrsToList (keycomb: action:
-      optionalString (action != null) "bindsym ${keycomb} ${action}")
-      keybindings);
+      optionalString (action != null) "bindsym ${
+        lib.optionalString (moduleName == "sway") "--to-code "
+      }${keycomb} ${action}") keybindings);
 
   keycodebindingsStr = keycodebindings:
     concatStringsSep "\n" (mapAttrsToList (keycomb: action:

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -48,7 +48,10 @@ rec {
         mode ${mode}
         hidden_state ${hiddenState}
         position ${position}
-        status_command ${statusCommand}
+        ${
+          optionalString (statusCommand != null)
+          "status_command ${statusCommand}"
+        }
         ${moduleName}bar_command ${command}
         workspace_buttons ${if workspaceButtons then "yes" else "no"}
         strip_workspace_numbers ${if !workspaceNumbers then "yes" else "no"}

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -111,7 +111,7 @@ let
       };
 
       statusCommand = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
         default = "${pkgs.i3status}/bin/i3status";
         description = "Command that will be used to get status lines.";
       };


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

- Use `bindsym --to-code` on `sway` for compatibility with all layouts. See https://github.com/swaywm/sway/wiki#key-bindings-on-a-dual-usrussian-layout
- Allow setting `bar.statusCommand` to `null` to avoid generating of `status_command` statement, useful when a custom bar is to be used (e.g. https://github.com/rvolosatovs/infrastructure/blob/89f162c7654533d6f0d8995a6ceeaaa6324e44f5/home/modules/sway.nix#L90-L92)

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
