### PR TITLE
home-manager: improve handling of conflicting files

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -90,10 +90,10 @@ in
                   errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
                   collision=1
                 else
-                  warnEcho "Existing file '$targetPath' is in the way, will be moved to '$backup'"
+                  warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
                 fi
               else
-                errorEcho "Existing file '$targetPath' is in the way"
+                errorEcho "Existing file '$targetPath' is in the way of '$sourcePath'"
                 collision=1
               fi
             fi


### PR DESCRIPTION
### Description

When files conflict during activation, home-manager will also print the path of the source file that wants to overwrite the other.

I think it would be even better if compared the files on conflict to determine if there *actually* is a conflict (which would resolve #1213), but this would create a dependency to `diffutils` and I don't know if that's okay.

### Checklist

- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
