### PR TITLE
home-manager: use `nix-env` to list generations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ os:
   - linux
   - osx
 
-before_script:
-  - mkdir -m 0755 -p /nix/var/nix/{profiles,gcroots}/per-user/$USER
-
 script:
   - ./format -c
   - nix-shell . -A install

--- a/README.md
+++ b/README.md
@@ -46,21 +46,12 @@ Installation
 
 Currently the easiest way to install Home Manager is as follows:
 
-1.  Make sure you have a working Nix installation. If you are not
-    using NixOS then you may here have to run
-
-    ```console
-    $ mkdir -m 0755 -p /nix/var/nix/{profiles,gcroots}/per-user/$USER
-    ```
-
-    since Home Manager uses these directories to manage your profile
-    generations. On NixOS these should already be available.
-
-    Also make sure that your user is able to build and install Nix
-    packages. For example, you should be able to successfully run a
-    command like `nix-instantiate '<nixpkgs>' -A hello` without having
-    to switch to the root user. For a multi-user install of Nix this
-    means that your user must be covered by the
+1.  Make sure you have a working Nix installation. Specifically, make
+    sure that your user is able to build and install Nix packages. For
+    example, you should be able to successfully run a command like
+    `nix-instantiate '<nixpkgs>' -A hello` without having to switch to
+    the root user. For a multi-user install of Nix this means that
+    your user must be covered by the
     [`allowed-users`][nixAllowedUsers] Nix option. On NixOS you can
     control this option using the
     [`nix.allowedUsers`][nixosAllowedUsers] system option.

--- a/doc/installation.xml
+++ b/doc/installation.xml
@@ -44,22 +44,12 @@
   <orderedlist>
    <listitem>
     <para>
-     Make sure you have a working Nix installation. If you are not using NixOS
-     then it may be necessary to run
-    </para>
-<screen>
-<prompt>$</prompt> <userinput>mkdir -m 0755 -p /nix/var/nix/{profiles,gcroots}/per-user/$USER</userinput>
-</screen>
-    <para>
-     since Home Manager uses these directories to manage your profile
-     generations. On NixOS these should already be available.
-    </para>
-    <para>
-     Also make sure that your user is able to build and install Nix packages.
-     For example, you should be able to successfully run a command like
-     <literal>nix-instantiate '&lt;nixpkgs&gt;' -A hello</literal> without
-     having to switch to the root user. For a multi-user install of Nix this
-     means that your user must be covered by the
+     Make sure you have a working Nix installation. Specifically, make
+     sure that your user is able to build and install Nix packages.
+     For example, you should be able to successfully run a command
+     like <literal>nix-instantiate '&lt;nixpkgs&gt;' -A hello</literal>
+     without having to switch to the root user. For a multi-user
+     install of Nix this means that your user must be covered by the
      <link xlink:href="https://nixos.org/nix/manual/#conf-allowed-users"><literal>allowed-users</literal></link>
      Nix option. On NixOS you can control this option using the
      <link xlink:href="https://nixos.org/nixos/manual/options.html#opt-nix.allowedUsers"><literal>nix.allowedUsers</literal></link>

--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -3,13 +3,16 @@
 function setupVars() {
     local profilesPath="/nix/var/nix/profiles/per-user/$USER"
     local gcPath="/nix/var/nix/gcroots/per-user/$USER"
-    local greatestGenNum
 
+    genProfilePath="$profilesPath/home-manager"
+    newGenPath="@GENERATION_DIR@";
+    newGenGcPath="$gcPath/current-home"
+
+    local greatestGenNum
     greatestGenNum=$( \
-        find "$profilesPath" -name 'home-manager-*-link' \
-            | sed 's/^.*-\([0-9]*\)-link$/\1/' \
-            | sort -rn \
-            | head -1)
+        nix-env --list-generations --profile "$genProfilePath" \
+            | tail -1 \
+            | sed -E 's/ *([[:digit:]]+) .*/\1/')
 
     if [[ -n $greatestGenNum ]] ; then
         oldGenNum=$greatestGenNum
@@ -18,15 +21,15 @@ function setupVars() {
         newGenNum=1
     fi
 
-    if [[ -e $gcPath/current-home ]] ; then
-        oldGenPath="$(readlink -e "$gcPath/current-home")"
+    if [[ -e $profilesPath/home-manager ]] ; then
+        oldGenPath="$(readlink -e "$profilesPath/home-manager")"
     fi
 
     $VERBOSE_ECHO "Sanity checking oldGenNum and oldGenPath"
     if [[ -v oldGenNum && ! -v oldGenPath
             || ! -v oldGenNum && -v oldGenPath ]]; then
-        errorEcho "Invalid profile number and GC root values! These must be"
-        errorEcho "either both empty or both set but are now set to"
+        errorEcho "Invalid profile number and current profile values! These"
+        errorEcho "must be either both empty or both set but are now set to"
         errorEcho "    '${oldGenNum:-}' and '${oldGenPath:-}'"
         errorEcho "If you don't mind losing previous profile generations then"
         errorEcho "the easiest solution is probably to run"
@@ -35,12 +38,6 @@ function setupVars() {
         errorEcho "and trying home-manager switch again. Good luck!"
         exit 1
     fi
-
-
-    genProfilePath="$profilesPath/home-manager"
-    newGenPath="@GENERATION_DIR@";
-    newGenProfilePath="$profilesPath/home-manager-$newGenNum-link"
-    newGenGcPath="$gcPath/current-home"
 }
 
 if [[ -v VERBOSE ]]; then
@@ -78,6 +75,5 @@ else
 fi
 $VERBOSE_ECHO "  newGenPath=$newGenPath"
 $VERBOSE_ECHO "  newGenNum=$newGenNum"
-$VERBOSE_ECHO "  newGenProfilePath=$newGenProfilePath"
 $VERBOSE_ECHO "  newGenGcPath=$newGenGcPath"
 $VERBOSE_ECHO "  genProfilePath=$genProfilePath"


### PR DESCRIPTION
Using the `nix-env` command is far more robust. It also has the benefit that if the per-user `profiles` and `gcroots` directories do not exist then they will be created with the correct permissions.

Because of the second point this commit also removes the `mkdir` step of the installation instructions.