### PR TITLE
home-manager: Fix first-time activation

### DIFF
--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -10,7 +10,7 @@ function setupVars() {
 
     local greatestGenNum
     greatestGenNum=$( \
-        nix-env --list-generations --profile "$genProfilePath" \
+        (nix-env --list-generations --profile "$genProfilePath" || echo "") \
             | tail -1 \
             | sed -E 's/ *([[:digit:]]+) .*/\1/')
 


### PR DESCRIPTION
## Description
`nix-env --list-generations` emits an error when there's no user profile:

> error: opening lock file '/nix/var/nix/profiles/per-user/<user>/home-manager.lock': No such file or directory

This ignores this error, treating it as if the response had been empty.

Since this is a follow-up to #1239, it will need to be backported to 20.03 along with it.

### Checklist

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
