### PR TITLE
Allow confAttr to be null in home-manager/home-manager.nix

### DIFF
--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> {}
 , confPath
-, confAttr
+, confAttr ? null
 , check ? true
 , newsReadIdsFile ? null
 }:
@@ -11,7 +11,7 @@ let
 
   env = import ../modules {
     configuration =
-      if confAttr == ""
+      if confAttr == "" || confAttr == null
       then confPath
       else (import confPath).${confAttr};
     pkgs = pkgs;


### PR DESCRIPTION
This makes it easier to invoke home-manager/home-manager.nix without
using the home-manager executable.

### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [N/A] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
