### PR TITLE
activation: add Nix sanity check

### DIFF
--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -50,6 +50,11 @@ fi
 
 echo "Starting home manager activation"
 
+# Verify that we can connect to the Nix store and/or daemon. This will
+# also create the necessary directories in profiles and gcroots.
+$VERBOSE_ECHO "Sanity checking Nix"
+nix-build --expr '{}' --no-out-link
+
 setupVars
 
 if [[ -v DRY_RUN ]] ; then


### PR DESCRIPTION
This adds an empty `nix-build` command to verify that the user is having a good Nix install. It also, as a side effect, will create the necessary per-user `profiles` and `gcroots` directories.