### PR TITLE
modules: Add extraModules option

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,4 +1,5 @@
 { configuration
+, extraModules ? [ ]
 , pkgs
 , lib ? pkgs.stdenv.lib
 
@@ -28,7 +29,7 @@ let
     };
 
   rawModule = extendedLib.evalModules {
-    modules = [ configuration ] ++ hmModules;
+    modules = [ configuration ] ++ hmModules ++ extraModules;
     specialArgs = {
       modulesPath = builtins.toString ./.;
     };


### PR DESCRIPTION
This allows you to extend configuration with other modules if needed.
Useful for providing defaults on top of the user’s config.

### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [N/A] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
