### PR TITLE
Set path in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,4 +7,6 @@ rec {
     pkgs.callPackage ./home-manager/install.nix { inherit home-manager; };
 
   nixos = import ./nixos;
+
+  path = ./.;
 }


### PR DESCRIPTION
### Description

This makes it possible to refer to the path of home-manager when you
just have a Nix expression, not the actual source. Some things (like
certain thunks) run import on a source and just give access to the
result of the import, not the source.

### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [N/A] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
