### PR TITLE
dircolors: fix `enableZshIntegration` with `zsh.oh-my-zsh`

### DIFF
--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -215,7 +215,8 @@ in {
       eval (${pkgs.coreutils}/bin/dircolors -c ~/.dir_colors)
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    # Set `LS_COLORS` before Oh My Zsh and `initExtra`.
+    programs.zsh.initExtraBeforeCompInit = mkIf cfg.enableZshIntegration ''
       eval $(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)
     '';
   };


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

Fix #1279

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
