### PR TITLE
powerline-go: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,6 +85,8 @@
 
 /modules/programs/pidgin.nix                          @rycee
 
+/modules/programs/powerline-go.nix                    @DamienCassou
+
 /modules/programs/rtorrent.nix                        @marsam
 
 /modules/programs/ssh.nix                             @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1560,6 +1560,14 @@ in
           A new module is available: 'services.clipmenu'
         '';
       }
+
+      {
+        time = "2020-06-12T07:08:09+00:00";
+        condition = config.programs.bash.enable;
+        message = ''
+          A new module is available: 'programs.powerline-go'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -99,6 +99,7 @@ let
     (loadModule ./programs/password-store.nix { })
     (loadModule ./programs/pazi.nix { })
     (loadModule ./programs/pidgin.nix { })
+    (loadModule ./programs/powerline-go.nix { })
     (loadModule ./programs/qutebrowser.nix { })
     (loadModule ./programs/readline.nix { })
     (loadModule ./programs/rofi.nix { })

--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -1,0 +1,120 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.powerline-go;
+
+  # Convert an option value to a string to be passed as argument to
+  # powerline-go:
+  valueToString = value:
+    if builtins.isList value then
+      builtins.concatStringsSep "," (builtins.map valueToString value)
+    else if builtins.isAttrs value then
+      valueToString
+      (mapAttrsToList (key: val: "${valueToString key}=${valueToString val}")
+        value)
+    else
+      builtins.toString value;
+
+  modulesArgument = optionalString (cfg.modules != null)
+    "-modules ${valueToString cfg.modules}";
+
+  newlineArgument = optionalString cfg.newline "-newline";
+
+  pathAliasesArgument = optionalString (cfg.pathAliases != null)
+    "-path-aliases ${valueToString cfg.pathAliases}";
+
+  otherSettingPairArgument = name: value:
+    if value == true then "-${name}" else "-${name} ${valueToString value}";
+
+  otherSettingsArgument = optionalString (cfg.settings != { })
+    (concatStringsSep " "
+      (mapAttrsToList otherSettingPairArgument cfg.settings));
+
+  commandLineArguments = ''
+    ${modulesArgument} ${newlineArgument} ${pathAliasesArgument} ${otherSettingsArgument}
+  '';
+
+in {
+  meta.maintainers = [ maintainers.DamienCassou ];
+
+  options = {
+    programs.powerline-go = {
+      enable = mkEnableOption
+        "Powerline-go, a beautiful and useful low-latency prompt for your shell";
+
+      modules = mkOption {
+        default = null;
+        type = types.nullOr (types.listOf types.str);
+        description = ''
+
+          List of module names to load. The list of all available
+          modules as well as the choice of default ones are at <link
+          xlink:href="https://github.com/justjanne/powerline-go">https://github.com/justjanne/powerline-go</link>.
+
+        '';
+        example = [ "host" "ssh" "cwd" "gitlite" "jobs" "exit" ];
+      };
+
+      newline = mkOption {
+        default = false;
+        type = types.bool;
+        description =
+          "Set to true if the prompt should be on a line of its own.";
+        example = true;
+      };
+
+      pathAliases = mkOption {
+        default = null;
+        type = types.nullOr (types.attrsOf types.str);
+        description = ''
+          Pairs of full-path and corresponding desired short name. You
+          may use '~' to represent your home directory but you should
+          protect it to avoid shell substitution.
+        '';
+        example = { "\\~/projects/home-manager" = "prj:home-manager"; };
+      };
+
+      settings = mkOption {
+        default = { };
+        type = with types; attrsOf (oneOf [ bool int str (listOf str) ]);
+        description = ''
+          This can be any key/value pair as described in <link
+          xlink:href="https://github.com/justjanne/powerline-go">https://github.com/justjanne/powerline-go</link>.'';
+
+        example = literalExample ''
+          {
+            hostname-only-if-ssh = true;
+            numeric-exit-codes = true;
+            cwd-max-depth = 7;
+            ignore-repos = [ "/home/me/big-project" "/home/me/huge-project" ];
+          }
+        '';
+      };
+
+      extraUpdatePS1 = mkOption {
+        default = "";
+        description = "Shell code to execute after the prompt is set.";
+        example = ''
+          PS1=$PS1"NixOS> ";
+        '';
+        type = types.str;
+      };
+    };
+  };
+
+  config = mkIf (cfg.enable && config.programs.bash.enable) {
+    programs.bash.initExtra = ''
+      function _update_ps1() {
+        PS1="$(${pkgs.powerline-go}/bin/powerline-go -error $? ${commandLineArguments})"
+        ${cfg.extraUpdatePS1}
+        }
+
+      if [ "$TERM" != "linux" ]; then
+        PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
+      fi
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -53,6 +53,7 @@ import nmt {
     ./modules/programs/newsboat
     ./modules/programs/qutebrowser
     ./modules/programs/readline
+    ./modules/programs/powerline-go
     ./modules/programs/ssh
     ./modules/programs/starship
     ./modules/programs/texlive

--- a/tests/modules/programs/powerline-go/default.nix
+++ b/tests/modules/programs/powerline-go/default.nix
@@ -1,0 +1,1 @@
+{ powerline-go-standard = ./standard.nix; }

--- a/tests/modules/programs/powerline-go/standard.nix
+++ b/tests/modules/programs/powerline-go/standard.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs = {
+      bash.enable = true;
+
+      powerline-go = {
+        enable = true;
+        newline = true;
+        modules = [ "nix-shell" ];
+        pathAliases = { "\\~/project/foo" = "prj-foo"; };
+        settings = {
+          ignore-repos = [ "/home/me/project1" "/home/me/project2" ];
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.bashrc
+      assertFileContains \
+        home-files/.bashrc \
+        '/bin/powerline-go -error $? -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Add support for [powerline-go](https://github.com/justjanne/powerline-go).

#### Without powerline-go:

![2020-05-29-200002](https://user-images.githubusercontent.com/217543/83290556-14ff1480-a1e7-11ea-8661-19822734c8c7.png)

This is sad :disappointed:.

#### With powerline-go:

![2020-05-29-200245](https://user-images.githubusercontent.com/217543/83290721-66a79f00-a1e7-11ea-91e6-0a49decc3681.png)

This is nice :smiley:.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
