### PR TITLE
kakoune: support user modes in keyMappings

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -535,22 +535,19 @@ let
       ];
 
     userModeString = mode:
-      optionalString
-        (!builtins.elem mode [
-          "insert"
-          "normal"
-          "prompt"
-          "menu"
-          "user"
-          "goto"
-          "view"
-          "object"
-        ])
-        "try %{declare-user-mode ${mode}}";
+      optionalString (!builtins.elem mode [
+        "insert"
+        "normal"
+        "prompt"
+        "menu"
+        "user"
+        "goto"
+        "view"
+        "object"
+      ]) "try %{declare-user-mode ${mode}}";
 
-    userModeStrings =
-      map userModeString
-        (lists.unique (map (km: km.mode) cfg.config.keyMappings));
+    userModeStrings = map userModeString
+      (lists.unique (map (km: km.mode) cfg.config.keyMappings));
 
     keyMappingString = km:
       concatStringsSep " " [
@@ -601,8 +598,8 @@ let
         ++ [ "# UI options" ]
         ++ optional (ui != null) "set-option global ui_options ${uiOptions}"
 
-        ++ [ "# User modes" ] ++ userModeStrings
-        ++ [ "# Key mappings" ] ++ map keyMappingString keyMappings
+        ++ [ "# User modes" ] ++ userModeStrings ++ [ "# Key mappings" ]
+        ++ map keyMappingString keyMappings
 
         ++ [ "# Hooks" ] ++ map hookString hooks);
   in pkgs.writeText "kakrc"

--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -97,16 +97,7 @@ let
   keyMapping = types.submodule {
     options = {
       mode = mkOption {
-        type = types.enum [
-          "insert"
-          "normal"
-          "prompt"
-          "menu"
-          "user"
-          "goto"
-          "view"
-          "object"
-        ];
+        type = types.str;
         example = "user";
         description = ''
           The mode in which the mapping takes effect.
@@ -543,6 +534,24 @@ let
         }"
       ];
 
+    userModeString = mode:
+      optionalString
+        (!builtins.elem mode [
+          "insert"
+          "normal"
+          "prompt"
+          "menu"
+          "user"
+          "goto"
+          "view"
+          "object"
+        ])
+        "try %{declare-user-mode ${mode}}";
+
+    userModeStrings =
+      map userModeString
+        (lists.unique (map (km: km.mode) cfg.config.keyMappings));
+
     keyMappingString = km:
       concatStringsSep " " [
         "map global"
@@ -592,6 +601,7 @@ let
         ++ [ "# UI options" ]
         ++ optional (ui != null) "set-option global ui_options ${uiOptions}"
 
+        ++ [ "# User modes" ] ++ userModeStrings
         ++ [ "# Key mappings" ] ++ map keyMappingString keyMappings
 
         ++ [ "# Hooks" ] ++ map hookString hooks);


### PR DESCRIPTION
### Description

The option `keyMappings.*.mode` only supported the builtin modes, but in kakoune you can define custom ones.

The option now accepts a string instead of the enum so one can define key mappings for user modes as well.

User modes are declared automatically.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- ~[ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```