### PR TITLE
Fix flake definition for newer nixFlakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,11 +1,27 @@
 {
-    "inputs": {
-        "nixpkgs": {
-            "inputs": {},
-            "narHash": "sha256-OiQYSXtgVbxbQwfOFe2L61M6d2X6Ah/E5q0FcJiJ5FM=",
-            "originalUrl": "github:NixOS/nixpkgs",
-            "url": "github:NixOS/nixpkgs/25eaaf8e8ad1d2091003c1573dc004ff0fd2a2c6"
-        }
+  "nodes": {
+    "nixpkgs": {
+      "info": {
+        "lastModified": 1590824667,
+        "narHash": "sha256-ut9bcUiG3LKIQtvLrhivTGqvjSP87fLlPssepQy7Ikg="
+      },
+      "locked": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "89e60f61ab6f09362433fd23370c590cd47e9c72",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
     },
-    "version": 3
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 5
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,4 @@
 {
-  edition = 201909;
-
   description = "Home Manager for Nix";
 
   outputs = { self, nixpkgs }: rec {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Current nixFlakes version from unstable does not support version 3 format of `flake.lock`. This PR updates `flake.lock` and removes deprecated attribute `edition` from `flake.nix`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

Notes on the checklist:
1. This change is not backwards compatible, because it may break setups with older `nixFlakes` versions, which still rely on `edition` attribute or don't support version 5 `flake.lock` format. However, flakes are still experimental feature.
2. Tests failed to evaluate on my machine, producing an error:
```
error: while evaluating the attribute 'shellHook' of the derivation 'nmt-run-all-tests' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/pkgs/build-support/trivial-builders.nix:7:7:
while evaluating anonymous function at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/attrsets.nix:234:10, called from undefined position:
while evaluating anonymous function at /nix/store/q1kjzm0niv63iinf2vj5jg3xsc5ic9y9-source/default.nix:62:25, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/attrsets.nix:234:16:
while evaluating 'reportResult' at /nix/store/q1kjzm0niv63iinf2vj5jg3xsc5ic9y9-source/default.nix:43:18, called from /nix/store/q1kjzm0niv63iinf2vj5jg3xsc5ic9y9-source/default.nix:63:7:
while evaluating the attribute 'config.nmt' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:98:9:
while evaluating 'yieldConfig' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:83:29, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:82:16:
while evaluating 'mergeModules' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:237:26, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:73:17:
while evaluating 'mergeModules'' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:241:36, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:238:5:
while evaluating 'flip' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/trivial.nix:138:16, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:284:6:
while evaluating 'byName' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:264:25, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:272:21:
while evaluating 'reverseList' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/lists.nix:393:17, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:73:38:
while evaluating anonymous function at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:171:37, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:68:19:
while evaluating 'filterModules' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:161:36, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:172:7:
while evaluating 'imap1' at /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/lists.nix:116:14, called from /nix/store/fjdfijxmxsys7wcjwjjzklfwgi8qj20b-source/lib/modules.nix:146:73:
value is a function while a list was expected, at /home/smakarov/Projects/home-manager/tests/default.nix:14:13
```
However, this error is not connected with this change, I encounter the same error in original branch.