### PR TITLE
sway: add config.bindkeysToCode

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -180,7 +180,7 @@ let
       client.placeholder ${colorSetStr colors.placeholder}
       client.background ${colors.background}
 
-      ${keybindingsStr keybindings}
+      ${keybindingsStr { inherit keybindings; }}
       ${keycodebindingsStr keycodebindings}
       ${concatStringsSep "\n" (mapAttrsToList modeStr modes)}
       ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -8,10 +8,10 @@ rec {
       concatStringsSep " " (mapAttrsToList (k: v: ''${k}="${v}"'') criteria)
     }]";
 
-  keybindingsStr = keybindings:
+  keybindingsStr = { keybindings, bindsymArgs ? "" }:
     concatStringsSep "\n" (mapAttrsToList (keycomb: action:
       optionalString (action != null) "bindsym ${
-        lib.optionalString (moduleName == "sway") "--to-code "
+        lib.optionalString (bindsymArgs != "") "${bindsymArgs} "
       }${keycomb} ${action}") keybindings);
 
   keycodebindingsStr = keycodebindings:
@@ -31,7 +31,7 @@ rec {
 
   modeStr = name: keybindings: ''
     mode "${name}" {
-    ${keybindingsStr keybindings}
+    ${keybindingsStr { inherit keybindings; }}
     }
   '';
 

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -139,6 +139,15 @@ let
         '';
       };
 
+      bindkeysToCode = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to make use of <option>--to-code</option> in keybindings.
+        '';
+      };
+
       input = mkOption {
         type = types.attrsOf (types.attrsOf types.str);
         default = { };
@@ -259,7 +268,11 @@ let
       client.placeholder ${colorSetStr colors.placeholder}
       client.background ${colors.background}
 
-      ${keybindingsStr keybindings}
+      ${keybindingsStr {
+        inherit keybindings;
+        bindsymArgs =
+          lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
+      }}
       ${keycodebindingsStr keycodebindings}
       ${concatStringsSep "\n" (mapAttrsToList inputStr input)}
       ${concatStringsSep "\n" (mapAttrsToList outputStr output)}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Do not use `--to-code` by default in `bindsym`, let user configure that behavior manually via `config.bindkeysToCode` in `sway` module.

Refs https://github.com/rycee/home-manager/pull/1229#issuecomment-636301091

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

tests fail with:
```
hash mismatch in fixed-output derivation '/nix/store/sd0pnznvqy3l9k773anr14kv5imchvg8-delta-0.0.16-vendor.tar.gz':
  wanted: sha256:1zmk70hccrxn1gdr1bksnvh6sa2h4518s0ni8k2ihxi4ld1ch5p2
  got:    sha256:0hah0qfgnl4w2h0djyh4xx1jks5dkzwin01qw001dqiasl60prn2
cannot build derivation '/nix/store/a9j70nsz3x37mkakcqjw60rl1zs4s4p6-delta-0.0.16.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/7z4qg944anpk1hfjfaxx9zv13c9bpinx-git-expected.conf.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/75y9mfswm5x82lrj28dii5yg6lyzmg68-hm_gitconfig.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/bc22arqm3vjb37jqdb2lag30p2rj9ajv-home-manager-files.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/2zzxyhscan5n2zgjqflbhkcc5vrcjvqh-nmt-test-script-git-with-most-options.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/zrdw6v8dixg1gap8scw11i8ccjh79hgv-nmt-report-git-with-most-options.drv': 1 dependencies couldn't be built
error: build of '/nix/store/zrdw6v8dixg1gap8scw11i8ccjh79hgv-nmt-report-git-with-most-options.drv' failed
```

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
