### PR TITLE
mpv: replace deprecated mpv-with-scripts module with wrapMpv

### DIFF
--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -125,7 +125,7 @@ in {
         (if cfg.scripts == [ ] then
           pkgs.mpv
         else
-          pkgs.mpv-with-scripts.override { scripts = cfg.scripts; })
+          pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = cfg.scripts; })
       ];
     }
     (mkIf (cfg.config != { } || cfg.profiles != { }) {


### PR DESCRIPTION
### Description

See:

- <https://github.com/NixOS/nixpkgs/pull/88620>
- <https://github.com/NixOS/nixpkgs/pull/89208>

`mpv-with-scripts` broke in `nixpkgs-unstable` branch.

I manually tested the mpris mpv script after rebuilding.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
