### PR TITLE
firefox: add link to NUR and Rycee's repository

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -101,10 +101,19 @@ in
           ]
         '';
         description = ''
-          List of Firefox add-on packages to install. Note, it is
-          necessary to manually enable these extensions inside Firefox
-          after the first installation.
-        '';
+          List of Firefox add-on packages to install. Some addons are
+          accessible from the NUR meta repository (<link
+          xlink:href="https://gitlab.com/rycee/nur-expressions">https://gitlab.com/rycee/nur-expressions</link>). Once
+          NUR is enabled, the following expression will list available
+          Firefox addons :
+
+          <programlisting language="bash">
+          nix-env -f '&lt;nixpkgs&gt;' -qaP -A nur.repos.rycee.firefox-addons
+          </programlisting>
+
+          Note that it is necessary to manually enable these extensions inside
+          Firefox after the first installation.
+          '';
       };
 
       profiles = mkOption {


### PR DESCRIPTION
### Description

While reading `options.html`, I saw this example value for `programs.firefox.extensions`:

```nix
with pkgs.nur.repos.rycee.firefox-addons; [
  https-everywhere
  privacy-badger
]
```

I had no idea what `pkgs.nur` was referring to and it didn't work. With the help of IRC, I got the link to NUR.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted appropriately

