### PR TITLE
Add support for nix-direnv to direnv

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1542,6 +1542,16 @@ in
               programs.ssh.matchBlocks.<name>.serverAliveCountMax
         '';
       }
+
+      {
+        time = "2020-06-01T08:22:16+00:00";
+        condition = config.programs.direnv.enable;
+        message = ''
+          The direnv module now supports 'nix-direnv', a fast, persistent use_nix implementation for direnv.
+
+          It can be enabled through the option 'programs.direnv.enableNixDirenvIntegration'.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -70,6 +70,11 @@ in {
         Whether to enable Fish integration.
       '';
     };
+
+    enableNixDirenvIntegration = mkEnableOption ''
+      <link
+          xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
+          a fast, persistent use_nix implementation for direnv'';
   };
 
   config = mkIf cfg.enable {
@@ -78,8 +83,14 @@ in {
     xdg.configFile."direnv/config.toml" =
       mkIf (cfg.config != { }) { source = configFile cfg.config; };
 
-    xdg.configFile."direnv/direnvrc" =
-      mkIf (cfg.stdlib != "") { text = cfg.stdlib; };
+    xdg.configFile."direnv/direnvrc" = let
+      stdlib = cfg.stdlib;
+      nixDirenv = cfg.enableNixDirenvIntegration;
+    in mkIf (cfg.stdlib != "" || nixDirenv) {
+      text = (optionalString (stdlib != "") (stdlib + "\n"))
+        + (optionalString nixDirenv
+          "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
+    };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (
       # Using mkAfter to make it more likely to appear after other

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -40,6 +40,7 @@ import nmt {
     ./modules/programs/bash
     ./modules/programs/browserpass
     ./modules/programs/dircolors
+    ./modules/programs/direnv
     ./modules/programs/fish
     ./modules/programs/git
     ./modules/programs/gpg

--- a/tests/modules/programs/direnv/bash.nix
+++ b/tests/modules/programs/direnv/bash.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.bash.enable = true;
+    programs.direnv.enable = true;
+
+    nmt.script = ''
+      assertFileExists home-files/.bashrc
+      assertFileRegex \
+        home-files/.bashrc \
+        'eval "\$(/nix/store/.*direnv.*/bin/direnv hook bash)"'
+    '';
+  };
+}

--- a/tests/modules/programs/direnv/default.nix
+++ b/tests/modules/programs/direnv/default.nix
@@ -1,4 +1,6 @@
 {
   direnv-bash = ./bash.nix;
+  direnv-nix-direnv = ./nix-direnv.nix;
   direnv-stdlib = ./stdlib.nix;
+  direnv-stdlib-and-nix-direnv = ./stdlib-and-nix-direnv.nix;
 }

--- a/tests/modules/programs/direnv/default.nix
+++ b/tests/modules/programs/direnv/default.nix
@@ -1,0 +1,4 @@
+{
+  direnv-bash = ./bash.nix;
+  direnv-stdlib = ./stdlib.nix;
+}

--- a/tests/modules/programs/direnv/nix-direnv.nix
+++ b/tests/modules/programs/direnv/nix-direnv.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.bash.enable = true;
+    programs.direnv.enable = true;
+    programs.direnv.enableNixDirenvIntegration = true;
+
+    nmt.script = ''
+      assertFileExists home-files/.bashrc
+      assertFileRegex \
+        home-files/.config/direnv/direnvrc \
+        'source /nix/store/.*nix-direnv.*/share/nix-direnv/direnvrc'
+    '';
+  };
+}

--- a/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
+++ b/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let expectedContent = "something important";
+in {
+  config = {
+    programs.bash.enable = true;
+    programs.direnv.enable = true;
+    programs.direnv.enableNixDirenvIntegration = true;
+    programs.direnv.stdlib = expectedContent;
+
+    nmt.script = ''
+      assertFileExists home-files/.bashrc
+      assertFileRegex \
+        home-files/.config/direnv/direnvrc \
+        'source /nix/store/.*nix-direnv.*/share/nix-direnv/direnvrc'
+      assertFileRegex \
+        home-files/.config/direnv/direnvrc \
+        '${expectedContent}'
+    '';
+  };
+}

--- a/tests/modules/programs/direnv/stdlib.nix
+++ b/tests/modules/programs/direnv/stdlib.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let expectedContent = "something important";
+in {
+  config = {
+    programs.bash.enable = true;
+    programs.direnv.enable = true;
+    programs.direnv.stdlib = expectedContent;
+
+    nmt.script = ''
+      assertFileExists home-files/.bashrc
+      assertFileRegex \
+        home-files/.config/direnv/direnvrc \
+        '${expectedContent}'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Add support for [nix-direnv](https://github.com/nix-community/nix-direnv) from @Mic92 to the direnv module.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like