### PR TITLE
sway: allow package to be null

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -159,6 +159,8 @@
 
 /modules/services/unison.nix                          @pacien
 
+/modlues/services/window-managers/i3-sway/sway.nix    @alexarice
+
 /modules/services/xcape.nix                           @nickhu
 
 /modules/services/xembed-sni-proxy.nix                @rycee

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -285,6 +285,8 @@ let
   };
 
 in {
+  meta.maintainers = [ maintainers.alexarice ];
+
   options.wayland.windowManager.sway = {
     enable = mkEnableOption "sway wayland compositor";
 

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -289,11 +289,15 @@ in {
     enable = mkEnableOption "sway wayland compositor";
 
     package = mkOption {
-      type = types.package;
+      type = with types; nullOr package;
       default = defaultSwayPackage;
       defaultText = literalExample "${pkgs.sway}";
       description = ''
-        Sway package to use. Will override the options 'wrapperFeatures', 'extraSessionCommands', and 'extraOptions'.
+        Sway package to use. Will override the options
+        'wrapperFeatures', 'extraSessionCommands', and 'extraOptions'.
+        Set to <code>null</code> to not add any Sway package to your
+        path. This should be done if you want to use the NixOS Sway
+        module to install Sway.
       '';
     };
 
@@ -372,14 +376,15 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ] ++ optional cfg.xwayland pkgs.xwayland;
+    home.packages = optional (cfg.package != null) cfg.package
+      ++ optional cfg.xwayland pkgs.xwayland;
     xdg.configFile."sway/config" = {
       source = configFile;
       onChange = ''
         swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway).sock
         if [ -S $swaySocket ]; then
           echo "Reloading sway"
-          $DRY_RUN_CMD ${cfg.package}/bin/swaymsg -s $swaySocket reload
+          $DRY_RUN_CMD ${pkgs.sway}/bin/swaymsg -s $swaySocket reload
         fi
       '';
     };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Allows the sway package to be set to `null` in the sway module. This should allow the nixos sway module to be used. see https://github.com/NixOS/nixpkgs/pull/89179 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.

I have also added myself as a codeowner for the module as this guideline didn't seem to be in place when I made the module