### PR TITLE
ssh: add support for ServerAliveCountMax

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1527,6 +1527,17 @@ in
           A new module is available: 'programs.zoxide'
         '';
       }
+
+      {
+        time = "2020-06-01T14:46:40+00:00";
+        condition = config.programs.ssh.enable;
+        message = ''
+          The ssh module now supports the 'ServerAliveCountMax' option
+          both globally (through 'programs.ssh.serverAliveCountMax')
+          and per match blocks (through
+          'programs.ssh.matchBlocks.<name>.serverAliveCountMax').
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -143,6 +143,14 @@ let
           "Set timeout in seconds after which response will be requested.";
       };
 
+      serverAliveCountMax = mkOption {
+        type = types.int;
+        default = 3;
+        description =
+          "Sets the number of server alive messages which may be sent
+          without ssh receiving any messages back from the server.";
+      };
+
       sendEnv = mkOption {
         type = types.listOf types.str;
         default = [];
@@ -281,7 +289,9 @@ let
     ++ optional (cf.addressFamily != null)   "  AddressFamily ${cf.addressFamily}"
     ++ optional (cf.sendEnv != [])           "  SendEnv ${unwords cf.sendEnv}"
     ++ optional (cf.serverAliveInterval != 0)
-         "  ServerAliveInterval ${toString cf.serverAliveInterval}"
+      "  ServerAliveInterval ${toString cf.serverAliveInterval}"
+    ++ optional (cf.serverAliveCountMax != 3)
+      "  ServerAliveCountMax ${toString cf.serverAliveCountMax}"
     ++ optional (cf.compression != null)     "  Compression ${yn cf.compression}"
     ++ optional (!cf.checkHostIP)            "  CheckHostIP no"
     ++ optional (cf.proxyCommand != null)    "  ProxyCommand ${cf.proxyCommand}"
@@ -323,6 +333,14 @@ in
       description = ''
         Set default timeout in seconds after which response will be requested.
       '';
+    };
+
+    serverAliveCountMax = mkOption {
+      type = types.int;
+      default = 3;
+      description =
+          "Sets the default number of server alive messages which may be sent
+          without ssh receiving any messages back from the server.";
     };
 
     hashKnownHosts = mkOption {
@@ -459,6 +477,7 @@ in
         ForwardAgent ${yn cfg.forwardAgent}
         Compression ${yn cfg.compression}
         ServerAliveInterval ${toString cfg.serverAliveInterval}
+        ServerAliveCountMax ${toString cfg.serverAliveCountMax}
         HashKnownHosts ${yn cfg.hashKnownHosts}
         UserKnownHostsFile ${cfg.userKnownHostsFile}
         ControlMaster ${cfg.controlMaster}

--- a/tests/modules/programs/ssh/default-config-expected.conf
+++ b/tests/modules/programs/ssh/default-config-expected.conf
@@ -6,6 +6,7 @@ Host *
   ForwardAgent no
   Compression no
   ServerAliveInterval 0
+  ServerAliveCountMax 3
   HashKnownHosts no
   UserKnownHostsFile ~/.ssh/known_hosts
   ControlMaster no

--- a/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
+++ b/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
@@ -10,6 +10,7 @@ Host *
   ForwardAgent no
   Compression no
   ServerAliveInterval 0
+  ServerAliveCountMax 3
   HashKnownHosts no
   UserKnownHostsFile ~/.ssh/known_hosts
   ControlMaster no

--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -10,6 +10,7 @@ Host abc
 
 Host xyz
   ServerAliveInterval 60
+  ServerAliveCountMax 10
   IdentityFile file
   LocalForward [localhost]:8080 [10.0.0.1]:80
   RemoteForward [localhost]:8081 [10.0.0.2]:80
@@ -23,6 +24,7 @@ Host *
   ForwardAgent no
   Compression no
   ServerAliveInterval 0
+  ServerAliveCountMax 3
   HashKnownHosts no
   UserKnownHostsFile ~/.ssh/known_hosts
   ControlMaster no

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -17,6 +17,7 @@ with lib;
         xyz = {
           identityFile = "file";
           serverAliveInterval = 60;
+          serverAliveCountMax = 10;
           localForwards = [{
             bind.port = 8080;
             host.address = "10.0.0.1";


### PR DESCRIPTION
### Description

Add the `ServerAliveCountMax` configuration option to the ssh module both globally (through 'programs.ssh.serverAliveCountMax')      and per match blocks (through 'programs.ssh.matchBlocks.<name>.serverAliveCountMax')

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like
