### PR TITLE
files: use canonical name in nativeBuildInputs

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -257,7 +257,7 @@ in
     home-files = pkgs.runCommand
       "home-manager-files"
       {
-        nativeBuildInputs = [ pkgs.xlibs.lndir ];
+        nativeBuildInputs = [ pkgs.xorg.lndir ];
         preferLocalBuild = true;
         allowSubstitutes = false;
       }


### PR DESCRIPTION
### Description


Allow `home-manager` to be used with `allowAliases = false;`

`rycee/nmd` also has aliases so this will only work when `manual.manpages.enable = false;` is set.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
