### PR TITLE
clipmenu: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -101,6 +101,8 @@
 
 /modules/services/cbatticon.nix                       @pmiddend
 
+/modules/services/clipmenu.nix                        @DamienCassou
+
 /modules/services/dunst.nix                           @rycee
 
 /modules/services/emacs.nix                           @tadfisher

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1552,6 +1552,13 @@ in
           It can be enabled through the option 'services.emacs.socketActivation.enable'.
         '';
       }
+
+      {
+        time = "2020-06-12T07:18:26+00:00";
+        message = ''
+          A new module is available: 'services.clipmenu'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -120,6 +120,7 @@ let
     (loadModule ./programs/zsh.nix { })
     (loadModule ./services/blueman-applet.nix { })
     (loadModule ./services/cbatticon.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./services/clipmenu.nix { })
     (loadModule ./services/compton.nix { })
     (loadModule ./services/dunst.nix { })
     (loadModule ./services/dwm-status.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/clipmenu.nix
+++ b/modules/services/clipmenu.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.clipmenu;
+in {
+  meta.maintainers = [ maintainers.DamienCassou ];
+
+  options.services.clipmenu = {
+    enable = mkEnableOption "clipmenu, the clipboard management daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.clipmenu;
+      defaultText = "pkgs.clipmenu";
+      description = "clipmenu derivation to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.clipmenu = {
+      Unit = {
+        Description = "Clipboard management daemon";
+        After = [ "graphical-session.target" ];
+      };
+      Service = {
+        ExecStart = "${cfg.package}/bin/clipmenud";
+        Environment = "PATH=${
+            makeBinPath
+            (with pkgs; [ coreutils findutils gnugrep gnused systemd ])
+          }";
+      };
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+    };
+
+    home.packages = [ cfg.package ];
+  };
+}


### PR DESCRIPTION
### Description

This is the same as the [NixOS service clipmenu](https://github.com/NixOS/nixpkgs/blob/20.03/nixos/modules/services/misc/clipmenu.nix).

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

- [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

- [x] Added myself and the module files to `.github/CODEOWNERS`.

I *haven't* added any new test case because this module only adds a systemd service. If there is a common way to test that, can someone please give me an example?