### PR TITLE
eclipse: Add option `package` to `programes.eclipse` module

### DIFF
--- a/modules/programs/eclipse.nix
+++ b/modules/programs/eclipse.nix
@@ -13,6 +13,15 @@ in {
     programs.eclipse = {
       enable = mkEnableOption "Eclipse";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.eclipses.eclipse-platform;
+        example = pkgs.eclipses.eclipse-java;
+        description = ''
+          The Eclipse package to install.
+        '';
+      };
+
       enableLombok = mkOption {
         type = types.bool;
         default = false;
@@ -40,7 +49,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [
       (pkgs.eclipses.eclipseWithPlugins {
-        eclipse = pkgs.eclipses.eclipse-platform;
+        eclipse = cfg.package;
         jvmArgs = cfg.jvmArgs ++ optional cfg.enableLombok
           "-javaagent:${pkgs.lombok}/share/java/lombok.jar";
         plugins = cfg.plugins;


### PR DESCRIPTION
### Description

Add config option `package` for module `programs.eclipse`
and assign `cfg.package` to the
`eclipse` parameter of `pkgs.eclipses.eclipseWithPlugins`,
instead of the hard-coded `pkgs.eclipses.eclipse-platform`.
This allows user to use other eclipse packages
like `pkgs.eclipses.eclipse-java`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
