### PR TITLE
travis-ci: override minver in Nixpkgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ os:
   - linux
   - osx
 
+before_script:
+  # Nixpkgs says it needs Nix 2.2 but we need to use 2.0.
+  - export NIX_PATH=$(nix-build --out-link nixpkgs -E '(import <nixpkgs/pkgs/top-level/impure.nix> {}).runCommandLocal "tweaked-nixpkgs" {} "cp -a ${<nixpkgs>} $out && chmod -v a+w $out/default.nix && echo import ./pkgs/top-level/impure.nix > $out/default.nix"'):$NIX_PATH
+
 script:
   - nix-shell . -A install
   - nix-shell --pure --max-jobs 10 tests -A run.all


### PR DESCRIPTION
This overrides the `minver.nix` file in Nixpkgs to allow evaluation by Nix 2.0 as necessary by Travis-CI.