### PR TITLE
fluidsynth: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -111,6 +111,8 @@
 
 /modules/services/flameshot.nix                       @moredhel
 
+/modules/services/fluidsynth.nix                      @Valodim
+
 /modules/services/gnome-keyring.nix                   @rycee
 
 /modules/services/gpg-agent.nix                       @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1568,6 +1568,14 @@ in
           A new module is available: 'programs.powerline-go'
         '';
       }
+
+      {
+        time = "2020-06-13T12:00:00+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'service.fluidsynth'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -127,6 +127,7 @@ let
     (loadModule ./services/dwm-status.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/emacs.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/flameshot.nix { })
+    (loadModule ./services/fluidsynth.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/getmail.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/gnome-keyring.nix { })
     (loadModule ./services/gpg-agent.nix { })

--- a/modules/services/fluidsynth.nix
+++ b/modules/services/fluidsynth.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  name = "fluidsynth";
+  cfg = config.services.fluidsynth;
+in {
+  meta.maintainers = [ maintainers.valodim ];
+
+  ###### interface
+  options = {
+    services.fluidsynth = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable fluidsynth, the music player daemon.
+        '';
+      };
+
+      soundFont = mkOption {
+        type = types.path;
+        default = "${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2";
+        description = ''
+          The soundfont file to use, in SoundFont 2 format.
+        '';
+      };
+
+      extraOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "--sample-rate 96000" ];
+        description = ''
+          Extra arguments, added verbatim to the fluidsynth command.
+          <citerefentry>
+            <refentrytitle>fluidsynth.conf</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    systemd.user.services.fluidsynth = {
+      Unit = {
+        Description = "FluidSynth Daemon";
+        Documentation = "man:fluidsynth(1)";
+        BindsTo = [ "pulseaudio.service" ];
+        After = [ "pulseaudio.service" ];
+      };
+      Install = { WantedBy = [ "default.target" ]; };
+      Service = {
+        ExecStart = "${pkgs.fluidsynth}/bin/fluidsynth -a pulseaudio -si ${
+            lib.concatStringsSep " " cfg.extraOptions
+          } ${cfg.soundFont}";
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -79,6 +79,7 @@ import nmt {
     ./modules/programs/rofi
     ./modules/services/polybar
     ./modules/services/sxhkd
+    ./modules/services/fluidsynth
     ./modules/services/window-managers/i3
     ./modules/systemd
     ./modules/targets

--- a/tests/modules/services/fluidsynth/default.nix
+++ b/tests/modules/services/fluidsynth/default.nix
@@ -1,0 +1,1 @@
+{ fluidsynth = import ./service.nix; }

--- a/tests/modules/services/fluidsynth/service.nix
+++ b/tests/modules/services/fluidsynth/service.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }: {
+  config = {
+    services.fluidsynth.enable = true;
+    services.fluidsynth.soundFont = "/path/to/soundFont";
+    services.fluidsynth.extraOptions = [ "--sample-rate 96000" ];
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/fluidsynth.service
+
+      assertFileExists $serviceFile
+
+      assertFileRegex $serviceFile 'ExecStart=.*/bin/fluidsynth.*--sample-rate 96000.*/path/to/soundFont'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Add fluidsynth service.

Fluidsynth is a real-time MIDI synthesizer, based on the SoundFont 2 format.

This works well for me with pulseaudio, but I can't speak for JACK or other audio drivers and fluidsynth doesn't seem to be very good at picking on its own, so I made this pulseaudio-specific for now. If anyone wants to expand on this, feel free. :)

To test:
``` sh
# find midi port
aplaymidi -l
# play some midi file
aplaymidi -p 128:0 somefile.mid`
```

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.fluidsynth`.
- [x] Test cases updated/added.
- [x] Commit messages are formatted like
- If this PR adds a new module
  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
  - [x] Added myself and the module files to `.github/CODEOWNERS`.