### PR TITLE
vscode: Fix extensions directory path

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -77,12 +77,13 @@ in
     # Adapted from https://discourse.nixos.org/t/vscode-extensions-setup/1801/2
     home.file =
       let
+        subDir = "share/vscode/extensions";
         toPaths = path:
           # Links every dir in path to the extension path.
-          mapAttrsToList (k: v:
+          mapAttrsToList (k: _:
             {
-              "${extensionPath}/${k}".source = "${path}/${k}";
-            }) (builtins.readDir path);
+              "${extensionPath}/${k}".source = "${path}/${subDir}/${k}";
+            }) (builtins.readDir (path + "/${subDir}"));
         toSymlink = concatMap toPaths cfg.extensions;
       in
         foldr


### PR DESCRIPTION
### Description

Fixes #1302

as a result of upstream vscode extension path changes here:
https://github.com/NixOS/nixpkgs/pull/89196

### Checklist

~~- [ ] Change is backwards compatible.~~

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```