### PR TITLE
waybar: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,9 @@
 
 /modules/programs/texlive.nix                         @rycee
 
+/modules/programs/waybar.nix                          @berbiche
+/tests/modules/programs/waybar                        @berbiche
+
 /modules/programs/z-lua.nix                           @marsam
 
 /modules/programs/zathura.nix                         @rprospero

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -25,4 +25,14 @@
     github = "cwyc";
     githubId = 16950437;
   };
+  berbiche = {
+    name = "Nicolas Berbiche";
+    email = "berbiche@users.noreply.github.com";
+    github = "berbiche";
+    githubId = 20448408;
+    keys = [{
+      longkeyid = "rsa4096/0xB461292445C6E696";
+      fingerprint = "D446 E58D 87A0 31C7 EC15  88D7 B461 2924 45C6 E696";
+    }];
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1604,6 +1604,14 @@ in
           A new module is available: 'programs.ne'
         '';
       }
+
+      {
+        time = "2020-07-18T18:13:00+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.waybar'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -117,6 +117,7 @@ let
     (loadModule ./programs/vim.nix { })
     (loadModule ./programs/vscode.nix { })
     (loadModule ./programs/vscode/haskell.nix { })
+    (loadModule ./programs/waybar.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/z-lua.nix { })
     (loadModule ./programs/zathura.nix { })
     (loadModule ./programs/zoxide.nix { })

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -200,10 +200,9 @@ in {
             layer = "top";
             position = "top";
             height = 30;
-            # Specify outputs to restrict to certain outputs, otherwise show on all outputs
             output = [
               "eDP-1"
-              "DP-1"
+              "HDMI-A-1"
             ];
             modules-left = [ "sway/workspaces" "sway/mode" "wlr/taskbar" ];
             modules-center = [ "sway/window" "custom/hello-from-waybar" ];
@@ -217,11 +216,9 @@ in {
                 format = "hello {}";
                 max-length = 40;
                 interval = "once";
-                # You may be interested in using symlinkJoin to merge all scripts in one derivation
-                # to have them all under one directory structure in the nix store
-                exec = "''${pkgs.writers.writeBashBin "hello-from-waybar" '''
+                exec = pkgs.writeShellScript "hello-from-waybar" '''
                   echo "from within waybar"
-                '''}/bin/hello-from-waybar";
+                ''';
               };
             };
           }

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -259,7 +259,7 @@ in {
   config = let
     # Inspired by https://github.com/NixOS/nixpkgs/pull/89781
     writePrettyJSON = name: x:
-      pkgs.runCommandNoCCLocal name { } ''
+      pkgs.runCommandLocal name { } ''
         ${pkgs.jq}/bin/jq . > $out <<<${escapeShellArg (builtins.toJSON x)}
       '';
 

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -1,0 +1,378 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.waybar;
+
+  # Used when generating warnings
+  modulesPath = "programs.waybar.settings.[].modules";
+
+  # Taken from <https://github.com/Alexays/Waybar/blob/adaf84304865e143e4e83984aaea6f6a7c9d4d96/src/factory.cpp>
+  defaultModuleNames = [
+    "sway/mode"
+    "sway/workspaces"
+    "sway/window"
+    "wlr/taskbar"
+    "idle_inhibitor"
+    "memory"
+    "cpu"
+    "clock"
+    "disk"
+    "tray"
+    "network"
+    "backlight"
+    "pulseaudio"
+    "mpd"
+    "temperature"
+    "bluetooth"
+    "battery"
+  ];
+
+  isValidCustomModuleName = x:
+    lib.elem x defaultModuleNames
+    || (lib.hasPrefix "custom/" x && lib.stringLength x > 7);
+
+  margins = let
+    mkMargin = name: {
+      "margin-${name}" = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+        example = 10;
+        description = "Margins value without unit.";
+      };
+    };
+    margins = map mkMargin [ "top" "left" "bottom" "right" ];
+  in lib.foldl' lib.mergeAttrs { } margins;
+
+  waybarBarConfig = with lib.types;
+    submodule {
+      options = {
+        layer = lib.mkOption {
+          type = nullOr (enum [ "top" "bottom" ]);
+          default = null;
+          description = ''
+            Decide if the bar is displayed in front (<code>"top"</code>)
+            of the windows or behind (<code>"bottom"</code>).
+          '';
+          example = "top";
+        };
+
+        output = lib.mkOption {
+          type = nullOr (either str (listOf str));
+          default = null;
+          example = literalExample ''
+            [ "DP-1" "!DP-2" "!DP-3" ]
+          '';
+          description = ''
+            Specifies on which screen this bar will be displayed.
+            Exclamation mark(!) can be used to exclude specific output.
+          '';
+        };
+
+        position = lib.mkOption {
+          type = nullOr (enum [ "top" "bottom" "left" "right" ]);
+          default = null;
+          example = "right";
+          description = "Bar position relative to the output.";
+        };
+
+        height = lib.mkOption {
+          type = nullOr ints.unsigned;
+          default = null;
+          example = 5;
+          description =
+            "Height to be used by the bar if possible. Leave blank for a dynamic value.";
+        };
+
+        width = lib.mkOption {
+          type = nullOr ints.unsigned;
+          default = null;
+          example = 5;
+          description =
+            "Width to be used by the bar if possible. Leave blank for a dynamic value.";
+        };
+
+        modules-left = lib.mkOption {
+          type = nullOr (listOf str);
+          default = null;
+          description = "Modules that will be displayed on the left.";
+          example = literalExample ''
+            [ "sway/workspaces" "sway/mode" "wlr/taskbar" ]
+          '';
+        };
+
+        modules-center = lib.mkOption {
+          type = nullOr (listOf str);
+          default = null;
+          description = "Modules that will be displayed in the center.";
+          example = literalExample ''
+            [ "sway/window" ]
+          '';
+        };
+
+        modules-right = lib.mkOption {
+          type = nullOr (listOf str);
+          default = null;
+          description = "Modules that will be displayed on the right.";
+          example = literalExample ''
+            [ "mpd" "custom/mymodule#with-css-id" "temperature" ]
+          '';
+        };
+
+        modules = lib.mkOption {
+          type = attrsOf unspecified;
+          default = { };
+          description = "Modules configuration.";
+          example = literalExample ''
+            {
+              "sway/window" = {
+                max-length = 50;
+              };
+              "clock" = {
+                format-alt = "{:%a, %d. %b  %H:%M}";
+              };
+              "custom/hello-from" = {
+                format = "hello {}";
+                max-length = 40;
+                interval = 10;
+                # If you have multiple scripts defined inline, you may be interested in
+                # using symlinkJoin to merge all scripts in one derivation
+                # to have them all under one directory structure in the nix store
+                exec = "''${pkgs.writers.writeBashBin "hello-from-waybar" '''
+                  echo "from within waybar"
+                '''}/bin/hello-from-waybar";
+              };
+            }
+          '';
+        };
+
+        margin = lib.mkOption {
+          type = nullOr str;
+          default = null;
+          description = "Margins value using the CSS format without units.";
+          example = "20 5";
+        };
+
+        inherit (margins) margin-top margin-left margin-bottom margin-right;
+
+        name = lib.mkOption {
+          type = nullOr str;
+          default = null;
+          description =
+            "Optional name added as a CSS class, for styling multiple waybars.";
+          example = "waybar-1";
+        };
+
+        gtk-layer-shell = lib.mkOption {
+          type = nullOr bool;
+          default = null;
+          example = false;
+          description =
+            "Option to disable the use of gtk-layer-shell for popups.";
+        };
+      };
+    };
+in {
+  meta.maintainers = [ lib.hm.maintainers.berbiche ];
+
+  options.programs.waybar = with lib.types; {
+    enable = lib.mkEnableOption "Waybar";
+
+    package = lib.mkOption {
+      type = nullOr package;
+      default = pkgs.waybar;
+      defaultText = literalExample "${pkgs.waybar}";
+      description = ''
+        Waybar package to use. Set to <code>null</code> to use the default module.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = listOf waybarBarConfig;
+      default = [ ];
+      description = ''
+        Configuration for Waybar, see <link
+          xlink:href="https://github.com/Alexays/Waybar/wiki/Configuration"/>
+        for supported values.
+      '';
+      example = literalExample ''
+        [
+          {
+            layer = "top";
+            position = "top";
+            height = 30;
+            # Specify outputs to restrict to certain outputs, otherwise show on all outputs
+            output = [
+              "eDP-1"
+              "DP-1"
+            ];
+            modules-left = [ "sway/workspaces" "sway/mode" "wlr/taskbar" ];
+            modules-center = [ "sway/window" "custom/hello-from-waybar" ];
+            modules-right = [ "mpd" "custom/mymodule#with-css-id" "temperature" ];
+            modules = {
+              "sway/workspaces" = {
+                disable-scroll = true;
+                all-outputs = true;
+              };
+              "custom/hello-from-waybar" = {
+                format = "hello {}";
+                max-length = 40;
+                interval = "once";
+                # You may be interested in using symlinkJoin to merge all scripts in one derivation
+                # to have them all under one directory structure in the nix store
+                exec = "''${pkgs.writers.writeBashBin "hello-from-waybar" '''
+                  echo "from within waybar"
+                '''}/bin/hello-from-waybar";
+              };
+            };
+          }
+        ]
+      '';
+    };
+
+    systemd.enable = lib.mkEnableOption "Waybar Systemd integration";
+
+    style = lib.mkOption {
+      type = nullOr str;
+      default = null;
+      description = ''
+        CSS style of the bar.
+        See <link
+          xlink:href="https://github.com/Alexays/Waybar/wiki/Configuration"/> for the documentation.
+      '';
+      example = ''
+        * {
+          border: none;
+          border-radius: 0;
+          font-family: Source Code Pro;
+        }
+        window#waybar {
+          background: #16191C;
+          color: #AAB2BF;
+        }
+        #workspaces button {
+          padding: 0 5px;
+        }
+      '';
+    };
+  };
+
+  config = let
+    # Inspired by https://github.com/NixOS/nixpkgs/pull/89781
+    writePrettyJSON = name: x:
+      pkgs.runCommandNoCCLocal name { } ''
+        ${pkgs.jq}/bin/jq . > $out <<<${lib.escapeShellArg (builtins.toJSON x)}
+      '';
+
+    configSource = let
+      # Removes nulls because Waybar ignores them for most values
+      removeNulls = lib.filterAttrs (_: v: v != null);
+
+      # Makes the actual valid configuration Waybar accepts
+      # (strips our custom settings before converting to JSON)
+      makeConfiguration = configuration:
+        let
+          # The "modules" option is not valid in the JSON
+          # as its descendants have to live at the top-level
+          settingsWithoutModules =
+            lib.filterAttrs (n: _: n != "modules") configuration;
+          settingsModules = lib.optionalAttrs (configuration.modules != { })
+            configuration.modules;
+        in removeNulls (settingsWithoutModules // settingsModules);
+      # The clean list of configurations
+      finalConfiguration = map makeConfiguration cfg.settings;
+    in writePrettyJSON "waybar-config.json" finalConfiguration;
+
+    warnings = let
+      mkUnreferencedModuleWarning = name:
+        "The module '${name}' defined in '${modulesPath}' is not referenced "
+        + "in either `modules-left`, `modules-center` or `modules-right` of Waybar's options";
+      mkUndefinedModuleWarning = settings: name:
+        let
+          # Locations where the module is undefined (a combination modules-{left,center,right})
+          locations = lib.flip lib.filter [ "left" "center" "right" ]
+            (x: lib.elem name settings."modules-${x}");
+          mkPath = loc: "'${modulesPath}-${loc}'";
+          # The modules-{left,center,right} configuration that includes
+          # an undefined module
+          path = lib.concatMapStringsSep " and " mkPath locations;
+        in "The module '${name}' defined in ${path} is neither "
+        + "a default module or a custom module declared in '${modulesPath}'";
+      mkInvalidModuleNameWarning = name:
+        "The custom module '${name}' defined in '${modulesPath}' is not a valid "
+        + "module name. A custom module's name must start with 'custom/' "
+        + "like 'custom/mymodule' for instance";
+
+      # Find all modules in `modules-{left,center,right}` and `modules` not declared/referenced.
+      # `cfg.settings` is a list of Waybar configurations
+      # and we need to preserve the index for appropriate warnings
+      allFaultyModules = lib.flip map cfg.settings (settings:
+        let
+          allModules = lib.unique
+            (lib.concatMap (x: lib.attrByPath [ "modules-${x}" ] [ ] settings) [
+              "left"
+              "center"
+              "right"
+            ]);
+          declaredModules = lib.attrNames settings.modules;
+          # Modules declared in `modules` but not referenced in `modules-{left,center,right}`
+          unreferencedModules = lib.subtractLists allModules declaredModules;
+          # Modules listed in modules-{left,center,right} that are not default modules
+          nonDefaultModules = lib.subtractLists defaultModuleNames allModules;
+          # Modules referenced in `modules-{left,center,right}` but not declared in `modules`
+          undefinedModules =
+            lib.subtractLists declaredModules nonDefaultModules;
+          # Check for invalid module names
+          invalidModuleNames = lib.filter (m: !isValidCustomModuleName m)
+            (lib.attrNames settings.modules);
+        in {
+          # The Waybar bar configuration (since config.settings is a list)
+          settings = settings;
+          undef = undefinedModules;
+          unref = unreferencedModules;
+          invalidName = invalidModuleNames;
+        });
+
+      allWarnings = lib.flip lib.concatMap allFaultyModules
+        ({ settings, undef, unref, invalidName }:
+          let
+            unreferenced = map mkUnreferencedModuleWarning unref;
+            undefined = map (mkUndefinedModuleWarning settings) undef;
+            invalid = map mkInvalidModuleNameWarning invalidName;
+          in undefined ++ unreferenced ++ invalid);
+    in allWarnings;
+
+  in lib.mkIf cfg.enable (lib.mkMerge [
+    { home.packages = [ cfg.package ]; }
+    (lib.mkIf (cfg.settings != [ ]) {
+      # Generate warnings about defined but unreferenced modules
+      inherit warnings;
+
+      xdg.configFile."waybar/config".source = configSource;
+    })
+    (lib.mkIf (cfg.style != null) {
+      xdg.configFile."waybar/style.css".text = cfg.style;
+    })
+    (lib.mkIf cfg.systemd.enable {
+      systemd.user.services.waybar = {
+        Unit = {
+          Description =
+            "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
+          Documentation = "https://github.com/Alexays/Waybar/wiki";
+          PartOf = [ "graphical-session.target" ];
+          Requisite = [ "dbus.service" ];
+          After = [ "dbus.service" ];
+        };
+
+        Service = {
+          Type = "dbus";
+          BusName = "fr.arouillard.waybar";
+          ExecStart = "${cfg.package}/bin/waybar";
+          Restart = "always";
+          RestartSec = "1sec";
+        };
+
+        Install = { WantedBy = [ "graphical-session.target" ]; };
+      };
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -79,6 +79,7 @@ import nmt {
     ./modules/programs/getmail
     ./modules/services/lieer
     ./modules/programs/rofi
+    ./modules/programs/waybar
     ./modules/services/polybar
     ./modules/services/sxhkd
     ./modules/services/fluidsynth

--- a/tests/modules/programs/waybar/broken-settings.nix
+++ b/tests/modules/programs/waybar/broken-settings.nix
@@ -1,0 +1,80 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  package = pkgs.writeScriptBin "dummy-waybar" "" // { outPath = "@waybar@"; };
+  expected = pkgs.writeText "expected-json" ''
+    [
+      {
+        "height": 26,
+        "layer": "top",
+        "modules-center": [
+          "sway/window"
+        ],
+        "modules-left": [
+          "sway/workspaces",
+          "sway/mode"
+        ],
+        "modules-right": [
+          "idle_inhibitor",
+          "pulseaudio",
+          "network",
+          "cpu",
+          "memory",
+          "backlight",
+          "tray",
+          "clock"
+        ],
+        "output": [
+          "DP-1",
+          "eDP-1",
+          "HEADLESS-1"
+        ],
+        "position": "top",
+        "sway/workspaces": {
+          "all-outputs": true
+        }
+      }
+    ]
+  '';
+in {
+  config = {
+    programs.waybar = {
+      inherit package;
+      enable = true;
+      systemd.enable = true;
+      settings = [{
+        layer = "top";
+        position = "top";
+        height = 26;
+        output = [ "DP-1" "eDP-1" "HEADLESS-1" ];
+        modules-left = [ "sway/workspaces" "sway/mode" ];
+        modules-center = [ "sway/window" ];
+        modules-right = [
+          "idle_inhibitor"
+          "pulseaudio"
+          "network"
+          "cpu"
+          "memory"
+          "backlight"
+          "tray"
+          "clock"
+        ];
+
+        modules = { "sway/workspaces".all-outputs = true; };
+      }];
+    };
+
+    nmt.description = ''
+      Test for the broken configuration
+      https://github.com/rycee/home-manager/pull/1329#issuecomment-653253069
+    '';
+    nmt.script = ''
+      assertPathNotExists home-files/.config/waybar/style.css
+      assertFileContent \
+        home-files/.config/waybar/config \
+        ${expected}
+    '';
+  };
+}

--- a/tests/modules/programs/waybar/default.nix
+++ b/tests/modules/programs/waybar/default.nix
@@ -1,0 +1,8 @@
+{
+  waybar-systemd-with-graphical-session-target =
+    ./systemd-with-graphical-session-target.nix;
+  waybar-styling = ./styling.nix;
+  waybar-settings-complex = ./settings-complex.nix;
+  # Broken configuration from https://github.com/rycee/home-manager/pull/1329#issuecomment-653253069
+  waybar-broken-settings = ./broken-settings.nix;
+}

--- a/tests/modules/programs/waybar/settings-complex-expected.json
+++ b/tests/modules/programs/waybar/settings-complex-expected.json
@@ -1,0 +1,46 @@
+[
+  {
+    "custom/my-module": {
+      "exec": "@dummy@/bin/dummy",
+      "format": "hello from {}"
+    },
+    "height": 30,
+    "idle_inhibitor": {
+      "format": "{icon}"
+    },
+    "layer": "top",
+    "modules-center": [
+      "sway/window"
+    ],
+    "modules-left": [
+      "sway/workspaces",
+      "sway/mode",
+      "custom/my-module"
+    ],
+    "modules-right": [
+      "idle_inhibitor",
+      "pulseaudio",
+      "network",
+      "cpu",
+      "memory",
+      "backlight",
+      "tray",
+      "battery",
+      "clock"
+    ],
+    "output": [
+      "DP-1"
+    ],
+    "position": "top",
+    "sway/mode": {
+      "tooltip": false
+    },
+    "sway/window": {
+      "max-length": 120
+    },
+    "sway/workspaces": {
+      "all-outputs": true,
+      "disable-scroll": true
+    }
+  }
+]

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  package = pkgs.writeScriptBin "dummy-waybar" "" // { outPath = "@waybar@"; };
+in {
+  config = {
+    programs.waybar = {
+      inherit package;
+      enable = true;
+      settings = [{
+        layer = "top";
+        position = "top";
+        height = 30;
+        output = [ "DP-1" ];
+        modules-left = [ "sway/workspaces" "sway/mode" "custom/my-module" ];
+        modules-center = [ "sway/window" ];
+        modules-right = [
+          "idle_inhibitor"
+          "pulseaudio"
+          "network"
+          "cpu"
+          "memory"
+          "backlight"
+          "tray"
+          "battery"
+          "clock"
+        ];
+
+        modules = {
+          "sway/workspaces" = {
+            disable-scroll = true;
+            all-outputs = true;
+          };
+          "sway/mode" = { tooltip = false; };
+          "sway/window" = { max-length = 120; };
+          "idle_inhibitor" = { format = "{icon}"; };
+          "custom/my-module" = {
+            format = "hello from {}";
+            exec = let
+              dummyScript =
+                pkgs.writeShellScriptBin "dummy" "echo within waybar" // {
+                  outPath = "@dummy@";
+                };
+            in "${dummyScript}/bin/dummy";
+          };
+        };
+      }];
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/waybar/style.css
+      assertFileContent \
+        home-files/.config/waybar/config \
+        ${./settings-complex-expected.json}
+    '';
+  };
+}

--- a/tests/modules/programs/waybar/styling-expected.css
+++ b/tests/modules/programs/waybar/styling-expected.css
@@ -1,0 +1,23 @@
+* {
+    border: none;
+    border-radius: 0;
+    font-family: Source Code Pro;
+    font-weight: bold;
+    color: #abb2bf;
+    font-size: 18px;
+    min-height: 0px;
+}
+window#waybar {
+    background: #16191C;
+    color: #aab2bf;
+}
+#window {
+    padding: 0 0px;
+}
+#workspaces button:hover {
+    box-shadow: inherit;
+    text-shadow: inherit;
+    background: #16191C;
+    border: #16191C;
+    padding: 0 3px;
+}

--- a/tests/modules/programs/waybar/styling.nix
+++ b/tests/modules/programs/waybar/styling.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  package = pkgs.writeScriptBin "dummy-waybar" "" // { outPath = "@waybar@"; };
+in {
+  config = {
+    programs.waybar = {
+      inherit package;
+      enable = true;
+      style = ''
+        * {
+            border: none;
+            border-radius: 0;
+            font-family: Source Code Pro;
+            font-weight: bold;
+            color: #abb2bf;
+            font-size: 18px;
+            min-height: 0px;
+        }
+        window#waybar {
+            background: #16191C;
+            color: #aab2bf;
+        }
+        #window {
+            padding: 0 0px;
+        }
+        #workspaces button:hover {
+            box-shadow: inherit;
+            text-shadow: inherit;
+            background: #16191C;
+            border: #16191C;
+            padding: 0 3px;
+        }
+      '';
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/waybar/config
+      assertFileContent \
+        home-files/.config/waybar/style.css \
+        ${./styling-expected.css}
+    '';
+  };
+}

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  package = pkgs.writeScriptBin "dummy-waybar" "" // { outPath = "@waybar@"; };
+in {
+  config = {
+    programs.waybar = {
+      inherit package;
+      enable = true;
+      systemd.enable = true;
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/waybar/config
+      assertPathNotExists home-files/.config/waybar/style.css
+
+      assertFileContent \
+        home-files/.config/systemd/user/waybar.service \
+        ${./systemd-with-graphical-session-target.service}
+    '';
+  };
+}

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -1,0 +1,16 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+BusName=fr.arouillard.waybar
+ExecStart=@waybar@/bin/waybar
+Restart=always
+RestartSec=1sec
+Type=dbus
+
+[Unit]
+After=dbus.service
+Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
+Documentation=https://github.com/Alexays/Waybar/wiki
+PartOf=graphical-session.target
+Requisite=dbus.service


### PR DESCRIPTION
### Description

Add a module for Waybar (improved upon #1130).

Additional notes:

- Warnings are emitted when modules used in the `modules-{left, center, right}` references unknown modules (modules that are neither in the default list or defined in the `modules` option)

- Warnings are emitted when modules defined in `modules` are not referenced in `modules-{left, center, right}`

- The `settings` option differs from Waybar in that module configurations are defined in `modules` instead of living alongside other settings.

  I think I could match Waybar by adding `_module.check = false` to allow options that are not defined while preserving checks for others (I believe?) and by changing the logic that verifies modules.

- `modules` option is not typed (type = attrs)

  This includes both normal modules as well as custom modules.

  Again, this is something I could implement if its wanted (I want to minimize the burden of maintaining the settings up-to-date)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
