### PR TITLE
vte: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,8 @@
 
 /modules/misc/tmpfiles.nix                            @dawidsowa
 
+/modules/misc/vte.nix                                 @rycee
+
 /modules/misc/xdg-mime-apps.nix                       @pacien
 
 /modules/misc/xdg-user-dirs.nix                       @pacien

--- a/modules/misc/vte.nix
+++ b/modules/misc/vte.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.rycee ];
+
+  options.programs = let
+    description = ''
+      Whether to enable integration with terminals using the VTE
+      library. This will let the terminal track the current working
+      directory.
+    '';
+  in {
+    bash.enableVteIntegration = mkEnableOption "" // { inherit description; };
+
+    zsh.enableVteIntegration = mkEnableOption "" // { inherit description; };
+  };
+
+  config = mkMerge [
+    (mkIf config.programs.bash.enableVteIntegration {
+      # Unfortunately we have to do a little dance here to fix two
+      # problems with the upstream vte.sh file:
+      #
+      #  - It does `PROMPT_COMMAND="__vte_prompt_command"` which
+      #    clobbers any previously assigned prompt command.
+      #
+      #  - Its `__vte_prompt_command` function runs commands that will
+      #    overwrite the exit status of the command the user ran.
+      programs.bash.initExtra = ''
+        __HM_PROMPT_COMMAND="''${PROMPT_COMMAND:+''${PROMPT_COMMAND%;};}__hm_vte_prompt_command"
+        . ${pkgs.vte}/etc/profile.d/vte.sh
+        if [[ $(type -t __vte_prompt_command) = function ]]; then
+          __hm_vte_prompt_command() {
+            local old_exit_status=$?
+            __vte_prompt_command
+            return $old_exit_status
+          }
+          PROMPT_COMMAND="$__HM_PROMPT_COMMAND"
+        fi
+        unset __HM_PROMPT_COMMAND
+      '';
+    })
+
+    (mkIf config.programs.zsh.enableVteIntegration {
+      programs.zsh.initExtra = ''
+        . ${pkgs.vte}/etc/profile.d/vte.sh
+      '';
+    })
+  ];
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -38,6 +38,7 @@ let
     (loadModule ./misc/submodule-support.nix { })
     (loadModule ./misc/tmpfiles.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/version.nix { })
+    (loadModule ./misc/vte.nix { })
     (loadModule ./misc/xdg-mime.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime-apps.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-user-dirs.nix { condition = hostPlatform.isLinux; })

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -6,11 +6,6 @@ let
 
   cfg = config.programs.gnome-terminal;
 
-  vteInitStr = ''
-    # gnome-terminal: Show current directory in the terminal window title.
-    . ${pkgs.vte}/etc/profile.d/vte.sh
-  '';
-
   backForeSubModule = types.submodule ({ ... }: {
     options = {
       foreground = mkOption {
@@ -217,7 +212,7 @@ in {
     (n: v: nameValuePair ("${dconfPath}/profiles:/:${n}") (buildProfileSet v))
     cfg.profile;
 
-    programs.bash.initExtra = mkBefore vteInitStr;
-    programs.zsh.initExtra = vteInitStr;
+    programs.bash.enableVteIntegration = true;
+    programs.zsh.enableVteIntegration = true;
   };
 }


### PR DESCRIPTION
This abstracts out the VTE setup from the gnome-terminal module into its own module and options.