### PR TITLE
fluidsynth: fix description

### DIFF
--- a/modules/services/fluidsynth.nix
+++ b/modules/services/fluidsynth.nix
@@ -11,7 +11,7 @@ in {
 
   options = {
     services.fluidsynth = {
-      enable = mkEnableOption "fluidsynth, the music player daemon";
+      enable = mkEnableOption "fluidsynth midi synthesizer";
 
       soundFont = mkOption {
         type = types.path;


### PR DESCRIPTION
I messed up the description of fluidsynth in #1326. The description as "music player daemon" was left over from the MPD module I used as a basis. Fluidsynth should really be described as midi synthesizer. :)