### PR TITLE
qutebrowser: add option to change the package used

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -36,6 +36,16 @@ in {
   options.programs.qutebrowser = {
     enable = mkEnableOption "qutebrowser";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.qutebrowser;
+      description = "Qutebrowser package to install.";
+      example = literalExample ''
+        pkgs.qutebrowser;
+      '';
+
+    };
+
     aliases = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -246,7 +256,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.qutebrowser ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."qutebrowser/config.py".text = concatStringsSep "\n" ([ ]
       ++ mapAttrsToList (formatLine "c.") cfg.settings


### PR DESCRIPTION
This will allow users of Nix on non-NixOS to specify None as their
qutebrowser package, thereby allowing them to use home-manager to handle
their qutebrowser config, while running their system-wide installed copy
of qutebrowser instead of the Nix-installed one.

This is necessary, because of what is described in #1315: sometimes
Nix-installed Qutebrowser fails to start, because of GLX issues.

Fixes #1315.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
