### PR TITLE
Move email account options to their owning modules

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -374,19 +374,7 @@ in {
     };
 
     accounts = mkOption {
-      type = types.attrsOf (types.submodule ([
-        mailAccountOpts
-        (import ../programs/alot-accounts.nix pkgs)
-        (import ../programs/astroid-accounts.nix)
-        (import ../programs/getmail-accounts.nix)
-        (import ../programs/lieer-accounts.nix)
-        (import ../programs/mbsync-accounts.nix)
-        (import ../programs/msmtp-accounts.nix)
-        (import ../programs/neomutt-accounts.nix)
-        (import ../programs/notmuch-accounts.nix)
-        (import ../programs/offlineimap-accounts.nix)
-      ] ++ optionals pkgs.stdenv.hostPlatform.isLinux
-        [ (import ../services/lieer-accounts.nix) ]));
+      type = types.attrsOf (types.submodule mailAccountOpts);
       default = { };
       description = "List of email accounts.";
     };

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -114,106 +114,112 @@ let
   '';
 
 in {
-  options.programs.alot = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
-      description = ''
-        Whether to enable the Alot mail user agent. Alot uses the
-        Notmuch email system and will therefore be automatically
-        enabled for each email account that is managed by Notmuch.
-      '';
-    };
+  options = {
+    programs.alot = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to enable the Alot mail user agent. Alot uses the
+          Notmuch email system and will therefore be automatically
+          enabled for each email account that is managed by Notmuch.
+        '';
+      };
 
-    hooks = mkOption {
-      type = types.lines;
-      default = "";
-      description = ''
-        Content of the hooks file.
-      '';
-    };
+      hooks = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Content of the hooks file.
+        '';
+      };
 
-    bindings = mkOption {
-      type = types.submodule {
-        options = {
-          global = mkOption {
-            type = types.attrsOf types.str;
-            default = { };
-            description = "Global keybindings.";
-          };
+      bindings = mkOption {
+        type = types.submodule {
+          options = {
+            global = mkOption {
+              type = types.attrsOf types.str;
+              default = { };
+              description = "Global keybindings.";
+            };
 
-          bufferlist = mkOption {
-            type = types.attrsOf types.str;
-            default = { };
-            description = "Bufferlist mode keybindings.";
-          };
+            bufferlist = mkOption {
+              type = types.attrsOf types.str;
+              default = { };
+              description = "Bufferlist mode keybindings.";
+            };
 
-          search = mkOption {
-            type = types.attrsOf types.str;
-            default = { };
-            description = "Search mode keybindings.";
-          };
+            search = mkOption {
+              type = types.attrsOf types.str;
+              default = { };
+              description = "Search mode keybindings.";
+            };
 
-          envelope = mkOption {
-            type = types.attrsOf types.str;
-            default = { };
-            description = "Envelope mode keybindings.";
-          };
+            envelope = mkOption {
+              type = types.attrsOf types.str;
+              default = { };
+              description = "Envelope mode keybindings.";
+            };
 
-          taglist = mkOption {
-            type = types.attrsOf types.str;
-            default = { };
-            description = "Taglist mode keybindings.";
-          };
+            taglist = mkOption {
+              type = types.attrsOf types.str;
+              default = { };
+              description = "Taglist mode keybindings.";
+            };
 
-          thread = mkOption {
-            type = types.attrsOf types.str;
-            default = { };
-            description = "Thread mode keybindings.";
+            thread = mkOption {
+              type = types.attrsOf types.str;
+              default = { };
+              description = "Thread mode keybindings.";
+            };
           };
         };
+        default = { };
+        description = ''
+          Keybindings.
+        '';
       };
-      default = { };
-      description = ''
-        Keybindings.
-      '';
-    };
 
-    tags = mkOption {
-      type = types.attrsOf tagSubmodule;
-      default = { };
-      description = "How to display the tags.";
-    };
-
-    settings = mkOption {
-      type = with types;
-        let primitive = either (either (either str int) bool) float;
-        in attrsOf primitive;
-      default = {
-        initial_command = "search tag:inbox AND NOT tag:killed";
-        auto_remove_unread = true;
-        handle_mouse = true;
-        prefer_plaintext = true;
+      tags = mkOption {
+        type = types.attrsOf tagSubmodule;
+        default = { };
+        description = "How to display the tags.";
       };
-      example = literalExample ''
-        {
+
+      settings = mkOption {
+        type = with types;
+          let primitive = either (either (either str int) bool) float;
+          in attrsOf primitive;
+        default = {
+          initial_command = "search tag:inbox AND NOT tag:killed";
           auto_remove_unread = true;
-          ask_subject = false;
-          thread_indent_replies = 2;
-        }
-      '';
-      description = ''
-        Configuration options added to alot configuration file.
-      '';
+          handle_mouse = true;
+          prefer_plaintext = true;
+        };
+        example = literalExample ''
+          {
+            auto_remove_unread = true;
+            ask_subject = false;
+            thread_indent_replies = 2;
+          }
+        '';
+        description = ''
+          Configuration options added to alot configuration file.
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Extra lines added to alot configuration file.
+        '';
+      };
     };
 
-    extraConfig = mkOption {
-      type = types.lines;
-      default = "";
-      description = ''
-        Extra lines added to alot configuration file.
-      '';
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./alot-accounts.nix pkgs));
     };
   };
 

--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -98,6 +98,10 @@ in {
         '';
       };
     };
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./astroid-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/getmail.nix
+++ b/modules/programs/getmail.nix
@@ -49,6 +49,12 @@ let
     ".getmail/getmail${if a.primary then "rc" else a.name}";
 
 in {
+  options = {
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./getmail-accounts.nix));
+    };
+  };
+
   config = mkIf getmailEnabled {
     home.file = foldl' (a: b: a // b) { }
       (map (a: { "${renderConfigFilepath a}".text = renderAccountConfig a; })

--- a/modules/programs/lieer.nix
+++ b/modules/programs/lieer.nix
@@ -43,6 +43,10 @@ in {
   options = {
     programs.lieer.enable =
       mkEnableOption "lieer Gmail synchronization for notmuch";
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./lieer-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -122,6 +122,10 @@ in {
         '';
       };
     };
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./mbsync-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -56,6 +56,10 @@ in {
         '';
       };
     };
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./msmtp-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -262,6 +262,10 @@ in {
         description = "Extra configuration appended to the end.";
       };
     };
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./neomutt-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -143,6 +143,10 @@ in {
         };
       };
     };
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./notmuch-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -147,6 +147,11 @@ in {
         '';
       };
     };
+
+    accounts.email.accounts = mkOption {
+      type = with types;
+        attrsOf (submodule (import ./offlineimap-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/services/lieer.nix
+++ b/modules/services/lieer.nix
@@ -52,6 +52,10 @@ in {
   options = {
     services.lieer.enable =
       mkEnableOption "lieer Gmail synchronization service";
+
+    accounts.email.accounts = mkOption {
+      type = with types; attrsOf (submodule (import ./lieer-accounts.nix));
+    };
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
This removes the long list of submodules from

    modules/accounts/email.nix

and instead move each entry to its owning module.