### PR TITLE
ne: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,9 @@
 
 /modules/programs/mpv.nix                             @tadeokondrak
 
+/modules/programs/ne.nix                              @cwyc
+/tests/modules/programs/ne                            @cwyc
+
 /modules/programs/noti.nix                            @marsam
 
 /modules/programs/obs-studio.nix                      @adisbladis

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -19,4 +19,10 @@
     github = "owm111";
     githubId = 7798336;
   };
+  cwyc = {
+    email = "cwyc@users.noreply.github.com";
+    name = "cwyc";
+    github = "cwyc";
+    githubId = 16950437;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -89,6 +89,7 @@ let
     (loadModule ./programs/mercurial.nix { })
     (loadModule ./programs/mpv.nix { })
     (loadModule ./programs/msmtp.nix { })
+    (loadModule ./programs/ne.nix { })
     (loadModule ./programs/neomutt.nix { })
     (loadModule ./programs/neovim.nix { })
     (loadModule ./programs/newsboat.nix { })

--- a/modules/programs/ne.nix
+++ b/modules/programs/ne.nix
@@ -1,0 +1,83 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.programs.ne;
+
+  autoPrefFiles = let
+    autoprefs = cfg.automaticPreferences
+      // optionalAttrs (cfg.defaultPreferences != "") {
+        ".default" = cfg.defaultPreferences;
+      };
+    gen = fileExtension: configText:
+      nameValuePair ".ne/${fileExtension}#ap" {
+        text = configText;
+      }; # generates [path].text format expected by home.file
+  in mapAttrs' gen autoprefs;
+in {
+  meta.maintainers = [ hm.maintainers.cwyc ];
+
+  options.programs.ne = {
+    enable = mkEnableOption "ne";
+
+    keybindings = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        KEY 7f BS
+        SEQ "\x1b[1;5D" 7f
+      '';
+      description = ''
+        Keybinding file for ne.
+      '';
+    };
+
+    defaultPreferences = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Default preferences for ne. </para><para>
+        Equivalent to <literal>programs.ne.automaticPreferences.".default"</literal>.
+      '';
+    };
+
+    automaticPreferences = mkOption {
+      type = types.attrsOf types.lines;
+      default = { };
+      example = {
+        nix = ''
+          TAB 0
+          TS 2
+        '';
+        js = ''
+          TS 4
+        '';
+      };
+      description = ''
+        Automatic preferences files for ne.
+      '';
+    };
+
+    menus = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Menu configuration file for ne.";
+    };
+
+    virtualExtensions = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Virtual extensions configuration file for ne.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.ne ];
+
+    home.file = {
+      ".ne/.keys" = mkIf (cfg.keybindings != "") { text = cfg.keybindings; };
+      ".ne/.extensions" =
+        mkIf (cfg.virtualExtensions != "") { text = cfg.virtualExtensions; };
+      ".ne/.menus" = mkIf (cfg.menus != "") { text = cfg.menus; };
+    } // autoPrefFiles;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -53,6 +53,7 @@ import nmt {
     ./modules/programs/lf
     ./modules/programs/lieer
     ./modules/programs/mbsync
+    ./modules/programs/ne
     ./modules/programs/neomutt
     ./modules/programs/newsboat
     ./modules/programs/qutebrowser

--- a/tests/modules/programs/ne/default.nix
+++ b/tests/modules/programs/ne/default.nix
@@ -1,0 +1,4 @@
+{
+  ne-defprefs = ./defprefs.nix;
+  ne-passthroughs = ./passthroughs.nix;
+}

--- a/tests/modules/programs/ne/defprefs.nix
+++ b/tests/modules/programs/ne/defprefs.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  defpref = ''
+    defined through defaultPreferences
+  '';
+  autopref = ''
+    defined through automaticPreferences
+  '';
+in {
+  config = {
+    programs.ne = {
+      enable = true;
+      defaultPreferences = defpref;
+      automaticPreferences.".default" = autopref;
+    };
+    nmt = {
+      description =
+        "Check that it gracefully handles the case of both defaultPreferences and automaticPreferences.'.default' being set, defaulting to the former.";
+      script = ''
+        assertFileExists home-files/.ne/.default#ap
+        assertFileContent home-files/.ne/.default#ap ${
+          builtins.toFile "defpref" defpref
+        }
+      '';
+
+    };
+  };
+}

--- a/tests/modules/programs/ne/passthroughs.nix
+++ b/tests/modules/programs/ne/passthroughs.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  #samples taken from the ne manual
+  keybindings = ''
+    SEQ  "\x1b[1;5D"  14A
+    KEY  14A          HELP
+  '';
+  menus = ''
+    MENU "File"
+    ITEM "Open...     ^O" Open
+    ITEM "Close         " Close
+    ITEM "DoIt          " Macro DoIt
+  '';
+  virtualExtensions = ''
+    sh   1  ^#!\s*/.*\b(bash|sh|ksh|zsh)\s*
+    csh  1  ^#!\s*/.*\b(csh|tcsh)\s*
+    pl   1  ^#!\s*/.*\bperl\b
+    py   1  ^#!\s*/.*\bpython[0-9]*\s*
+    rb   1  ^#!\s*/.*\bruby\s*
+    xml  1  ^<\?xml
+  '';
+  automaticPreferences = {
+    nix = ''
+      TAB 0
+      TS 2
+    '';
+    js = ''
+      TS 4
+    '';
+  };
+
+  checkFile = filename: contents: ''
+    assertFileExists home-files/.ne/${filename}
+    assertFileContent home-files/.ne/${filename} ${
+      builtins.toFile "checkFile" contents
+    }
+  '';
+in {
+  config = {
+    programs.ne = {
+      enable = true;
+      inherit keybindings;
+      inherit menus;
+      inherit virtualExtensions;
+      inherit automaticPreferences;
+    };
+    nmt = {
+      description = "Check that configuration files are correctly written";
+      script = concatStringsSep "\n" [
+        (checkFile ".keys" keybindings)
+        (checkFile ".extensions" virtualExtensions)
+        (checkFile ".menus" menus)
+        (concatStringsSep "\n" (mapAttrsToList
+          (extension: contents: checkFile "${extension}#ap" contents)
+          automaticPreferences) # generates a check command for each entry in automaticPreferences
+        )
+      ];
+    };
+  };
+}


### PR DESCRIPTION
### Description

I've added a simple module to place configuration files for the ne text editor

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
