### PR TITLE
home-environment: use per-user profile path in /etc

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -402,7 +402,7 @@ in
     home.profileDirectory =
       if config.submoduleSupport.enable
         && config.submoduleSupport.externalPackageInstall
-      then config.home.path
+      then "/etc/profiles/per-user/${cfg.username}"
       else cfg.homeDirectory + "/.nix-profile";
 
     home.sessionVariables =

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -68,7 +68,7 @@ in
 
     users.users = mkIf cfg.useUserPackages (
       mapAttrs (username: usercfg: {
-        packages = usercfg.home.packages;
+        packages = [ usercfg.home.path ];
       }) cfg.users
     );
 

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -72,6 +72,8 @@ in
       }) cfg.users
     );
 
+    environment.pathsToLink = mkIf cfg.useUserPackages [ "/etc/profile.d" ];
+
     system.activationScripts.postActivation.text =
       concatStringsSep "\n" (mapAttrsToList (username: usercfg: ''
         echo Activating home-manager configuration for ${username}

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -85,7 +85,7 @@ in {
       })));
 
     users.users = mkIf cfg.useUserPackages
-      (mapAttrs (username: usercfg: { packages = usercfg.home.packages; })
+      (mapAttrs (username: usercfg: { packages = [ usercfg.home.path ]; })
         cfg.users);
 
     systemd.services = mapAttrs' (_: usercfg:

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -88,6 +88,8 @@ in {
       (mapAttrs (username: usercfg: { packages = [ usercfg.home.path ]; })
         cfg.users);
 
+    environment.pathsToLink = mkIf cfg.useUserPackages [ "/etc/profile.d" ];
+
     systemd.services = mapAttrs' (_: usercfg:
       let username = usercfg.home.username;
       in nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {


### PR DESCRIPTION
Before the profile directory value would point directly to the build output in the Nix store. Unfortunately this would cause an infinite loop if the user's configuration directly or indirectly refers to the profile directory value.

CC @cole-h 