### PR TITLE
tmux: only enable secureSocket on Linux by default

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -251,7 +251,7 @@ in
       };
 
       secureSocket = mkOption {
-        default = true;
+        default = pkgs.stdenv.isLinux;
         type = types.bool;
         description = ''
           Store tmux socket under <filename>/run</filename>, which is more


### PR DESCRIPTION

### Description
Darwin does not have the `/run/user/` directory which is provided by `pam_systemd` on Linux.

Please backport it to `release-20.03`

<!--

Please provide a brief description of your change.

-->
Fixes #1270 https://github.com/NixOS/nixpkgs/issues/91185

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
