### PR TITLE
vscode: add keybdings config

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -20,11 +20,14 @@ let
     "vscodium" = "vscode-oss";
   }.${vscodePname};
 
-  configFilePath =
+  userDir =
     if pkgs.stdenv.hostPlatform.isDarwin then
-      "Library/Application Support/${configDir}/User/settings.json"
+      "Library/Application Support/${configDir}/User"
     else
-      "${config.xdg.configHome}/${configDir}/User/settings.json";
+      "${config.xdg.configHome}/${configDir}/User";
+
+  configFilePath = "${userDir}/settings.json";
+  keybindingsFilePath = "${userDir}/keybindings.json";
 
   # TODO: On Darwin where are the extensions?
   extensionPath = ".${extensionDir}/extensions";
@@ -56,6 +59,24 @@ in
         description = ''
           Configuration written to Visual Studio Code's
           <filename>settings.json</filename>.
+        '';
+      };
+
+      keybindings = mkOption {
+        type = types.listOf (types.attrsOf types.str);
+        default = [];
+        example = literalExample ''
+          [
+            {
+              key = "ctrl+c";
+              command = "editor.action.clipboardCopyAction";
+              when = "textInputFocus";
+            }
+          ]
+        '';
+        description = ''
+          Keybindings written to Visual Studio Code's
+          <filename>keybindings.json</filename>.
         '';
       };
 
@@ -92,6 +113,10 @@ in
             "${configFilePath}" =
               mkIf (cfg.userSettings != {}) {
                 text = builtins.toJSON cfg.userSettings;
+              };
+            "${keybindingsFilePath}" =
+              mkIf (cfg.keybindings != []) {
+                text = builtins.toJSON cfg.keybindings;
               };
           }
           toSymlink;

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -63,7 +63,26 @@ in
       };
 
       keybindings = mkOption {
-        type = types.listOf (types.attrsOf types.str);
+        type = types.listOf (types.submodule {
+          options = {
+            key = mkOption {
+              type = types.str;
+              example = "ctrl+c";
+              description = "The key or key-combination to bind.";
+            };
+            command = mkOption {
+              type = types.str;
+              example = "editor.action.clipboardCopyAction";
+              description = "The VS Code command to execute.";
+            };
+            when = mkOption {
+              type = types.str;
+              default = "";
+              example = "textInputFocus";
+              description = "Optional context filter.";
+            };
+          };
+        });
         default = [];
         example = literalExample ''
           [

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -64,6 +64,7 @@ import nmt {
     ./modules/programs/starship
     ./modules/programs/texlive
     ./modules/programs/tmux
+    ./modules/programs/vscode
     ./modules/programs/zplug
     ./modules/programs/zsh
     ./modules/xresources

--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -1,0 +1,1 @@
+{ vscode-keybindings = ./keybindings.nix; }

--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -11,6 +11,11 @@ let
       when = "textInputFocus && false";
     }
     {
+      key = "ctrl+c";
+      command = "deleteFile";
+      when = "";
+    }
+    {
       key = "d";
       command = "deleteFile";
       when = "explorerViewletVisible";

--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -1,0 +1,46 @@
+# Test that keybdinings.json is created correctly.
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  bindings = [
+    {
+      key = "ctrl+c";
+      command = "editor.action.clipboardCopyAction";
+      when = "textInputFocus && false";
+    }
+    {
+      key = "d";
+      command = "deleteFile";
+      when = "explorerViewletVisible";
+    }
+  ];
+
+  targetPath = if pkgs.stdenv.hostPlatform.isDarwin then
+    "Library/Application Support/Code/User/keybindings.json"
+  else
+    ".config/Code/User/keybindings.json";
+
+  expectedJson = pkgs.writeText "expected.json" (builtins.toJSON bindings);
+in {
+  config = {
+    programs.vscode = {
+      enable = true;
+      keybindings = bindings;
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        vscode = pkgs.runCommandLocal "vscode" { pname = "vscode"; } ''
+          mkdir -p $out/bin; touch $out/bin/code; chmod +x $out/bin/code;
+        '';
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists "home-files/${targetPath}"
+      assertFileContent "home-files/${targetPath}" "${expectedJson}"
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Add vscode keybindings setting that is written to keybindings.json.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

No tests exist

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

