### PR TITLE
emacs: Fix service environment

### DIFF
--- a/tests/modules/services/emacs/emacs-service-emacs.service
+++ b/tests/modules/services/emacs/emacs-service-emacs.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@emacs@/bin/emacs --fg-daemon
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon"
 ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
 Restart=on-failure
 

--- a/tests/modules/services/emacs/emacs-service.nix
+++ b/tests/modules/services/emacs/emacs-service.nix
@@ -24,7 +24,12 @@ with lib;
       assertFileExists home-path/share/applications/emacsclient.desktop
 
       assertFileContent home-files/.config/systemd/user/emacs.service \
-                        ${./emacs-service-emacs.service}
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) runtimeShell;
+                            src = ./emacs-service-emacs.service;
+                          }
+                        }
       assertFileContent home-path/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';

--- a/tests/modules/services/emacs/emacs-socket-26-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-26-emacs.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@emacs@/bin/emacs --fg-daemon="%T/emacs%U/server"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%T/emacs%U/server'"
 ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
 Restart=on-failure
 

--- a/tests/modules/services/emacs/emacs-socket-26.nix
+++ b/tests/modules/services/emacs/emacs-socket-26.nix
@@ -27,7 +27,12 @@ with lib;
       assertFileContent home-files/.config/systemd/user/emacs.socket \
                         ${./emacs-socket-26-emacs.socket}
       assertFileContent home-files/.config/systemd/user/emacs.service \
-                        ${./emacs-socket-26-emacs.service}
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) runtimeShell;
+                            src = ./emacs-socket-26-emacs.service;
+                          }
+                        }
       assertFileContent home-path/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';

--- a/tests/modules/services/emacs/emacs-socket-27-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-27-emacs.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@emacs@/bin/emacs --fg-daemon="%t/emacs/server"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%t/emacs/server'"
 ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
 Restart=on-failure
 

--- a/tests/modules/services/emacs/emacs-socket-27.nix
+++ b/tests/modules/services/emacs/emacs-socket-27.nix
@@ -29,7 +29,12 @@ in {
       assertFileContent home-files/.config/systemd/user/emacs.socket \
                         ${./emacs-socket-27-emacs.socket}
       assertFileContent home-files/.config/systemd/user/emacs.service \
-                        ${./emacs-socket-27-emacs.service}
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) runtimeShell;
+                            src = ./emacs-socket-27-emacs.service;
+                          }
+                        }
       assertFileContent home-path/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';


### PR DESCRIPTION
Emacs populates 'exec-path' at launch from the 'PATH' environment
variable. Likewise, the emacs derivation from nixpkgs populates
'load-path' from the 'NIX_PROFILES' variable. As neither of these are
available by default in the systemd user manager, revert to the previous
behavior of launching the Emacs daemon from a login shell.

### Description

Fixes #1354 
Fixes #1340 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
