### PR TITLE
kakoune: add support for plugins

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -498,6 +498,10 @@ let
     };
   };
 
+  kakouneWithPlugins = pkgs.wrapKakoune pkgs.kakoune-unwrapped {
+    configure = { plugins = cfg.plugins; };
+  };
+
   configFile = let
     wrapOptions = with cfg.config.wrapLines;
       concatStrings [
@@ -617,11 +621,22 @@ in {
           <filename>~/.config/kak/kakrc</filename>.
         '';
       };
+
+      plugins = mkOption {
+        type = with types; listOf package;
+        default = [ ];
+        example = literalExample "[ pkgs.kakounePlugins.kak-fzf ]";
+        description = ''
+          List of kakoune plugins to install. To get a list of
+          supported plugins run:
+          <command>nix-env -f '&lt;nixpkgs&gt;' -qaP -A kakounePlugins</command>.
+        '';
+      };
     };
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.kakoune ];
+    home.packages = [ kakouneWithPlugins ];
     xdg.configFile."kak/kakrc".source = configFile;
   };
 }

--- a/tests/modules/programs/kakoune/default.nix
+++ b/tests/modules/programs/kakoune/default.nix
@@ -1,1 +1,5 @@
-{ kakoune-whitespace-highlighter = ./whitespace-highlighter.nix; }
+{
+  kakoune-whitespace-highlighter = ./whitespace-highlighter.nix;
+  kakoune-no-plugins = ./no-plugins.nix;
+  kakoune-use-plugins = ./use-plugins.nix;
+}

--- a/tests/modules/programs/kakoune/no-plugins.nix
+++ b/tests/modules/programs/kakoune/no-plugins.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.kakoune = { enable = true; };
+
+    nmt.script = ''
+      assertFileNotRegex home-path/share/kak/plugins.kak . # file is empty
+    '';
+  };
+}

--- a/tests/modules/programs/kakoune/use-plugins.nix
+++ b/tests/modules/programs/kakoune/use-plugins.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.kakoune = {
+      enable = true;
+      plugins =
+        [ pkgs.kakounePlugins.kak-fzf pkgs.kakounePlugins.kak-powerline ];
+    };
+
+    nmt.script = let plugins_kak = "home-path/share/kak/plugins.kak";
+    in ''
+      assertFileRegex ${plugins_kak} \
+        '^source "/nix/store/.*-kak-powerline/share/kak/autoload/plugins/powerline/.*.kak"$'
+
+      assertFileRegex ${plugins_kak} \
+        '^source "/nix/store/.*-kak-fzf/share/kak/autoload/plugins/fzf/.*.kak"$'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

The kakoune editor has a plugin mechanism and several plugins are
already packaged under `pkgs.kakounePlugins`. However, adding these
packages to `home.packages` is not enough: the `kakoune` package
needs to be configured with the list of plugins to include, so
that they get sourced on start-up.

We add a `programs.kakoune.plugins` option, analogous to
`programs.vim.plugins`.

The change is backwards compatible since `pkgs.kakoune` is defined as

```
wrapKakoune kakoune-unwrapped { };
```

and `wrapKakoune` defaults the list of plugins to empty.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- ~If this PR adds a new module~
