### PR TITLE
kakoune: escape showWhitespace separators

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -515,12 +515,22 @@ let
       ];
 
     showWhitespaceOptions = with cfg.config.showWhitespace;
-      concatStrings [
-        (optionalString (tab != null) " -tab ${tab}")
-        (optionalString (tabStop != null) " -tabpad ${tabStop}")
-        (optionalString (space != null) " -spc ${space}")
-        (optionalString (nonBreakingSpace != null) " -nbsp ${nonBreakingSpace}")
-        (optionalString (lineFeed != null) " -lf ${lineFeed}")
+      let
+        quoteSep = sep:
+          if sep == "'" then
+            ''"'"''
+          else if lib.strings.stringLength sep == 1 then
+            "'${sep}'"
+          else
+            sep; # backwards compat, in case sep == "' '", etc.
+
+      in concatStrings [
+        (optionalString (tab != null) " -tab ${quoteSep tab}")
+        (optionalString (tabStop != null) " -tabpad ${quoteSep tabStop}")
+        (optionalString (space != null) " -spc ${quoteSep space}")
+        (optionalString (nonBreakingSpace != null)
+          " -nbsp ${quoteSep nonBreakingSpace}")
+        (optionalString (lineFeed != null) " -lf ${quoteSep lineFeed}")
       ];
 
     uiOptions = with cfg.config.ui;

--- a/tests/modules/programs/kakoune/default.nix
+++ b/tests/modules/programs/kakoune/default.nix
@@ -1,1 +1,5 @@
-{ kakoune-whitespace-highlighter = ./whitespace-highlighter.nix; }
+{
+  kakoune-whitespace-highlighter = ./whitespace-highlighter.nix;
+  kakoune-whitespace-highlighter-corner-cases =
+    ./whitespace-highlighter-corner-cases.nix;
+}

--- a/tests/modules/programs/kakoune/whitespace-highlighter-corner-cases.nix
+++ b/tests/modules/programs/kakoune/whitespace-highlighter-corner-cases.nix
@@ -8,18 +8,18 @@ with lib;
       enable = true;
       config.showWhitespace = {
         enable = true;
-        lineFeed = "1";
-        space = "2";
-        nonBreakingSpace = "3";
-        tab = "4";
-        tabStop = "5";
+        lineFeed = ''"'';
+        space = " ";
+        nonBreakingSpace = "' '"; # backwards compat
+        tab = "'";
+        # tabStop = <default>
       };
     };
 
     nmt.script = ''
       assertFileExists home-files/.config/kak/kakrc
       assertFileContains home-files/.config/kak/kakrc \
-        "add-highlighter global/ show-whitespaces -tab '4' -tabpad '5' -spc '2' -nbsp '3' -lf '1'"
+        "add-highlighter global/ show-whitespaces -tab \"'\" -spc ' ' -nbsp ' ' -lf '\"'"
     '';
   };
 }

--- a/tests/modules/programs/kakoune/whitespace-highlighter.nix
+++ b/tests/modules/programs/kakoune/whitespace-highlighter.nix
@@ -16,17 +16,10 @@ with lib;
       };
     };
 
-    nmt.script = let
-      lineStart =
-        "^add-highlighter\\s\\+global\\/\\?\\s\\+show-whitespaces\\s\\+"
-        + "\\(-\\w\\+\\s\\+.\\s\\+\\)*";
-    in ''
+    nmt.script = ''
       assertFileExists home-files/.config/kak/kakrc
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-lf\s\+1\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-spc\s\+2\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-nbsp\s\+3\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-tab\s\+4\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-tabpad\s\+5\b'
+      assertFileContains home-files/.config/kak/kakrc \
+        "add-highlighter global/ show-whitespaces -tab 4 -tabpad 5 -spc 2 -nbsp 3 -lf 1"
     '';
   };
 }


### PR DESCRIPTION
### Description

We were passing the separators for the `show-whitespaces` highlighter
verbatim. This was problematic in case one wanted to use, spaces,
quotes or `%` as separators since the resulting kakoune configuration
would be invalid.
    
According to kakoune's docs, the separator has to be one character
long, so we can use a simple rule for escaping them. It is possible
that people has been working this around by passing, e.g. `"' '"` as
separator in order to get a space, so we just let longer strings be used
verbatim as before.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- ~If this PR adds a new module~
