### PR TITLE
powerline-go: Fix argument to -error option

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1604,6 +1604,14 @@ in
           A new module is available: 'programs.ne'
         '';
       }
+
+      {
+        time = "2020-06-29T05:23:24+00:00";
+        condition = config.programs.powerline-go.enable;
+        message = ''
+          Fixed a bug where powerline-go would never show the exit status of the previous command.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -110,7 +110,7 @@ in {
     programs.bash.initExtra = ''
       function _update_ps1() {
         local old_exit_status=$?
-        PS1="$(${pkgs.powerline-go}/bin/powerline-go -error $? ${commandLineArguments})"
+        PS1="$(${pkgs.powerline-go}/bin/powerline-go -error $old_exit_status ${commandLineArguments})"
         ${cfg.extraUpdatePS1}
         return $old_exit_status
       }

--- a/tests/modules/programs/powerline-go/standard.nix
+++ b/tests/modules/programs/powerline-go/standard.nix
@@ -22,7 +22,7 @@ with lib;
       assertFileExists home-files/.bashrc
       assertFileContains \
         home-files/.bashrc \
-        '/bin/powerline-go -error $? -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
+        '/bin/powerline-go -error $old_exit_status -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
     '';
   };
 }


### PR DESCRIPTION
### Description

Addition of the line "local old_exit_status=$?" broke the call to
powerline-go.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.