### PR TITLE
git: configure delta through [delta] git section

### DIFF
--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -7,7 +7,16 @@
 	gpgSign = true
 
 [core]
-	pager = "@deltaCommand@ --dark"
+	pager = "@deltaCommand@"
+
+[delta]
+	features = "decorations"
+	whitespace-error-style = "22 reverse"
+
+[delta "decorations"]
+	commit-decoration-style = "bold yellow box ul"
+	file-decoration-style = "none"
+	file-style = "bold yellow ul"
 
 [extra]
 	boolean = true
@@ -32,7 +41,7 @@
 	program = "path-to-gpg"
 
 [interactive]
-	diffFilter = "@deltaCommand@ --dark --color-only"
+	diffFilter = "@deltaCommand@ --color-only"
 
 [user]
 	email = "user@example.org"

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -60,7 +60,15 @@ in {
         lfs.enable = true;
         delta = {
           enable = true;
-          options = [ "--dark" ];
+          options = {
+            features = "decorations";
+            whitespace-error-style = "22 reverse";
+            decorations = {
+              commit-decoration-style = "bold yellow box ul";
+              file-style = "bold yellow ul";
+              file-decoration-style = "none";
+            };
+          };
         };
       }
 


### PR DESCRIPTION
### Description

The latest delta release recommends to configure it through .gitconfig https://github.com/dandavison/delta/releases/tag/0.2.0

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
