### PR TITLE
alacritty: add package option

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -36,12 +36,21 @@ in {
           for the default configuration.
         '';
       };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.alacritty;
+        defaultText = literalExample "pkgs.alacritty";
+        description = ''
+          The alacritty package to install. May be used to change the version.
+        '';
+      };
     };
   };
 
   config = mkMerge [
     (mkIf cfg.enable {
-      home.packages = [ pkgs.alacritty ];
+      home.packages = [ cfg.package ];
 
       xdg.configFile."alacritty/alacritty.yml" = mkIf (cfg.settings != { }) {
         text =

--- a/tests/modules/programs/alacritty/example-settings.nix
+++ b/tests/modules/programs/alacritty/example-settings.nix
@@ -6,6 +6,7 @@ with lib;
   config = {
     programs.alacritty = {
       enable = true;
+      package = pkgs.writeScriptBin "dummy-alacritty" "";
 
       settings = {
         window.dimensions = {
@@ -20,10 +21,6 @@ with lib;
         }];
       };
     };
-
-    nixpkgs.overlays = [
-      (self: super: { alacritty = pkgs.writeScriptBin "dummy-alacritty" ""; })
-    ];
 
     nmt.script = ''
       assertFileContent \


### PR DESCRIPTION
### Description

This PR adds the `package` option to the alacritty home-manager module.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
