### PR TITLE
systemd: fix systemd spelling

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -452,7 +452,7 @@ in
 
       {
         time = "2017-12-11T17:23:12+00:00";
-        condition = config.home.activation ? reloadSystemD;
+        condition = config.home.activation ? reloadSystemd;
         message = ''
           The Boolean option 'systemd.user.startServices' is now
           available. When enabled the current naive systemd unit

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -228,7 +228,7 @@ in
       # running this from the NixOS module then XDG_RUNTIME_DIR is not
       # set and systemd commands will fail. We'll therefore have to
       # set it ourselves in that case.
-      home.activation.reloadSystemD = hm.dag.entryAfter ["linkGeneration"] (
+      home.activation.reloadSystemd = hm.dag.entryAfter ["linkGeneration"] (
         let
           autoReloadCmd = ''
             ${pkgs.ruby}/bin/ruby ${./systemd-activate.rb} \


### PR DESCRIPTION
### Description

systemd is supposed to be spelled systemd (lowercase d) or sÿstëmd (only on high holidays) according to https://www.freedesktop.org/wiki/Software/systemd/.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
