### PR TITLE
direnv: backport nix-direnv support to 20.03

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -70,6 +70,11 @@ in {
         Whether to enable Fish integration.
       '';
     };
+
+    enableNixDirenvIntegration = mkEnableOption ''
+      <link
+          xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
+          a fast, persistent use_nix implementation for direnv'';
   };
 
   config = mkIf cfg.enable {
@@ -78,8 +83,11 @@ in {
     xdg.configFile."direnv/config.toml" =
       mkIf (cfg.config != { }) { source = configFile cfg.config; };
 
-    xdg.configFile."direnv/direnvrc" =
-      mkIf (cfg.stdlib != "") { text = cfg.stdlib; };
+    xdg.configFile."direnv/direnvrc" = let
+      text = concatStringsSep "\n" (optional (cfg.stdlib != "") cfg.stdlib
+        ++ optional cfg.enableNixDirenvIntegration
+        "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
+    in mkIf (text != "") { inherit text; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (
       # Using mkAfter to make it more likely to appear after other


### PR DESCRIPTION
### Description

Backports the existing changes in master to the release-20.03 branch.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
