### PR TITLE
add temp CI job to test syspolicy impact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,16 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-shell . -A install
     - run: nix-shell --pure --max-jobs 4 tests -A run.all
+  macos_perf_test:
+    runs-on: macos-latest
+    steps:
+    - name: Disable syspolicy assessments
+      run: |
+        spctl --status
+        sudo spctl --master-disable
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v10
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-shell . -A install
+    - run: nix-shell --pure --max-jobs 4 tests -A run.all


### PR DESCRIPTION
Starting in Catalina, macOS runs a syspolicyd "assessment" that hits the network for each binary/script executable. It does cache these results, but Nix tends to introduce many "new" executables per build. (You can read more about this at https://github.com/NixOS/nix/issues/3789).

This PR adds a temporary, redundant macOS job with these assessments disabled. I'm hoping you can adopt it for a few weeks to help me collect more data on how this affects real projects.

(I'm also hoping this runs clean. I've been waiting for these to run through before I PR, but I guess the CI config is only set to test on schedule and pull, so they aren't automatically running. 🤞)
