### PR TITLE
sway: Set bar defaults to null

### DIFF
--- a/doc/release-notes/rl-2009.adoc
+++ b/doc/release-notes/rl-2009.adoc
@@ -52,3 +52,46 @@ will automatically include these options, when necessary.
 _module.args.pkgsPath = <nixpkgs>;
 +
 to your Home Manager configuration.
+
+* The options `wayland.windowManager.sway.config.bars` and `opt-xsession.windowManager.i3.config.bars` have been changed so that most of the suboptions are now nullable and default to null. The default for these two options has been changed to manually set the old defaults for each suboption. The overall effect is that if the `bars` options is not set, then the default remains the same, however something like:
++
+--
+[source,nix]
+----
+bars = [ {
+  command = "waybar";
+} ];
+----
+will now create the config:
+....
+bar {
+  swaybar_command waybar
+}
+....
+instead of
+....
+bar {
+
+  font pango:monospace 8
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command /nix/store/h7s6i9q1z5fxrlyyw5ls8vqxhf5bcs5a-i3status-2.13/bin/i3status
+  swaybar_command waybar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output primary
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+
+}
+....
+--

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -7,7 +7,7 @@ let
   cfg = config.xsession.windowManager.i3;
 
   commonOptions = import ./lib/options.nix {
-    inherit lib cfg pkgs;
+    inherit config lib cfg pkgs;
     moduleName = "i3";
     isGaps = cfg.package == pkgs.i3-gaps;
   };

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -41,31 +41,66 @@ rec {
 
   barStr = { id, fonts, mode, hiddenState, position, workspaceButtons
     , workspaceNumbers, command, statusCommand, colors, trayOutput, extraConfig
-    , ... }: ''
+    , ... }:
+    let colorsNotNull = lib.filterAttrs (n: v: v != null) colors != { };
+    in ''
       bar {
         ${optionalString (id != null) "id ${id}"}
-        font pango:${concatStringsSep ", " fonts}
-        mode ${mode}
-        hidden_state ${hiddenState}
-        position ${position}
+        ${
+          optionalString (fonts != [ ])
+          "font pango:${concatStringsSep ", " fonts}"
+        }
+        ${optionalString (mode != null) "mode ${mode}"}
+        ${optionalString (hiddenState != null) "hidden_state ${hiddenState}"}
+        ${optionalString (position != null) "position ${position}"}
         ${
           optionalString (statusCommand != null)
           "status_command ${statusCommand}"
         }
         ${moduleName}bar_command ${command}
-        workspace_buttons ${if workspaceButtons then "yes" else "no"}
-        strip_workspace_numbers ${if !workspaceNumbers then "yes" else "no"}
-        tray_output ${trayOutput}
-        colors {
-          background ${colors.background}
-          statusline ${colors.statusline}
-          separator ${colors.separator}
-          focused_workspace ${barColorSetStr colors.focusedWorkspace}
-          active_workspace ${barColorSetStr colors.activeWorkspace}
-          inactive_workspace ${barColorSetStr colors.inactiveWorkspace}
-          urgent_workspace ${barColorSetStr colors.urgentWorkspace}
-          binding_mode ${barColorSetStr colors.bindingMode}
+        ${
+          optionalString (workspaceButtons != null)
+          "workspace_buttons ${if workspaceButtons then "yes" else "no"}"
         }
+        ${
+          optionalString (workspaceNumbers != null)
+          "strip_workspace_numbers ${if !workspaceNumbers then "yes" else "no"}"
+        }
+        ${optionalString (trayOutput != null) "tray_output ${trayOutput}"}
+        ${optionalString colorsNotNull "colors {"}
+          ${
+            optionalString (colors.background != null)
+            "background ${colors.background}"
+          }
+          ${
+            optionalString (colors.statusline != null)
+            "statusline ${colors.statusline}"
+          }
+          ${
+            optionalString (colors.separator != null)
+            "separator ${colors.separator}"
+          }
+          ${
+            optionalString (colors.focusedWorkspace != null)
+            "focused_workspace ${barColorSetStr colors.focusedWorkspace}"
+          }
+          ${
+            optionalString (colors.activeWorkspace != null)
+            "active_workspace ${barColorSetStr colors.activeWorkspace}"
+          }
+          ${
+            optionalString (colors.inactiveWorkspace != null)
+            "inactive_workspace ${barColorSetStr colors.inactiveWorkspace}"
+          }
+          ${
+            optionalString (colors.urgentWorkspace != null)
+            "urgent_workspace ${barColorSetStr colors.urgentWorkspace}"
+          }
+          ${
+            optionalString (colors.bindingMode != null)
+            "binding_mode ${barColorSetStr colors.bindingMode}"
+          }
+        ${optionalString colorsNotNull "}"}
         ${extraConfig}
       }
     '';

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -7,7 +7,7 @@ let
   cfg = config.wayland.windowManager.sway;
 
   commonOptions = import ./lib/options.nix {
-    inherit lib cfg pkgs;
+    inherit config lib cfg pkgs;
     moduleName = "sway";
     capitalModuleName = "Sway";
   };

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -1,5 +1,6 @@
 {
   sway-default = ./sway-default.nix;
+  sway-post-2003 = ./sway-post-2003.nix;
   sway-followmouse = ./sway-followmouse.nix;
   sway-followmouse-legacy = ./sway-followmouse-legacy.nix;
 }

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -1,4 +1,5 @@
 {
+  sway-default = ./sway-default.nix;
   sway-followmouse = ./sway-followmouse.nix;
   sway-followmouse-legacy = ./sway-followmouse-legacy.nix;
 }

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -1,0 +1,117 @@
+font pango:monospace 8
+floating_modifier Mod1
+default_border pixel 2
+default_floating_border pixel 2
+hide_edge_borders none
+focus_wrapping no
+focus_follows_mouse yes
+focus_on_window_activation smart
+mouse_warping output
+workspace_layout default
+workspace_auto_back_and_forth no
+
+client.focused #4c7899 #285577 #ffffff #2e9ef4 #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50 #5f676a
+client.unfocused #333333 #222222 #888888 #292d2e #222222
+client.urgent #2f343a #900000 #ffffff #900000 #900000
+client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
+client.background #ffffff
+
+bindsym Mod1+1 workspace number 1
+bindsym Mod1+2 workspace number 2
+bindsym Mod1+3 workspace number 3
+bindsym Mod1+4 workspace number 4
+bindsym Mod1+5 workspace number 5
+bindsym Mod1+6 workspace number 6
+bindsym Mod1+7 workspace number 7
+bindsym Mod1+8 workspace number 8
+bindsym Mod1+9 workspace number 9
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Right focus right
+bindsym Mod1+Shift+1 move container to workspace number 1
+bindsym Mod1+Shift+2 move container to workspace number 2
+bindsym Mod1+Shift+3 move container to workspace number 3
+bindsym Mod1+Shift+4 move container to workspace number 4
+bindsym Mod1+Shift+5 move container to workspace number 5
+bindsym Mod1+Shift+6 move container to workspace number 6
+bindsym Mod1+Shift+7 move container to workspace number 7
+bindsym Mod1+Shift+8 move container to workspace number 8
+bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+Down move down
+bindsym Mod1+Shift+Left move left
+bindsym Mod1+Shift+Right move right
+bindsym Mod1+Shift+Up move up
+bindsym Mod1+Shift+c reload
+bindsym Mod1+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -b 'Yes, exit sway' 'swaymsg exit'
+bindsym Mod1+Shift+h move left
+bindsym Mod1+Shift+j move down
+bindsym Mod1+Shift+k move up
+bindsym Mod1+Shift+l move right
+bindsym Mod1+Shift+minus move scratchpad
+bindsym Mod1+Shift+q kill
+bindsym Mod1+Shift+space floating toggle
+bindsym Mod1+Up focus up
+bindsym Mod1+a focus parent
+bindsym Mod1+b splith
+bindsym Mod1+d exec @dmenu@/bin/dmenu_run
+bindsym Mod1+e layout toggle split
+bindsym Mod1+f fullscreen toggle
+bindsym Mod1+h focus left
+bindsym Mod1+j focus down
+bindsym Mod1+k focus up
+bindsym Mod1+l focus right
+bindsym Mod1+minus scratchpad show
+bindsym Mod1+r mode resize
+bindsym Mod1+s layout stacking
+bindsym Mod1+space focus mode_toggle
+bindsym Mod1+v splitv
+bindsym Mod1+w layout tabbed
+
+
+
+mode "resize" {
+bindsym Down resize grow height 10 px
+bindsym Escape mode default
+bindsym Left resize shrink width 10 px
+bindsym Return mode default
+bindsym Right resize grow width 10 px
+bindsym Up resize shrink height 10 px
+bindsym h resize shrink width 10 px
+bindsym j resize grow height 10 px
+bindsym k resize shrink height 10 px
+bindsym l resize grow width 10 px
+}
+
+
+bar {
+  
+  font pango:monospace 8
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  swaybar_command @sway/bin/swaybar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output primary
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+  
+}
+
+
+
+
+
+
+exec "systemctl --user import-environment; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-default.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    wayland.windowManager.sway = {
+      enable = true;
+      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // {
+        outPath = "@sway";
+      };
+      # overriding findutils causes issues
+      config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        dummy-package = super.runCommandLocal "dummy-package" { } "mkdir $out";
+        dmenu = self.dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = self.dummy-package // {
+          outPath = "@rxvt-unicode-unwrapped@";
+        };
+        i3status = self.dummy-package // { outPath = "@i3status@"; };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sway/config
+      assertFileContent home-files/.config/sway/config \
+        ${./sway-default.conf}
+    '';
+  };
+}

--- a/tests/modules/services/window-managers/sway/sway-post-2003.nix
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "20.09";
+
+    wayland.windowManager.sway = {
+      enable = true;
+      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // {
+        outPath = "@sway";
+      };
+      # overriding findutils causes issues
+      config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        dummy-package = super.runCommandLocal "dummy-package" { } "mkdir $out";
+        dmenu = self.dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = self.dummy-package // {
+          outPath = "@rxvt-unicode-unwrapped@";
+        };
+        i3status = self.dummy-package // { outPath = "@i3status@"; };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sway/config
+      assertFileContent home-files/.config/sway/config \
+        ${./sway-default.conf}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fixes #1361
Allows most of the fields in `bar` to be null. The defaults bar then sets these. This should mean that the default bar is unchanged but if the user creates a new bar with
```
bar {
  command = x;
}
```
then there won't be lots of unnecessary fields anymore. These changes are guarded by a stateVersion.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. 
The tests run fine but is there a way to test this with `stateVersion = "20.09"` @rycee 

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
No changes atm though would be nice to add separate tests for pre 20.09 and post 20.09

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
