### PR TITLE
spotifyd: allow the user to configure the spotifyd package

### DIFF
--- a/modules/services/spotifyd.nix
+++ b/modules/services/spotifyd.nix
@@ -14,6 +14,18 @@ in {
   options.services.spotifyd = {
     enable = mkEnableOption "SpotifyD connect";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.spotifyd;
+      defaultText = literalExample "pkgs.spotifyd";
+      example =
+        literalExample "(pkgs.spotifyd.override { withKeyring = true; })";
+      description = ''
+        The <literal>spotifyd</literal> package to use.
+        Can be used to specify extensions.
+      '';
+    };
+
     settings = mkOption {
       type = types.attrsOf (types.attrsOf types.str);
       default = { };
@@ -31,7 +43,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.spotifyd ];
+    home.packages = [ cfg.package ];
 
     systemd.user.services.spotifyd = {
       Unit = {
@@ -43,7 +55,7 @@ in {
 
       Service = {
         ExecStart =
-          "${pkgs.spotifyd}/bin/spotifyd --no-daemon --config-path ${configFile}";
+          "${cfg.package}/bin/spotifyd --no-daemon --config-path ${configFile}";
         Restart = "always";
         RestartSec = 12;
       };


### PR DESCRIPTION
### Description

This PR adds the ability to configure the `spotifyd` package (defaults to `pkgs.spotifyd`), which can be used to enable optional Spotifyd features, such as looking up the Spotify password in the system keyring or enabling MPRIS support.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` (I had few failed Emacs tests locally).

  <details>
     <summary>Failed tests</summary>

     ``` text
    emacs-service: FAILED
    Expected home-path/share/applications/emacsclient.desktop to be same as /nix/store/55ijdimmbpc5i3q9kj9a0xvgwvrprxgf-emacs-emacsclient.desktop but were different:
    --- actual
    +++ expected
    @@ -3,10 +3,10 @@
     Exec=@emacs@/bin/emacsclient -c %F
     Terminal=false
     Name=Emacs Client
    -Categories=Utility;TextEditor;
     Icon=emacs
     Comment=Edit text
     GenericName=Text Editor
     MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;
    +Categories=Utility;TextEditor;
     StartupWMClass=Emacs

    For further reference please introspect /nix/store/xaw8sw4d10dnylg0k2v30kkcnangkwrh-nmt-report-emacs-service
    emacs-socket-26: FAILED
    Expected home-path/share/applications/emacsclient.desktop to be same as /nix/store/55ijdimmbpc5i3q9kj9a0xvgwvrprxgf-emacs-emacsclient.desktop but were different:
    --- actual
    +++ expected
    @@ -3,10 +3,10 @@
     Exec=@emacs@/bin/emacsclient -c %F
     Terminal=false
     Name=Emacs Client
    -Categories=Utility;TextEditor;
     Icon=emacs
     Comment=Edit text
     GenericName=Text Editor
     MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;
    +Categories=Utility;TextEditor;
     StartupWMClass=Emacs

    For further reference please introspect /nix/store/lxxpyiaarx0hyp74q3pifxw3974rpv9m-nmt-report-emacs-socket-26
    emacs-socket-27: FAILED
    Expected home-path/share/applications/emacsclient.desktop to be same as /nix/store/55ijdimmbpc5i3q9kj9a0xvgwvrprxgf-emacs-emacsclient.desktop but were different:
    --- actual
    +++ expected
    @@ -3,10 +3,10 @@
     Exec=@emacs@/bin/emacsclient -c %F
     Terminal=false
     Name=Emacs Client
    -Categories=Utility;TextEditor;
     Icon=emacs
     Comment=Edit text
     GenericName=Text Editor
     MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;
    +Categories=Utility;TextEditor;
     StartupWMClass=Emacs
     ```
  </details>

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.