### PR TITLE
services.dropbox: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -110,6 +110,8 @@
 
 /modules/services/clipmenu.nix                        @DamienCassou
 
+/modules/services/dropbox.nix                         @eyJhb
+
 /modules/services/dunst.nix                           @rycee
 
 /modules/services/emacs.nix                           @tadfisher

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -126,6 +126,7 @@ let
     (loadModule ./services/cbatticon.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/clipmenu.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/compton.nix { })
+    (loadModule ./services/dropbox.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/dunst.nix { })
     (loadModule ./services/dwm-status.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/emacs.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/dropbox.nix
+++ b/modules/services/dropbox.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.dropbox;
+  baseDir = ".dropbox-hm";
+  dropboxCmd = ''
+    ${pkgs.coreutils}/bin/env -i HOME="$HOME" ${pkgs.dropbox-cli}/bin/dropbox'';
+in {
+  meta.maintainers = [ maintainers.eyjhb ];
+
+  options = {
+    services.dropbox = {
+      enable = mkEnableOption "Dropbox daemon";
+
+      path = mkOption {
+        type = types.path;
+        default = "${config.home.homeDirectory}/Dropbox";
+        defaultText = "\${config.home.homeDirectory}/Dropbox";
+        description = "Where to put the Dropbox directory.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [{
+    home.packages = [ pkgs.dropbox-cli ];
+
+    systemd.user.services.dropbox = {
+      Unit = { Description = "Starting dropbox"; };
+
+      Install = { WantedBy = [ "default.target" ]; };
+
+      Service = {
+        Environment = [ "HOME=${config.home.homeDirectory}/${baseDir}" ];
+
+        Type = "forking";
+        PIDFile =
+          "${config.home.homeDirectory}/${baseDir}/.dropbox/dropbox.pid";
+
+        Restart = "on-failure";
+        PrivateTmp = true;
+        ProtectSystem = "full";
+        Nice = 10;
+
+        ExecReload = "${pkgs.coreutils.out}/bin/kill -HUP $MAINPID";
+        ExecStop = "${dropboxCmd} stop";
+        ExecStart = let
+          script = pkgs.writeScript "dropboxInit" ''
+            #!/bin/sh
+            if [ ! -f $HOME/.dropbox-dist/VERSION ]; then
+              ${pkgs.coreutils}/bin/yes | ${pkgs.coreutils}/bin/env -i HOME="$HOME" ${pkgs.dropbox-cli}/bin/dropbox update
+            fi
+
+            ${dropboxCmd} start
+          '';
+        in "${script}";
+      };
+    };
+
+    home.activation.dropbox = let dag = lib.hm.dag;
+    in dag.entryAfter [ "writeBoundary" ] ''
+      # ensure we have the dirs we need
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/${baseDir}/.dropbox
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/${baseDir}/.dropbox-dist
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/${baseDir}/Dropbox
+
+      # symlink them as needed
+      if [ ! -d ${config.home.homeDirectory}/.dropbox ]; then $DRY_RUN_CMD ${pkgs.coreutils}/bin/ln -s ${config.home.homeDirectory}/${baseDir}/.dropbox ${config.home.homeDirectory}/.dropbox; fi
+      # if [ ! -d ${config.home.homeDirectory}/.dropbox-dist ]; then $DRY_RUN_CMD ${pkgs.coreutils}/bin/ln -s ${config.home.homeDirectory}/${baseDir}/.dropbox-dist ${config.home.homeDirectory}/.dropbox-dist; fi
+      if [ ! -d ${cfg.path} ]; then $DRY_RUN_CMD ${pkgs.coreutils}/bin/ln -s ${config.home.homeDirectory}/${baseDir}/Dropbox ${cfg.path}; fi
+    '';
+  }]);
+}

--- a/modules/services/dropbox.nix
+++ b/modules/services/dropbox.nix
@@ -5,8 +5,7 @@ with lib;
 let
   cfg = config.services.dropbox;
   baseDir = ".dropbox-hm";
-  dropboxCmd = ''
-    ${pkgs.coreutils}/bin/env -i HOME="$HOME" ${pkgs.dropbox-cli}/bin/dropbox'';
+  dropboxCmd = "${pkgs.dropbox-cli}/bin/dropbox";
   homeBaseDir = "${config.home.homeDirectory}/${baseDir}";
 in {
   meta.maintainers = [ maintainers.eyjhb ];
@@ -28,7 +27,7 @@ in {
     home.packages = [ pkgs.dropbox-cli ];
 
     systemd.user.services.dropbox = {
-      Unit = { Description = "Starting dropbox"; };
+      Unit = { Description = "dropbox"; };
 
       Install = { WantedBy = [ "default.target" ]; };
 
@@ -43,7 +42,7 @@ in {
         ProtectSystem = "full";
         Nice = 10;
 
-        ExecReload = "${pkgs.coreutils.out}/bin/kill -HUP $MAINPID";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStop = "${dropboxCmd} stop";
         ExecStart = let
           script = pkgs.writeShellScript "dropboxInit" ''
@@ -59,7 +58,7 @@ in {
 
     home.activation.dropbox = hm.dag.entryAfter [ "writeBoundary" ] ''
       # ensure we have the dirs we need
-      $DRY_RUN_CMD ${pkgs.coreutils}/bin/mkdir $VERBOSE_ARG -p ${homeBaseDir}{config.home.homeDirectory}/${baseDir}/{.dropbox,.dropbox-dist,Dropbox}
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/mkdir $VERBOSE_ARG -p ${homeBaseDir}/{.dropbox,.dropbox-dist,Dropbox}
 
       # symlink them as needed
       if [[ ! -d ${config.home.homeDirectory}/.dropbox ]]; then

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -75,6 +75,7 @@ import nmt {
     ./modules/programs/abook
     ./modules/programs/autorandr
     ./modules/services/emacs
+    ./modules/services/dropbox
     ./modules/programs/firefox
     ./modules/programs/getmail
     ./modules/services/lieer

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -74,6 +74,7 @@ import nmt {
     ./modules/misc/xsession
     ./modules/programs/abook
     ./modules/programs/autorandr
+    ./modules/services/dropbox
     ./modules/services/emacs
     ./modules/services/dropbox
     ./modules/programs/firefox

--- a/tests/modules/services/dropbox/basic-configuration.nix
+++ b/tests/modules/services/dropbox/basic-configuration.nix
@@ -1,0 +1,10 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.dropbox = {
+      enable = true;
+      path = "${config.home.homeDirectory}/dropbox";
+    };
+  };
+}

--- a/tests/modules/services/dropbox/basic-configuration.nix
+++ b/tests/modules/services/dropbox/basic-configuration.nix
@@ -6,5 +6,20 @@
       enable = true;
       path = "${config.home.homeDirectory}/dropbox";
     };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        dropbox-cli = pkgs.writeScriptBin "dummy-dropbox-cli" "" // {
+          outPath = "@dropbox-cli@";
+        };
+      })
+    ];
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/dropbox.service
+
+      assertFileExists $serviceFile
+    '';
+
   };
 }

--- a/tests/modules/services/dropbox/default.nix
+++ b/tests/modules/services/dropbox/default.nix
@@ -1,0 +1,1 @@
+{ dropbox-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
Ability to control Dropbox daemon, if it should start and where to place
the files.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
