### PR TITLE
git: set SSL if useStartTls is false

### DIFF
--- a/doc/release-notes/rl-2009.adoc
+++ b/doc/release-notes/rl-2009.adoc
@@ -43,3 +43,9 @@ $ nix-shell '<home-manager>' -A install
 
 will automatically include these options, when necessary.
 --
+
+* Git's `smtpEncryption` option now only is set to `tls` if
+<<opt-accounts.email.accounts.\_name_.smtp.tls.enable>> AND
+<<opt-accounts.email.accounts.\_name_.smtp.tls.useStartTls>> are `true`. If
+only <<opt-accounts.email.accounts.\_name_.smtp.tls.enable>> is `true`, `ssl`
+is used instead.

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -265,7 +265,14 @@ in {
         genIdentity = name: account:
           with account;
           nameValuePair "sendemail.${name}" ({
-            smtpEncryption = if smtp.tls.enable then "tls" else "";
+            smtpEncryption = if smtp.tls.enable then
+              (if smtp.tls.useStartTls
+              || versionOlder config.home.stateVersion "20.09" then
+                "tls"
+              else
+                "ssl")
+            else
+              "";
             smtpServer = smtp.host;
             smtpUser = userName;
             from = address;

--- a/tests/modules/accounts/email-test-accounts.nix
+++ b/tests/modules/accounts/email-test-accounts.nix
@@ -21,6 +21,7 @@
         passwordCommand = "password-command 2";
         imap.host = "imap.example.org";
         smtp.host = "smtp.example.org";
+        smtp.tls.useStartTls = true;
       };
     };
   };

--- a/tests/modules/programs/git/git-with-email-expected.conf
+++ b/tests/modules/programs/git/git-with-email-expected.conf
@@ -6,7 +6,7 @@
 
 [sendemail "hm@example.com"]
 	from = "hm@example.com"
-	smtpEncryption = "tls"
+	smtpEncryption = "ssl"
 	smtpServer = "smtp.example.com"
 	smtpUser = "home.manager"
 

--- a/tests/modules/programs/git/git-with-email.nix
+++ b/tests/modules/programs/git/git-with-email.nix
@@ -13,6 +13,8 @@ with lib;
       userName = "H. M. Test";
     };
 
+    home.stateVersion = "20.09";
+
     nmt.script = ''
       function assertGitConfig() {
         local value


### PR DESCRIPTION
### Description

The [`git-send-email`][0] script uses StartTls if `smtpEncryption` is
set to `tls`, which can break services that don't support StartTls.

[0]: https://github.com/git/git/blob/bd42bbe1a46c0fe486fc33e82969275e27e4dc19/git-send-email.perl#L1533

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
