### PR TITLE
add support to render quoteless strings in gvariant

### DIFF
--- a/modules/lib/gvariant.nix
+++ b/modules/lib/gvariant.nix
@@ -111,6 +111,11 @@ in rec {
       __toString = self: "'${escape [ "'" ] self.value}'";
     };
 
+  mkRawString = v:
+    mkPrimitive type.string v // {
+      __toString = self: self.value;
+    };
+
   mkObjectpath = v:
     mkPrimitive type.string v // {
       __toString = self: "objectpath '${escape [ "'" ] self.value}'";

--- a/tests/lib/types/gvariant-merge.nix
+++ b/tests/lib/types/gvariant-merge.nix
@@ -28,6 +28,8 @@ in {
         { string = "foo"; }
 
         { tuple = mkTuple [ 1 [ "foo" ] ]; }
+
+        { raw = mkRawString "@mb true"; }
       ];
 
     home.file."result.txt".text = let
@@ -46,6 +48,7 @@ in {
             float = 3.140000
             int = 42
             list = @as ['one','two']
+            raw = @mb true
             string = 'foo'
             tuple = @(ias) (1,@as ['foo'])
           ''


### PR DESCRIPTION
### Description
Some of the values in my dconf settings ini file need to be quoteless strings,
`@mb true` for example when rendered with quotes does not set the value for bluetooth correctly as its a string and not a maybe type boolean set to true.
but if pass mkRawString "@mb true" in it writes the correct key=@mb true to the file.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
