### PR TITLE
Qutebrowser default keybindings type coercion

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -261,7 +261,7 @@ in {
       ++ mapAttrsToList (formatDictLine "c.url.searchengines") cfg.searchEngines
       ++ mapAttrsToList (formatDictLine "c.bindings.key_mappings")
       cfg.keyMappings
-      ++ optional (!cfg.enableDefaultBindings) [ "c.bindings.default = {}" ]
+      ++ optional (!cfg.enableDefaultBindings) "c.bindings.default = {}"
       ++ mapAttrsToList formatKeyBindings cfg.keyBindings
       ++ optional (cfg.extraConfig != "") cfg.extraConfig);
   };

--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -7,6 +7,8 @@ with lib;
     programs.qutebrowser = {
       enable = true;
 
+      enableDefaultBindings = false;
+
       keyBindings = {
         normal = {
           "<Ctrl-v>" = "spawn mpv {url}";
@@ -27,6 +29,7 @@ with lib;
         home-files/.config/qutebrowser/config.py \
         ${
           pkgs.writeText "qutebrowser-expected-config.py" ''
+            c.bindings.default = {}
             config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")
             config.bind("<Ctrl-v>", "spawn mpv {url}", mode="normal")
             config.bind("<Ctrl-y>", "prompt-yes", mode="prompt")''


### PR DESCRIPTION
### Description

When attempting to add Emacs keybindings to Qutebrowser, I ran into a type coercion error. A mess of traces eventually found that the `programs.qutebrowser.enableDefaultKeybindings` option added a config line that was unnecessarily wrapped in a list, when it should've just been a string. I unwrapped the list from around it, and added the missing test line to `tests/modules/programs/qutebrowser/keybindings.nix` that would've caught the problem. 

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
