### PR TITLE
zsh: add `cdpath` option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -185,6 +185,14 @@ in
         type = types.nullOr types.bool;
       };
 
+      cdpath = mkOption {
+        default = [];
+        description = ''
+          List of paths to autocomplete calls to `cd`.
+        '';
+        type = types.listOf types.str;
+      };
+
       dotDir = mkOption {
         default = null;
         example = ".config/zsh";
@@ -391,6 +399,10 @@ in
 
       home.file."${relToDotDir ".zshrc"}".text = ''
         typeset -U path cdpath fpath manpath
+
+        ${optionalString (cfg.cdpath != []) ''
+          cdpath+=(${concatStringsSep " " cfg.cdpath})
+        ''}
 
         for profile in ''${(z)NIX_PROFILES}; do
           fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)


### PR DESCRIPTION
### Description

The `cdpath` option in Zsh makes it easy to `cd` to sub-directories of the paths specified. [ThoughtBot wrote a blog post](https://thoughtbot.com/blog/cding-to-frequently-used-directories-in-zsh) about it which includes a nice example.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
