### PR TITLE
nixpkgs: take Nixpkgs path from argument

### DIFF
--- a/doc/release-notes/rl-2009.adoc
+++ b/doc/release-notes/rl-2009.adoc
@@ -45,3 +45,10 @@ will automatically include these options, when necessary.
 --
 
 * Git's `smtpEncryption` option is now set to `tls` only if both <<opt-accounts.email.accounts.\_name_.smtp.tls.enable>> and <<opt-accounts.email.accounts.\_name_.smtp.tls.useStartTls>> are `true`. If only <<opt-accounts.email.accounts.\_name_.smtp.tls.enable>> is `true`, `ssl` is used instead.
+
+* The `nixpkgs` module no longer references `<nixpkgs>`. Before it would do so when building the `pkgs` module argument. Starting with state version 20.09, the `pkgs` argument is instead built from the same Nixpkgs that was used to initialize the Home Manager modules. This is useful, for example, when using Home Manager within a Nix Flake. If you want to keep using `<nixpkgs>` with state version ≥ 20.09 then add
++
+[source,nix]
+_module.args.pkgsPath = <nixpkgs>;
++
+to your Home Manager configuration.

--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -1,6 +1,6 @@
 # Adapted from Nixpkgs.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, pkgsPath, ... }:
 
 with lib;
 
@@ -49,7 +49,7 @@ let
     merge = lib.mergeOneOption;
   };
 
-  _pkgs = import <nixpkgs> (
+  _pkgs = import pkgsPath (
     filterAttrs (n: v: v != null) config.nixpkgs
   );
 

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -197,9 +197,14 @@ let
 
   modules = map (getAttr "file") (filter (getAttr "condition") allModules);
 
-  pkgsModule = {
+  pkgsModule = { config, ... }: {
     config = {
       _module.args.baseModules = modules;
+      _module.args.pkgsPath = lib.mkDefault (
+        if versionAtLeast config.home.stateVersion "20.09" then
+          pkgs.path
+        else
+          <nixpkgs>);
       _module.args.pkgs = lib.mkDefault pkgs;
       _module.check = check;
       lib = lib.hm;


### PR DESCRIPTION
### Description

This removes the dependency on the `nixpkgs` channel within the modules. This can be used to override the Nixpkgs version. It is also a prerequisite for creating a Home Manager flake.