### PR TITLE
starship: fix fish integration syntax

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -101,7 +101,7 @@ in {
     '';
 
     programs.fish.promptInit = mkIf cfg.enableFishIntegration ''
-      if test [[  "$TERM" != "dumb"  -a \( -n "$INSIDE_EMACS"  -o "$INSIDE_EMACS" == "vterm" \)  ]]
+      if test "$TERM" != "dumb"  -a \( -z "$INSIDE_EMACS"  -o "$INSIDE_EMACS" = "vterm" \)
         eval (${cfg.package}/bin/starship init fish)
       end
     '';


### PR DESCRIPTION
The logic is fine, but the syntax is not valid fish and must have been
untested. I've tested the fixed version, and it works as expected.

### Description

The current fish integration for starship uses parts of POSIX-esque test syntax. fish does not use this syntax. It also uses -n instead of -z to check for an unset variable. This patch fixes these issues.

Testing these integrations would be difficult, as it would probably require setting up a shell and monitoring the output somehow.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added.

- [x] Commit messages are formatted.

- This PR doesn't initiate a module.
