### PR TITLE
Extend gnome-terminal profile to support `Command` options

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -122,6 +122,20 @@ let
           The number of scrollback lines to keep, null for infinite.
         '';
       };
+
+      customCommand = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        description =
+          "The command to use to start the shell, or null for default shell";
+      };
+
+      loginShell = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Run command as a login shell.";
+      };
+
     };
   });
 
@@ -132,7 +146,13 @@ let
       scrollback-lines = pcfg.scrollbackLines;
       cursor-shape = pcfg.cursorShape;
       cursor-blink-mode = pcfg.cursorBlinkMode;
-    } // (if (pcfg.font == null) then {
+      login-shell = pcfg.loginShell;
+    } // (if (pcfg.customCommand != null) then {
+      use-custom-command = true;
+      custom-command = pcfg.customCommand;
+    } else {
+      use-custom-command = false;
+    }) // (if (pcfg.font == null) then {
       use-system-font = true;
     } else {
       use-system-font = false;


### PR DESCRIPTION
My default gnome-terminal profile uses a custom command to attach to a tmux session, and I wanted to add support for that to home-manager. 

allow setting Custom Command and Login shell via home-manager config

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
(There are no test cases for gnome-terminal)

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
