### PR TITLE
bash: initExtra after autojump config

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -176,10 +176,10 @@ in
 
           ${aliasesStr}
 
-          ${cfg.initExtra}
-
           ${optionalString cfg.enableAutojump
             ". ${pkgs.autojump}/share/autojump/autojump.bash"}
+
+          ${cfg.initExtra}
         fi
       '';
 


### PR DESCRIPTION
### Description
Allow for initExtra to manipulate results of autojump, eg, remove aliases. I noticed this while trying to use [jc](https://github.com/kellyjonbrazil/jc)

### Checklist

- [ ] Change is backwards compatible.  - maybe, depends on if someone currently is using initExtra to change things before autojump, i can't think of many cases of that

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
