### PR TITLE
lib.gvariant: escape backslashes in strings

### DIFF
--- a/modules/lib/gvariant.nix
+++ b/modules/lib/gvariant.nix
@@ -108,7 +108,7 @@ in rec {
 
   mkString = v:
     mkPrimitive type.string v // {
-      __toString = self: "'${escape [ "'" ] self.value}'";
+      __toString = self: "'${escape [ "'" "\\" ] self.value}'";
     };
 
   mkObjectpath = v:


### PR DESCRIPTION
### Description

Strings containing backslashes in `dconf.settings` are not properly escaped.

tested with this module:
```nix

{ pkgs, lib, config, ... }:
let
  fav = {
    shrug = ''¯\_(ツ)_/¯'';
    "markdown-shrug" = ''¯\\\_(ツ)\_/¯'';
    flip = ''(╯°□°）╯︵ ┻━┻'';
  };
in
{
  dconf.settings."desktop/ibus/panel/emoji" = with lib.hm.gvariant; {
    favorite-annotations = mkArray type.string (lib.attrNames fav);
    favorites = mkArray type.string (lib.attrValues fav);
  };
}
```

Type `<ctrl-shift-e>shrug<space>` and you should see backslashes.

Please backport
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
