### PR TITLE
xdg-user-dirs: Fix errnous dirs file

### DIFF
--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -89,16 +89,21 @@ in {
   };
 
   config = mkIf cfg.enable {
-    xdg.configFile."user-dirs.dirs".text = generators.toKeyValue { } ({
-      XDG_DESKTOP_DIR = cfg.desktop;
-      XDG_DOCUMENTS_DIR = cfg.documents;
-      XDG_DOWNLOAD_DIR = cfg.download;
-      XDG_MUSIC_DIR = cfg.music;
-      XDG_PICTURES_DIR = cfg.pictures;
-      XDG_PUBLICSHARE_DIR = cfg.publicShare;
-      XDG_TEMPLATES_DIR = cfg.templates;
-      XDG_VIDEOS_DIR = cfg.videos;
-    } // cfg.extraConfig);
+    xdg.configFile."user-dirs.dirs".text = let
+      options = {
+        XDG_DESKTOP_DIR = cfg.desktop;
+        XDG_DOCUMENTS_DIR = cfg.documents;
+        XDG_DOWNLOAD_DIR = cfg.download;
+        XDG_MUSIC_DIR = cfg.music;
+        XDG_PICTURES_DIR = cfg.pictures;
+        XDG_PUBLICSHARE_DIR = cfg.publicShare;
+        XDG_TEMPLATES_DIR = cfg.templates;
+        XDG_VIDEOS_DIR = cfg.videos;
+      } // cfg.extraConfig;
+
+      # For some reason, these need to be wrapped with quotes to be valid.
+      wrapped = mapAttrs (_: value: ''"${value}"'') options;
+    in generators.toKeyValue { } wrapped;
 
     xdg.configFile."user-dirs.conf".text = "enabled=False";
   };


### PR DESCRIPTION
### Description

Before this change,

```rust
fn main() {
    println!("{:?}", glib::get_user_special_dir(glib::UserDirectory::Documents));
}
```

would return `None` even though I had ~/Documents available and `xdg.userDirs.enable = true`. I checked the differences between `xdg-user-dirs-update`, and the latter had quotes around each thing. Not sure why they were required.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
