### PR TITLE
zplug: Reduce noise

### DIFF
--- a/modules/programs/zplug.nix
+++ b/modules/programs/zplug.nix
@@ -45,11 +45,14 @@ in {
             optionalString (plugin.tags != [ ]) ''
               ${concatStrings (map (tag: ", ${tag}") plugin.tags)}
             ''
-          } 
+          }
         '') cfg.plugins)}
       ''}
 
-      zplug install
+      if ! zplug check; then
+        zplug install
+      fi
+
       zplug load
     '';
 

--- a/tests/modules/programs/zplug/modules.nix
+++ b/tests/modules/programs/zplug/modules.nix
@@ -38,8 +38,10 @@ with lib;
       assertFileContains home-files/.zshrc \
         'zplug "lib/clipboard", from:oh-my-zsh, if:"[[ $OSTYPE == *darwin* ]]"'
 
-      assertFileRegex home-files/.zshrc \
-        '^zplug install$'
+      assertFileContains home-files/.zshrc \
+        'if ! zplug check; then
+           zplug install
+         fi'
 
       assertFileRegex home-files/.zshrc \
         '^zplug load$'


### PR DESCRIPTION
### Description

Running `zplug install` will always product output, even if there is
nothing to do.

Gating it behind a `zplug check` eliminates that output when there is
nothing to do, and is recommended in the zplug README.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
