### PR TITLE
pulseeffects: fix autostart

### DIFF
--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -36,9 +36,12 @@ in {
     systemd.user.services.pulseeffects = {
       Unit = {
         Description = "Pulseeffects daemon";
-        Requires = [ "pulseaudio.service" "dbus.service" ];
-        After = [ "graphical-session.target" ];
+        Requires = [ "dbus.service" ];
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" "pulseaudio.service" ];
       };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
 
       Service = {
         ExecStart =


### PR DESCRIPTION
### Description

Pulseeffects did not autostart when starting a graphical session.
This PR should fix this.

I haven't done too many systemd-services, I'm not sure if this is the best way.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
