### PR TITLE
waybar: Allow configurable systemd target

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -215,7 +215,17 @@ in {
       '';
     };
 
-    systemd.enable = mkEnableOption "Waybar systemd integration";
+    systemd = {
+      enable = mkEnableOption "Waybar systemd integration";
+
+      target = mkOption {
+        type = str;
+        default = "sway-session.target";
+        description = ''
+          Systemd target to bind to.
+        '';
+      };
+    };
 
     style = mkOption {
       type = nullOr str;
@@ -343,9 +353,9 @@ in {
           Description =
             "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
           Documentation = "https://github.com/Alexays/Waybar/wiki";
-          PartOf = [ "graphical-session.target" ];
+          PartOf = [ cfg.systemd.target ];
           Requisite = [ "dbus.service" ];
-          After = [ "dbus.service" ];
+          After = [ cfg.systemd.target ];
         };
 
         Service = {
@@ -356,7 +366,7 @@ in {
           RestartSec = "1sec";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ cfg.systemd.target ]; };
       };
     })
   ]);

--- a/tests/modules/programs/waybar/default.nix
+++ b/tests/modules/programs/waybar/default.nix
@@ -1,6 +1,8 @@
 {
-  waybar-systemd-with-graphical-session-target =
-    ./systemd-with-graphical-session-target.nix;
+  waybar-systemd-with-sway-session-target =
+    ./systemd-with-sway-session-target.nix;
+  waybar-systemd-with-cage-session-target =
+    ./systemd-with-cage-session-target.nix;
   waybar-styling = ./styling.nix;
   waybar-settings-complex = ./settings-complex.nix;
   # Broken configuration from https://github.com/rycee/home-manager/pull/1329#issuecomment-653253069

--- a/tests/modules/programs/waybar/systemd-with-cage-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-cage-session-target.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  package = pkgs.writeScriptBin "dummy-waybar" "" // { outPath = "@waybar@"; };
+in {
+  config = {
+    programs.waybar = {
+      inherit package;
+      enable = true;
+      systemd.enable = true;
+      systemd.target = "cage-session.target";
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/waybar/config
+      assertPathNotExists home-files/.config/waybar/style.css
+
+      assertFileContent \
+        home-files/.config/systemd/user/waybar.service \
+        ${./systemd-with-cage-session-target.service}
+    '';
+  };
+}

--- a/tests/modules/programs/waybar/systemd-with-cage-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-cage-session-target.service
@@ -1,0 +1,16 @@
+[Install]
+WantedBy=cage-session.target
+
+[Service]
+BusName=fr.arouillard.waybar
+ExecStart=@waybar@/bin/waybar
+Restart=always
+RestartSec=1sec
+Type=dbus
+
+[Unit]
+After=cage-session.target
+Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
+Documentation=https://github.com/Alexays/Waybar/wiki
+PartOf=cage-session.target
+Requisite=dbus.service

--- a/tests/modules/programs/waybar/systemd-with-sway-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-sway-session-target.nix
@@ -18,7 +18,7 @@ in {
 
       assertFileContent \
         home-files/.config/systemd/user/waybar.service \
-        ${./systemd-with-graphical-session-target.service}
+        ${./systemd-with-sway-session-target.service}
     '';
   };
 }

--- a/tests/modules/programs/waybar/systemd-with-sway-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-sway-session-target.service
@@ -1,5 +1,5 @@
 [Install]
-WantedBy=graphical-session.target
+WantedBy=sway-session.target
 
 [Service]
 BusName=fr.arouillard.waybar
@@ -9,8 +9,8 @@ RestartSec=1sec
 Type=dbus
 
 [Unit]
-After=dbus.service
+After=sway-session.target
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
-PartOf=graphical-session.target
+PartOf=sway-session.target
 Requisite=dbus.service


### PR DESCRIPTION
### Description

Create an option for the systemd target for the waybar service.

`graphical-session.target` is used to launch the display-manager and while that works for launching waybar the first time, if you exit your window manager, `waybar` crashes. When I log in again waybar it not launched since `graphical-session.target` has not changed state. By making the target the window manager, when you exit the window-manager waybar will also exit gracefully, and more importantly will be launched again when you log back in from the display-manager.

I copied the pattern from the recently merged kanshi module of making it configurable, so that waybar can be used with other window managers. I've defaulted it to sway as I believe it's most heavily associated with sway.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
