### PR TITLE
kanshi: fix exec configuration

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -120,7 +120,7 @@ let
     ''
       profile ${name} {
         ${concatStringsSep "\n  " (map outputStr outputs)}
-    '' + optionalString (exec != null) "  ${exec}" + ''
+    '' + optionalString (exec != null) "  exec ${exec}\n" + ''
       }
     '';
 in {

--- a/tests/modules/services/kanshi/basic-configuration.conf
+++ b/tests/modules/services/kanshi/basic-configuration.conf
@@ -2,6 +2,7 @@ profile desktop {
   output "eDP-1" disable
   output "Iiyama North America PLE2483H-DP" enable position 0,0
   output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
+  exec echo "1 two 3"
 }
 
 profile nomad {

--- a/tests/modules/services/kanshi/basic-configuration.nix
+++ b/tests/modules/services/kanshi/basic-configuration.nix
@@ -11,6 +11,7 @@
           }];
         };
         desktop = {
+          exec = ''echo "1 two 3"'';
           outputs = [
             {
               criteria = "eDP-1";


### PR DESCRIPTION
### Description

Kanshi's generated configuration does not work for the `exec` option.

I also tested the changes with my configuration (the kanshi service would not start previously).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
