### PR TITLE
Add a flake.nix nondestructively

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,3 +203,5 @@
 /modules/xresources.nix                               @rycee
 
 /modules/xsession.nix                                 @rycee
+
+/flake.nix                                            @bqv @kisik21

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /result*
+flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Home Manager for Nix";
+
+  outputs = { self, nixpkgs }: rec {
+
+    nixosModules.home-manager = import ./nixos;
+
+    lib = {
+      homeManagerConfiguration = { configuration, system, homeDirectory
+        , username
+        , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+        , check ? true }@args:
+        import ./modules {
+          inherit pkgs check;
+          configuration = { ... }: {
+            imports = [ configuration ];
+            home = { inherit homeDirectory username; };
+          };
+        };
+    };
+  };
+}


### PR DESCRIPTION
This... seems to work, now.

No flake.lock, because the only input (nixpkgs) will almost always be overridden, and currently h-m's testing and verification is not flake-based

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
