### PR TITLE
files: make sure the target file name is escaped

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -316,12 +316,15 @@ in
         }
       '' + concatStrings (
         mapAttrsToList (n: v: ''
-          insertFile "${sourceStorePath v}" \
-                     "${v.target}" \
-                     "${if v.executable == null
-                        then "inherit"
-                        else builtins.toString v.executable}" \
-                     "${builtins.toString v.recursive}"
+          insertFile ${
+            escapeShellArgs [
+              (sourceStorePath v)
+              v.target
+              (if v.executable == null
+               then "inherit"
+               else toString v.executable)
+              (toString v.recursive)
+            ]}
         '') cfg
       ));
   };

--- a/tests/modules/files/default.nix
+++ b/tests/modules/files/default.nix
@@ -3,5 +3,6 @@
   files-hidden-source = ./hidden-source.nix;
   files-out-of-store-symlink = ./out-of-store-symlink.nix;
   files-source-with-spaces = ./source-with-spaces.nix;
+  files-target-with-shellvar = ./target-with-shellvar.nix;
   files-text = ./text.nix;
 }

--- a/tests/modules/files/target-with-shellvar.nix
+++ b/tests/modules/files/target-with-shellvar.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.file."$HOME/$FOO/bar baz".text = "blah";
+
+    nmt.script = ''
+      assertFileExists 'home-files/$HOME/$FOO/bar baz';
+      assertFileContent 'home-files/$HOME/$FOO/bar baz' \
+        ${pkgs.writeText "expected" "blah"}
+    '';
+  };
+}


### PR DESCRIPTION
The previous implementation would allow variables to sneak into the file names. This commit makes sure the resulting target file path exactly matches the expected path.