### PR TITLE
lib/file-type: remove types.loaOf

### DIFF
--- a/doc/release-notes/rl-1903.adoc
+++ b/doc/release-notes/rl-1903.adoc
@@ -5,7 +5,7 @@ The 19.03 release branch became the stable branch in April, 2019.
 
 [[sec-release-19.03-highlights]]
 === Highlights
-:opt-home-file-source: opt-home.file._name__.source
+:opt-home-file-source: opt-home.file._name_.source
 
 This release has the following notable changes:
 

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -11,7 +11,7 @@ with lib;
   # Arguments:
   #   - basePathDesc   docbook compatible description of the base path
   #   - basePath       the file base path
-  fileType = basePathDesc: basePath: types.loaOf (types.submodule (
+  fileType = basePathDesc: basePath: types.attrsOf (types.submodule (
     { name, config, ... }: {
       options = {
         target = mkOption {
@@ -32,7 +32,7 @@ with lib;
           type = types.nullOr types.lines;
           description = ''
             Text of the file. If this option is null then
-            <link linkend="opt-home.file._name__.source">home.file.&lt;name?&gt;.source</link>
+            <link linkend="opt-home.file._name_.source">home.file.&lt;name?&gt;.source</link>
             must be set.
           '';
         };
@@ -41,7 +41,7 @@ with lib;
           type = types.path;
           description = ''
             Path of the source file or directory. If
-            <link linkend="opt-home.file._name__.text">home.file.&lt;name?&gt;.text</link>
+            <link linkend="opt-home.file._name_.text">home.file.&lt;name?&gt;.text</link>
             is non-null then this option will automatically point to a file
             containing that text.
           '';


### PR DESCRIPTION
### Description

loaOf has been deprecated for a long time and is now in the process of
removal (see https://github.com/NixOS/nixpkgs/pull/96042). Thus, we
remove it here, too.

Fixes https://github.com/rycee/home-manager/issues/1472.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
